### PR TITLE
feat: add tenant and organization hierarchy foundation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -77,6 +77,7 @@ jobs:
           --health-retries 10
     env:
       ALLOW_SECURITY_POC: "true"
+      ALLOW_TENANT_FOUNDATION_POC: "true"
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/openschool
 
     steps:
@@ -107,3 +108,51 @@ jobs:
 
       - name: Prove transaction-scoped RLS with real roles
         run: bun run db:security-poc
+
+      - name: Prove Tenant and Organization Tree constraints
+        run: bun run db:tenant-foundation-poc
+
+  database-upgrade:
+    name: Upgrade representative existing data
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+        env:
+          POSTGRES_DB: openschool
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d openschool"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      ALLOW_TENANT_FOUNDATION_POC: "true"
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/openschool
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Prepare representative migration 0002 data
+        run: bun run db:prepare-upgrade-fixture
+
+      - name: Apply Tenant foundation migrations twice
+        run: |
+          bun run db:migrate
+          bun run db:migrate
+
+      - name: Verify upgraded rows and constraints
+        run: bun run db:verify-upgrade-fixture

--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -74,7 +74,7 @@ bun run db:migrate
 bun run db:seed
 ```
 
-The seed is idempotent and creates two organizations, three schools spanning primary and high-school profiles, organization and school roles, classes, students, enrollments, a parent relationship, and a representative grade. Seeded user records are application fixtures; they are not login identities in Supabase Auth.
+The seed is idempotent and creates two Tenants with pooled placements; a ministry, board, network, district, and second-Tenant hierarchy; three Schools spanning primary, secondary, and all-through profiles; organization and School roles; classes, students, enrollments, a parent relationship, and a representative grade. Seeded user records are application fixtures; they are not login identities in Supabase Auth.
 
 Stop PostgreSQL without deleting its named volume:
 
@@ -112,6 +112,8 @@ bun run build
 ```
 
 GitHub Actions additionally provisions a clean PostgreSQL service, applies all migrations, seeds it, repeats both operations, and runs the guarded [transaction-scoped RLS proof](./packages/db/security-poc/README.md) through real non-owner roles. The proof is destructive and intentionally refuses non-loopback database hosts.
+
+CI also runs the guarded [Tenant and Education Organization proof](./packages/db/TENANT_HIERARCHY.md) and a separate upgrade job that starts with representative data at migration `0002`, applies the Tenant foundation twice, and verifies the backfill and constraints.
 
 ## Database policy safety
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The current development preview contains a narrow administrator-facing slice:
 
 - a Next.js application shell and marketing/auth routes;
 - Supabase email authentication helpers and callback/sign-out routes;
-- schemas for organizations, schools, users, memberships, classes, enrollments, students, grades, and audit events;
+- staged schemas for Tenants, pooled placement, versioned Education Organization trees, effective School governance, Schools, users, memberships, classes, enrollments, students, grades, and audit events;
 - basic student list, create, detail, and edit flows;
 - early tenant-context, permission, and audit primitives;
 - CI-enforced formatting, linting, workspace type checks, unit tests, and production build.
@@ -114,14 +114,14 @@ bun run audit:security
 bun run build
 ```
 
-CI provisions a clean PostgreSQL service and repeats migration plus seed operations to prove idempotence. The unapproved RLS proposal is quarantined outside the executable migration path pending the security and tenancy decision in #68.
+CI provisions clean PostgreSQL services, repeats migration plus seed operations, proves the Tenant/hierarchy constraints, and upgrades representative migration-`0002` data twice. The unapproved legacy RLS proposal remains quarantined outside the executable migration path; production RLS for the first vertical slice is tracked in #87.
 
 ## Security and privacy status
 
 Security-sensitive code exists, but the platform has not completed a production security or privacy review. In particular:
 
 - tenant isolation is not yet proven across all access paths;
-- the permission model and organization hierarchy require redesign and negative testing;
+- hierarchy storage and Tenant-safe foreign keys have targeted negative tests, but authorization over organization subtrees is not yet implemented;
 - existing RLS policies are not an approved production boundary;
 - audit writes are not yet guaranteed to be atomic with mutations;
 - backup, restore, incident response, retention, and offboarding are not demonstrated;

--- a/apps/web/src/services/students.ts
+++ b/apps/web/src/services/students.ts
@@ -1,5 +1,5 @@
 import { logAuditEvent } from '@openschool/audit'
-import { type NewStudent, type Student, getDb, students } from '@openschool/db'
+import { type NewStudent, type Student, getDb, schools, students } from '@openschool/db'
 import type { TenantContext } from '@openschool/rbac'
 import { TRPCError } from '@trpc/server'
 import { and, eq } from 'drizzle-orm'
@@ -73,7 +73,7 @@ export async function getStudentById(
  */
 export async function createStudent(
   ctx: TenantContext,
-  data: Omit<NewStudent, 'id' | 'createdAt' | 'updatedAt'>
+  data: Omit<NewStudent, 'id' | 'tenantId' | 'createdAt' | 'updatedAt'>
 ): Promise<Student> {
   // Verify tenant access
   if (!ctx.schoolIds.includes(data.schoolId)) {
@@ -84,7 +84,20 @@ export async function createStudent(
   }
 
   const db = getDb()
-  const [student] = await db.insert(students).values(data).returning()
+  const [school] = await db
+    .select({ tenantId: schools.tenantId })
+    .from(schools)
+    .where(eq(schools.id, data.schoolId))
+    .limit(1)
+
+  if (!school) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'School not found' })
+  }
+
+  const [student] = await db
+    .insert(students)
+    .values({ ...data, tenantId: school.tenantId })
+    .returning()
 
   // Audit log
   await logAuditEvent(ctx, {
@@ -108,7 +121,7 @@ export async function createStudent(
 export async function updateStudent(
   ctx: TenantContext,
   studentId: string,
-  data: Partial<Omit<NewStudent, 'id' | 'schoolId' | 'createdAt' | 'updatedAt'>>
+  data: Partial<Omit<NewStudent, 'id' | 'tenantId' | 'schoolId' | 'createdAt' | 'updatedAt'>>
 ): Promise<Student> {
   // Get existing student to verify access
   const existing = await getStudentById(ctx, studentId)

--- a/docs/adr/0002-education-organization-hierarchy.md
+++ b/docs/adr/0002-education-organization-hierarchy.md
@@ -33,3 +33,5 @@ Tree changes and School transfers are privileged, effective-dated operations. Cl
 ## Migration path and rollback
 
 Create the tree and closure structures alongside existing organizations, import each current organization as a root, and attach existing Schools. Dual-read consistency tests precede cutover. Rollback returns reads to the flat tables while preserving the new records for diagnosis.
+
+The concrete write contract, staged migration boundary, and automated evidence are documented in [`packages/db/TENANT_HIERARCHY.md`](../../packages/db/TENANT_HIERARCHY.md).

--- a/docs/security/TENANT_ISOLATION_MATRIX.md
+++ b/docs/security/TENANT_ISOLATION_MATRIX.md
@@ -1,7 +1,7 @@
 # M1 tenant isolation matrix
 
 - Owner: Security Engineering
-- Status: Required test contract; implementation evidence pending
+- Status: Required test contract; Tenant/hierarchy foundation evidence implemented, end-to-end enforcement pending
 - Governing ADRs: [0001](../adr/0001-tenant-isolation-and-placement.md), [0004](../adr/0004-request-context-and-session-verification.md), [0005](../adr/0005-capability-authorization.md), [0006](../adr/0006-database-execution-and-rls.md)
 
 Each implementation issue converts the relevant rows below into automated tests. Positive tests are necessary but never sufficient: every path requires same-Tenant allow and cross-scope deny evidence.
@@ -23,7 +23,7 @@ Each implementation issue converts the relevant rows below into automated tests.
 | Policy module | role template plus active affiliation grants capability | expired/future/revoked/wrong-scope grant denied with stable reason | policy version included in decision | authorization |
 | Query module | approved Scope constrains query | missing/wrong resource scope returns no foreign row | every query requires transaction adapter | data access |
 | PostgreSQL/RLS | runtime role selects/inserts/updates/deletes Tenant A rows; worker performs its granted subset | no context, Tenant B select, cross-Tenant insert/update/delete denied by RLS; ungranted worker writes fail by privilege | role/privilege assertions distinguish grants from policies; context clears on commit, rollback, policy error, and same-connection reuse | RLS migration |
-| Organization Tree | subtree admin reaches descendants | sibling and ancestor outside grant denied | reparenting changes current access, not historical evidence | hierarchy |
+| Organization Tree | versioned insert, descendants, siblings, and reparenting pass in the domain and real PostgreSQL proof | cycles, incomplete closure, sealed-version mutation, overlap, and cross-Tenant references fail by constraint/trigger | reparenting changes current resolution while prior tree and School governance remain available as-of time | hierarchy authorization remains pending |
 | School/class | assigned teacher reaches assigned classes | another School/class in same Tenant denied | assignment expiry invalidates access | academics |
 | Guardian/student | active verified relationship reaches linked student | unlinked sibling/student denied | relationship expiry/revocation invalidates access | portals |
 | Platform control plane | operator manages placement metadata | operator cannot read school records without support grant | grant creation/use/expiry audited | operations |

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "db:check": "turbo run db:check --filter=@openschool/db",
     "db:migrate": "turbo run db:migrate --filter=@openschool/db",
     "db:security-poc": "turbo run db:security-poc --filter=@openschool/db",
+    "db:tenant-foundation-poc": "turbo run db:tenant-foundation-poc --filter=@openschool/db",
+    "db:prepare-upgrade-fixture": "turbo run db:prepare-upgrade-fixture --filter=@openschool/db",
+    "db:verify-upgrade-fixture": "turbo run db:verify-upgrade-fixture --filter=@openschool/db",
     "db:seed": "turbo run db:seed --filter=@openschool/db",
     "db:studio": "turbo run db:studio --filter=@openschool/db"
   },

--- a/packages/db/TENANT_HIERARCHY.md
+++ b/packages/db/TENANT_HIERARCHY.md
@@ -1,0 +1,46 @@
+# Tenant and Education Organization foundation
+
+This package implements the first M1 isolation-key and hierarchy slice. It does **not** enable RLS or replace the legacy Account/Person model.
+
+## Domain boundaries
+
+- `tenants` is the immutable isolation, placement, residency, and billing boundary.
+- `tenant_placements` selects the pooled adapter. Bridge and silo adapters remain disabled design seams.
+- `education_organizations` represents typed ministry, board, district, network, region, or other administrative nodes inside one Tenant.
+- `schools` remains one model for primary, secondary, all-through, special, and other profiles.
+- legacy `organizations` remains available during dual-read migration; imported records are linked by `legacy_organization_id`.
+
+Every tenant-owned operational row introduced by the existing schema carries a non-null, immutable `tenant_id`. Composite foreign keys prevent a child from combining one Tenant key with another Tenant's parent identifier. Global `users` remain outside this cutover because Account/Person separation belongs to #83. Audit scoping remains part of the atomic audit implementation in #88.
+
+## Immutable Organization Tree writes
+
+An Organization Tree version consists of:
+
+1. one row per organization in `organization_tree_nodes`;
+2. the exact ancestor/descendant expansion in `organization_tree_closure`;
+3. one `organization_tree_versions` row that seals the version.
+
+Application code must call `insertOrganizationTreeVersion` inside a database transaction. The service validates roots, parents, duplicates, self-parenting, and cycles, derives closure edges, inserts nodes and closure first, and inserts the version last. Deferred foreign keys make the complete version visible atomically.
+
+PostgreSQL independently validates the same boundary. Before sealing, it requires exactly one root, every parent in the version, and an exact closure match. After sealing, node/closure inserts and all tree updates or deletes fail. A move therefore creates a new effective-dated version; it never rewrites history.
+
+School governance uses separate half-open effective periods (`[valid_from, valid_until)`). A GiST exclusion constraint rejects overlapping assignments for the same Tenant and School.
+
+## Migration and rollback boundary
+
+The migration is deliberately staged:
+
+- `0003` creates the additive Tenant/hierarchy structures and nullable isolation keys.
+- `0004` locks tenant-owned legacy tables, creates one Tenant per legacy organization, backfills every key, imports root nodes and School governance, and aborts on nulls or mismatches.
+- `0005` makes the keys non-null, replaces single-column relationships with composite Tenant-safe foreign keys, and adds Tenant-leading indexes.
+- `0006` adds the shared School profile discriminator.
+- `0007` adds immutable-key, version-sealing, cycle/closure, and governance-overlap guards.
+- `0008` constrains Tenant, placement, Education Organization, and School profile values at the database boundary.
+
+Before `0005`, an operator can stop and correct the source data without cutover. After `0005`, rollback means restoring the pre-migration backup or shipping a forward repair; isolation keys must not be dropped from live data.
+
+## Evidence
+
+`db:tenant-foundation-poc` is a guarded, destructive proof for a disposable loopback PostgreSQL database. It verifies real SQLSTATE failures for cross-Tenant references, immutable keys, overlapping governance, cycles, incomplete closure, and sealed-tree mutation; it also proves moves, siblings, descendants, historical resolution, shared School profiles, and hierarchy/Tenant index plans. The proof rolls back its temporary hierarchy changes.
+
+CI additionally constructs a representative database at migration `0002`, applies the full migration set twice, and verifies that rows, hierarchy imports, School assignments, and cross-Tenant constraints survive the upgrade.

--- a/packages/db/migrations/0003_tenant_hierarchy_additive.sql
+++ b/packages/db/migrations/0003_tenant_hierarchy_additive.sql
@@ -1,0 +1,132 @@
+CREATE TABLE "tenant_placements" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"adapter" text DEFAULT 'pooled' NOT NULL,
+	"placement_key" text DEFAULT 'primary' NOT NULL,
+	"region" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tenant_placements_tenant_id_unique" UNIQUE("tenant_id")
+);
+--> statement-breakpoint
+CREATE TABLE "tenants" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"settings" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tenants_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "education_organizations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"legacy_organization_id" uuid,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"type" text NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"settings" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "education_organizations_tenant_id_id_unique" UNIQUE("tenant_id","id"),
+	CONSTRAINT "education_organizations_tenant_id_slug_unique" UNIQUE("tenant_id","slug"),
+	CONSTRAINT "education_organizations_legacy_organization_id_unique" UNIQUE("legacy_organization_id")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_tree_closure" (
+	"tenant_id" uuid NOT NULL,
+	"tree_version_id" uuid NOT NULL,
+	"ancestor_organization_id" uuid NOT NULL,
+	"descendant_organization_id" uuid NOT NULL,
+	"depth" integer NOT NULL,
+	CONSTRAINT "organization_tree_closure_pk" PRIMARY KEY("tenant_id","tree_version_id","ancestor_organization_id","descendant_organization_id"),
+	CONSTRAINT "organization_tree_closure_depth_nonnegative" CHECK ("organization_tree_closure"."depth" >= 0),
+	CONSTRAINT "organization_tree_closure_self_depth" CHECK (("organization_tree_closure"."ancestor_organization_id" = "organization_tree_closure"."descendant_organization_id") = ("organization_tree_closure"."depth" = 0))
+);
+--> statement-breakpoint
+CREATE TABLE "organization_tree_nodes" (
+	"tenant_id" uuid NOT NULL,
+	"tree_version_id" uuid NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"parent_organization_id" uuid,
+	CONSTRAINT "organization_tree_nodes_pk" PRIMARY KEY("tenant_id","tree_version_id","organization_id"),
+	CONSTRAINT "organization_tree_nodes_not_self_parent" CHECK ("organization_tree_nodes"."parent_organization_id" IS NULL OR "organization_tree_nodes"."parent_organization_id" <> "organization_tree_nodes"."organization_id")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_tree_versions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"version" integer NOT NULL,
+	"effective_from" timestamp with time zone NOT NULL,
+	"reason" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "organization_tree_versions_tenant_id_id_unique" UNIQUE("tenant_id","id"),
+	CONSTRAINT "organization_tree_versions_tenant_id_version_unique" UNIQUE("tenant_id","version"),
+	CONSTRAINT "organization_tree_versions_tenant_effective_from_unique" UNIQUE("tenant_id","effective_from"),
+	CONSTRAINT "organization_tree_versions_version_positive" CHECK ("organization_tree_versions"."version" > 0)
+);
+--> statement-breakpoint
+CREATE TABLE "school_governance_assignments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"school_id" uuid NOT NULL,
+	"education_organization_id" uuid NOT NULL,
+	"valid_from" timestamp with time zone NOT NULL,
+	"valid_until" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "school_governance_assignments_tenant_id_id_unique" UNIQUE("tenant_id","id"),
+	CONSTRAINT "school_governance_assignments_valid_period" CHECK ("school_governance_assignments"."valid_until" IS NULL OR "school_governance_assignments"."valid_until" > "school_governance_assignments"."valid_from")
+);
+--> statement-breakpoint
+ALTER TABLE "students" DROP CONSTRAINT "students_student_number_unique";--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "schools" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "classes" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "students" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "parent_student" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "teachers_on_class" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "users_on_org" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "users_on_school" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "enrollments" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "grades" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "organizations" ADD CONSTRAINT "organizations_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "schools" ADD CONSTRAINT "schools_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "schools" ADD CONSTRAINT "schools_tenant_id_slug_unique" UNIQUE("tenant_id","slug");--> statement-breakpoint
+ALTER TABLE "classes" ADD CONSTRAINT "classes_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "students" ADD CONSTRAINT "students_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "students" ADD CONSTRAINT "students_tenant_id_student_number_unique" UNIQUE("tenant_id","student_number");--> statement-breakpoint
+ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "tenant_placements" ADD CONSTRAINT "tenant_placements_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "education_organizations" ADD CONSTRAINT "education_organizations_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "organization_tree_closure" ADD CONSTRAINT "organization_tree_closure_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "organization_tree_closure" ADD CONSTRAINT "organization_tree_closure_version_fk" FOREIGN KEY ("tenant_id","tree_version_id") REFERENCES "public"."organization_tree_versions"("tenant_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_tree_closure" ADD CONSTRAINT "organization_tree_closure_ancestor_fk" FOREIGN KEY ("tenant_id","ancestor_organization_id") REFERENCES "public"."education_organizations"("tenant_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_tree_closure" ADD CONSTRAINT "organization_tree_closure_descendant_fk" FOREIGN KEY ("tenant_id","descendant_organization_id") REFERENCES "public"."education_organizations"("tenant_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_tree_nodes" ADD CONSTRAINT "organization_tree_nodes_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "organization_tree_nodes" ADD CONSTRAINT "organization_tree_nodes_version_fk" FOREIGN KEY ("tenant_id","tree_version_id") REFERENCES "public"."organization_tree_versions"("tenant_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_tree_nodes" ADD CONSTRAINT "organization_tree_nodes_organization_fk" FOREIGN KEY ("tenant_id","organization_id") REFERENCES "public"."education_organizations"("tenant_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_tree_nodes" ADD CONSTRAINT "organization_tree_nodes_parent_fk" FOREIGN KEY ("tenant_id","parent_organization_id") REFERENCES "public"."education_organizations"("tenant_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_tree_versions" ADD CONSTRAINT "organization_tree_versions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "school_governance_assignments" ADD CONSTRAINT "school_governance_assignments_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "school_governance_assignments" ADD CONSTRAINT "school_governance_assignments_school_fk" FOREIGN KEY ("tenant_id","school_id") REFERENCES "public"."schools"("tenant_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "school_governance_assignments" ADD CONSTRAINT "school_governance_assignments_organization_fk" FOREIGN KEY ("tenant_id","education_organization_id") REFERENCES "public"."education_organizations"("tenant_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "education_organizations_tenant_type_idx" ON "education_organizations" USING btree ("tenant_id","type");--> statement-breakpoint
+CREATE INDEX "organization_tree_closure_descendants_idx" ON "organization_tree_closure" USING btree ("tenant_id","tree_version_id","ancestor_organization_id","depth","descendant_organization_id");--> statement-breakpoint
+CREATE INDEX "organization_tree_closure_ancestors_idx" ON "organization_tree_closure" USING btree ("tenant_id","tree_version_id","descendant_organization_id","depth","ancestor_organization_id");--> statement-breakpoint
+CREATE INDEX "organization_tree_nodes_parent_idx" ON "organization_tree_nodes" USING btree ("tenant_id","tree_version_id","parent_organization_id");--> statement-breakpoint
+CREATE INDEX "organization_tree_versions_effective_lookup_idx" ON "organization_tree_versions" USING btree ("tenant_id","effective_from");--> statement-breakpoint
+CREATE INDEX "school_governance_assignments_effective_lookup_idx" ON "school_governance_assignments" USING btree ("tenant_id","school_id","valid_from","valid_until");--> statement-breakpoint
+ALTER TABLE "organizations" ADD CONSTRAINT "organizations_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "schools" ADD CONSTRAINT "schools_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "classes" ADD CONSTRAINT "classes_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "students" ADD CONSTRAINT "students_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "parent_student" ADD CONSTRAINT "parent_student_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "teachers_on_class" ADD CONSTRAINT "teachers_on_class_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "users_on_org" ADD CONSTRAINT "users_on_org_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "users_on_school" ADD CONSTRAINT "users_on_school_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "grades" ADD CONSTRAINT "grades_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;

--- a/packages/db/migrations/0004_tenant_hierarchy_backfill.sql
+++ b/packages/db/migrations/0004_tenant_hierarchy_backfill.sql
@@ -1,0 +1,289 @@
+-- Phase 2 of the Tenant cutover: backfill and verify before any tenant key is
+-- made NOT NULL. Existing flat organizations become independent Tenants and
+-- root Education Organizations because no safe trust-realm merge can be
+-- inferred from legacy data.
+
+LOCK TABLE
+  "organizations",
+  "schools",
+  "classes",
+  "students",
+  "users_on_org",
+  "users_on_school",
+  "teachers_on_class",
+  "parent_student",
+  "enrollments",
+  "grades"
+IN SHARE ROW EXCLUSIVE MODE;
+
+INSERT INTO "tenants" (
+  "id",
+  "name",
+  "slug",
+  "status",
+  "settings",
+  "created_at",
+  "updated_at"
+)
+SELECT
+  "id",
+  "name",
+  "slug",
+  'active',
+  COALESCE("settings", '{}'::jsonb),
+  "created_at" AT TIME ZONE 'UTC',
+  "updated_at" AT TIME ZONE 'UTC'
+FROM "organizations"
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO "tenant_placements" (
+  "tenant_id",
+  "adapter",
+  "placement_key",
+  "status"
+)
+SELECT "id", 'pooled', 'primary', 'active'
+FROM "tenants"
+ON CONFLICT ("tenant_id") DO NOTHING;
+
+UPDATE "organizations"
+SET "tenant_id" = "id"
+WHERE "tenant_id" IS NULL;
+
+UPDATE "schools" AS school
+SET "tenant_id" = organization."tenant_id"
+FROM "organizations" AS organization
+WHERE school."org_id" = organization."id"
+  AND school."tenant_id" IS NULL;
+
+UPDATE "classes" AS class
+SET "tenant_id" = school."tenant_id"
+FROM "schools" AS school
+WHERE class."school_id" = school."id"
+  AND class."tenant_id" IS NULL;
+
+UPDATE "students" AS student
+SET "tenant_id" = school."tenant_id"
+FROM "schools" AS school
+WHERE student."school_id" = school."id"
+  AND student."tenant_id" IS NULL;
+
+UPDATE "users_on_org" AS membership
+SET "tenant_id" = organization."tenant_id"
+FROM "organizations" AS organization
+WHERE membership."org_id" = organization."id"
+  AND membership."tenant_id" IS NULL;
+
+UPDATE "users_on_school" AS membership
+SET "tenant_id" = school."tenant_id"
+FROM "schools" AS school
+WHERE membership."school_id" = school."id"
+  AND membership."tenant_id" IS NULL;
+
+UPDATE "teachers_on_class" AS assignment
+SET "tenant_id" = class."tenant_id"
+FROM "classes" AS class
+WHERE assignment."class_id" = class."id"
+  AND assignment."tenant_id" IS NULL;
+
+UPDATE "parent_student" AS relationship
+SET "tenant_id" = student."tenant_id"
+FROM "students" AS student
+WHERE relationship."student_id" = student."id"
+  AND relationship."tenant_id" IS NULL;
+
+UPDATE "enrollments" AS enrollment
+SET "tenant_id" = student."tenant_id"
+FROM "students" AS student
+WHERE enrollment."student_id" = student."id"
+  AND enrollment."tenant_id" IS NULL;
+
+UPDATE "grades" AS grade
+SET "tenant_id" = enrollment."tenant_id"
+FROM "enrollments" AS enrollment
+WHERE grade."enrollment_id" = enrollment."id"
+  AND grade."tenant_id" IS NULL;
+
+DO $$
+DECLARE
+  null_rows bigint;
+  mismatched_rows bigint;
+BEGIN
+  SELECT SUM(row_count) INTO null_rows
+  FROM (
+    SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) AS row_count FROM "organizations"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "schools"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "classes"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "students"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "users_on_org"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "users_on_school"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "teachers_on_class"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "parent_student"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "enrollments"
+    UNION ALL SELECT COUNT(*) FILTER (WHERE "tenant_id" IS NULL) FROM "grades"
+  ) AS tenant_null_counts;
+
+  IF null_rows <> 0 THEN
+    RAISE EXCEPTION 'Tenant backfill left % tenant-owned rows without tenant_id', null_rows;
+  END IF;
+
+  SELECT SUM(row_count) INTO mismatched_rows
+  FROM (
+    SELECT COUNT(*) AS row_count
+    FROM "schools" AS child
+    JOIN "organizations" AS parent ON parent."id" = child."org_id"
+    WHERE child."tenant_id" <> parent."tenant_id"
+    UNION ALL
+    SELECT COUNT(*) FROM "classes" AS child
+    JOIN "schools" AS parent ON parent."id" = child."school_id"
+    WHERE child."tenant_id" <> parent."tenant_id"
+    UNION ALL
+    SELECT COUNT(*) FROM "students" AS child
+    JOIN "schools" AS parent ON parent."id" = child."school_id"
+    WHERE child."tenant_id" <> parent."tenant_id"
+    UNION ALL
+    SELECT COUNT(*) FROM "users_on_org" AS child
+    JOIN "organizations" AS parent ON parent."id" = child."org_id"
+    WHERE child."tenant_id" <> parent."tenant_id"
+    UNION ALL
+    SELECT COUNT(*) FROM "users_on_school" AS child
+    JOIN "schools" AS parent ON parent."id" = child."school_id"
+    WHERE child."tenant_id" <> parent."tenant_id"
+    UNION ALL
+    SELECT COUNT(*) FROM "teachers_on_class" AS child
+    JOIN "classes" AS parent ON parent."id" = child."class_id"
+    WHERE child."tenant_id" <> parent."tenant_id"
+    UNION ALL
+    SELECT COUNT(*) FROM "parent_student" AS child
+    JOIN "students" AS parent ON parent."id" = child."student_id"
+    WHERE child."tenant_id" <> parent."tenant_id"
+    UNION ALL
+    SELECT COUNT(*) FROM "enrollments" AS enrollment
+    JOIN "students" AS student ON student."id" = enrollment."student_id"
+    JOIN "classes" AS class ON class."id" = enrollment."class_id"
+    WHERE enrollment."tenant_id" <> student."tenant_id"
+       OR enrollment."tenant_id" <> class."tenant_id"
+    UNION ALL
+    SELECT COUNT(*) FROM "grades" AS child
+    JOIN "enrollments" AS parent ON parent."id" = child."enrollment_id"
+    WHERE child."tenant_id" <> parent."tenant_id"
+  ) AS tenant_mismatch_counts;
+
+  IF mismatched_rows <> 0 THEN
+    RAISE EXCEPTION 'Tenant backfill found % cross-tenant operational references', mismatched_rows;
+  END IF;
+END
+$$;
+
+INSERT INTO "education_organizations" (
+  "id",
+  "tenant_id",
+  "legacy_organization_id",
+  "name",
+  "slug",
+  "type",
+  "status",
+  "settings",
+  "created_at",
+  "updated_at"
+)
+SELECT
+  "id",
+  "tenant_id",
+  "id",
+  "name",
+  "slug",
+  'other',
+  'active',
+  COALESCE("settings", '{}'::jsonb),
+  "created_at" AT TIME ZONE 'UTC',
+  "updated_at" AT TIME ZONE 'UTC'
+FROM "organizations"
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO "organization_tree_versions" (
+  "id",
+  "tenant_id",
+  "version",
+  "effective_from",
+  "reason"
+)
+SELECT
+  "id",
+  "tenant_id",
+  1,
+  "created_at" AT TIME ZONE 'UTC',
+  'Imported from the legacy flat organization model'
+FROM "organizations"
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO "organization_tree_nodes" (
+  "tenant_id",
+  "tree_version_id",
+  "organization_id",
+  "parent_organization_id"
+)
+SELECT "tenant_id", "id", "id", NULL
+FROM "organizations"
+ON CONFLICT DO NOTHING;
+
+INSERT INTO "organization_tree_closure" (
+  "tenant_id",
+  "tree_version_id",
+  "ancestor_organization_id",
+  "descendant_organization_id",
+  "depth"
+)
+SELECT "tenant_id", "id", "id", "id", 0
+FROM "organizations"
+ON CONFLICT DO NOTHING;
+
+INSERT INTO "school_governance_assignments" (
+  "tenant_id",
+  "school_id",
+  "education_organization_id",
+  "valid_from"
+)
+SELECT
+  "tenant_id",
+  "id",
+  "org_id",
+  "created_at" AT TIME ZONE 'UTC'
+FROM "schools";
+
+DO $$
+DECLARE
+  legacy_organizations bigint;
+  imported_roots bigint;
+  legacy_schools bigint;
+  imported_school_assignments bigint;
+BEGIN
+  SELECT COUNT(*) INTO legacy_organizations FROM "organizations";
+  SELECT COUNT(*) INTO imported_roots
+  FROM "education_organizations" AS organization
+  JOIN "organization_tree_nodes" AS node
+    ON node."tenant_id" = organization."tenant_id"
+   AND node."organization_id" = organization."id"
+  WHERE organization."legacy_organization_id" IS NOT NULL
+    AND node."parent_organization_id" IS NULL;
+
+  SELECT COUNT(*) INTO legacy_schools FROM "schools";
+  SELECT COUNT(*) INTO imported_school_assignments
+  FROM "schools" AS school
+  JOIN "school_governance_assignments" AS assignment
+    ON assignment."tenant_id" = school."tenant_id"
+   AND assignment."school_id" = school."id"
+   AND assignment."education_organization_id" = school."org_id"
+  WHERE assignment."valid_until" IS NULL;
+
+  IF legacy_organizations <> imported_roots THEN
+    RAISE EXCEPTION 'Expected % imported organization roots, found %',
+      legacy_organizations, imported_roots;
+  END IF;
+
+  IF legacy_schools <> imported_school_assignments THEN
+    RAISE EXCEPTION 'Expected % imported School assignments, found %',
+      legacy_schools, imported_school_assignments;
+  END IF;
+END
+$$;

--- a/packages/db/migrations/0005_tenant_hierarchy_constraints.sql
+++ b/packages/db/migrations/0005_tenant_hierarchy_constraints.sql
@@ -1,0 +1,56 @@
+ALTER TABLE "schools" DROP CONSTRAINT "schools_org_id_organizations_id_fk";
+--> statement-breakpoint
+ALTER TABLE "classes" DROP CONSTRAINT "classes_school_id_schools_id_fk";
+--> statement-breakpoint
+ALTER TABLE "students" DROP CONSTRAINT "students_school_id_schools_id_fk";
+--> statement-breakpoint
+ALTER TABLE "parent_student" DROP CONSTRAINT "parent_student_student_id_students_id_fk";
+--> statement-breakpoint
+ALTER TABLE "teachers_on_class" DROP CONSTRAINT "teachers_on_class_class_id_classes_id_fk";
+--> statement-breakpoint
+ALTER TABLE "users_on_org" DROP CONSTRAINT "users_on_org_org_id_organizations_id_fk";
+--> statement-breakpoint
+ALTER TABLE "users_on_school" DROP CONSTRAINT "users_on_school_school_id_schools_id_fk";
+--> statement-breakpoint
+ALTER TABLE "enrollments" DROP CONSTRAINT "enrollments_student_id_students_id_fk";
+--> statement-breakpoint
+ALTER TABLE "enrollments" DROP CONSTRAINT "enrollments_class_id_classes_id_fk";
+--> statement-breakpoint
+ALTER TABLE "grades" DROP CONSTRAINT "grades_enrollment_id_enrollments_id_fk";
+--> statement-breakpoint
+ALTER TABLE "organizations" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "schools" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "classes" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "students" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "parent_student" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "teachers_on_class" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "users_on_org" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "users_on_school" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "enrollments" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "grades" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "schools" ADD CONSTRAINT "schools_tenant_organization_fk" FOREIGN KEY ("tenant_id","org_id") REFERENCES "public"."organizations"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "education_organizations" ADD CONSTRAINT "education_organizations_legacy_organization_fk" FOREIGN KEY ("tenant_id","legacy_organization_id") REFERENCES "public"."organizations"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "classes" ADD CONSTRAINT "classes_tenant_school_fk" FOREIGN KEY ("tenant_id","school_id") REFERENCES "public"."schools"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "students" ADD CONSTRAINT "students_tenant_school_fk" FOREIGN KEY ("tenant_id","school_id") REFERENCES "public"."schools"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "parent_student" ADD CONSTRAINT "parent_student_tenant_student_fk" FOREIGN KEY ("tenant_id","student_id") REFERENCES "public"."students"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "teachers_on_class" ADD CONSTRAINT "teachers_on_class_tenant_class_fk" FOREIGN KEY ("tenant_id","class_id") REFERENCES "public"."classes"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "users_on_org" ADD CONSTRAINT "users_on_org_tenant_organization_fk" FOREIGN KEY ("tenant_id","org_id") REFERENCES "public"."organizations"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "users_on_school" ADD CONSTRAINT "users_on_school_tenant_school_fk" FOREIGN KEY ("tenant_id","school_id") REFERENCES "public"."schools"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_tenant_student_fk" FOREIGN KEY ("tenant_id","student_id") REFERENCES "public"."students"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_tenant_class_fk" FOREIGN KEY ("tenant_id","class_id") REFERENCES "public"."classes"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "grades" ADD CONSTRAINT "grades_tenant_enrollment_fk" FOREIGN KEY ("tenant_id","enrollment_id") REFERENCES "public"."enrollments"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+CREATE INDEX "schools_tenant_organization_idx" ON "schools" USING btree ("tenant_id","org_id");--> statement-breakpoint
+CREATE INDEX "classes_tenant_school_idx" ON "classes" USING btree ("tenant_id","school_id");--> statement-breakpoint
+CREATE INDEX "students_tenant_school_idx" ON "students" USING btree ("tenant_id","school_id");--> statement-breakpoint
+CREATE INDEX "parent_student_tenant_parent_idx" ON "parent_student" USING btree ("tenant_id","parent_id");--> statement-breakpoint
+CREATE INDEX "teachers_on_class_tenant_user_idx" ON "teachers_on_class" USING btree ("tenant_id","user_id");--> statement-breakpoint
+CREATE INDEX "users_on_org_tenant_user_idx" ON "users_on_org" USING btree ("tenant_id","user_id");--> statement-breakpoint
+CREATE INDEX "users_on_school_tenant_user_idx" ON "users_on_school" USING btree ("tenant_id","user_id");--> statement-breakpoint
+CREATE INDEX "enrollments_tenant_student_idx" ON "enrollments" USING btree ("tenant_id","student_id");--> statement-breakpoint
+CREATE INDEX "enrollments_tenant_class_idx" ON "enrollments" USING btree ("tenant_id","class_id");--> statement-breakpoint
+CREATE INDEX "grades_tenant_enrollment_idx" ON "grades" USING btree ("tenant_id","enrollment_id");--> statement-breakpoint
+ALTER TABLE "parent_student" ADD CONSTRAINT "parent_student_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "teachers_on_class" ADD CONSTRAINT "teachers_on_class_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "users_on_org" ADD CONSTRAINT "users_on_org_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "users_on_school" ADD CONSTRAINT "users_on_school_tenant_id_id_unique" UNIQUE("tenant_id","id");--> statement-breakpoint
+ALTER TABLE "grades" ADD CONSTRAINT "grades_tenant_id_id_unique" UNIQUE("tenant_id","id");

--- a/packages/db/migrations/0006_school_profile.sql
+++ b/packages/db/migrations/0006_school_profile.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "schools" ADD COLUMN "profile" text DEFAULT 'other' NOT NULL;

--- a/packages/db/migrations/0007_tenant_hierarchy_guards.sql
+++ b/packages/db/migrations/0007_tenant_hierarchy_guards.sql
@@ -1,0 +1,297 @@
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+ALTER TABLE "school_governance_assignments"
+  ADD CONSTRAINT "school_governance_assignments_no_overlap"
+  EXCLUDE USING gist (
+    "tenant_id" WITH =,
+    "school_id" WITH =,
+    tstzrange(
+      "valid_from",
+      COALESCE("valid_until", 'infinity'::timestamptz),
+      '[)'
+    ) WITH &&
+  );
+
+ALTER TABLE "organization_tree_nodes"
+  ADD CONSTRAINT "organization_tree_nodes_parent_in_version_fk"
+  FOREIGN KEY ("tenant_id", "tree_version_id", "parent_organization_id")
+  REFERENCES "organization_tree_nodes" (
+    "tenant_id",
+    "tree_version_id",
+    "organization_id"
+  )
+  DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE "organization_tree_nodes"
+  ALTER CONSTRAINT "organization_tree_nodes_version_fk"
+  DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE "organization_tree_closure"
+  ALTER CONSTRAINT "organization_tree_closure_version_fk"
+  DEFERRABLE INITIALLY DEFERRED;
+
+CREATE FUNCTION "openschool_reject_tenant_change"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW."tenant_id" IS DISTINCT FROM OLD."tenant_id" THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = format(
+        'tenant_id is immutable on %I (row id %s)',
+        TG_TABLE_NAME,
+        COALESCE(OLD."id"::text, '<composite-key>')
+      );
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER "organizations_tenant_id_immutable"
+  BEFORE UPDATE ON "organizations"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "schools_tenant_id_immutable"
+  BEFORE UPDATE ON "schools"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "classes_tenant_id_immutable"
+  BEFORE UPDATE ON "classes"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "students_tenant_id_immutable"
+  BEFORE UPDATE ON "students"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "users_on_org_tenant_id_immutable"
+  BEFORE UPDATE ON "users_on_org"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "users_on_school_tenant_id_immutable"
+  BEFORE UPDATE ON "users_on_school"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "teachers_on_class_tenant_id_immutable"
+  BEFORE UPDATE ON "teachers_on_class"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "parent_student_tenant_id_immutable"
+  BEFORE UPDATE ON "parent_student"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "enrollments_tenant_id_immutable"
+  BEFORE UPDATE ON "enrollments"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "grades_tenant_id_immutable"
+  BEFORE UPDATE ON "grades"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "tenant_placements_tenant_id_immutable"
+  BEFORE UPDATE ON "tenant_placements"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "education_organizations_tenant_id_immutable"
+  BEFORE UPDATE ON "education_organizations"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "organization_tree_versions_tenant_id_immutable"
+  BEFORE UPDATE ON "organization_tree_versions"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+CREATE TRIGGER "school_governance_assignments_tenant_id_immutable"
+  BEFORE UPDATE ON "school_governance_assignments"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tenant_change"();
+
+CREATE FUNCTION "openschool_reject_tree_mutation"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION USING
+    ERRCODE = '55000',
+    MESSAGE = format(
+      '%I rows are immutable; create a new Organization Tree version',
+      TG_TABLE_NAME
+    );
+END
+$$;
+
+CREATE TRIGGER "organization_tree_versions_immutable"
+  BEFORE UPDATE OR DELETE ON "organization_tree_versions"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tree_mutation"();
+CREATE TRIGGER "organization_tree_nodes_immutable"
+  BEFORE UPDATE OR DELETE ON "organization_tree_nodes"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tree_mutation"();
+CREATE TRIGGER "organization_tree_closure_immutable"
+  BEFORE UPDATE OR DELETE ON "organization_tree_closure"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_reject_tree_mutation"();
+
+CREATE FUNCTION "openschool_guard_tree_node_insert"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "organization_tree_versions"
+    WHERE "tenant_id" = NEW."tenant_id"
+      AND "id" = NEW."tree_version_id"
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'Organization Tree version is sealed; insert a new version instead';
+  END IF;
+
+  IF NEW."parent_organization_id" IS NOT NULL AND EXISTS (
+    WITH RECURSIVE parent_chain AS (
+      SELECT "organization_id", "parent_organization_id"
+      FROM "organization_tree_nodes"
+      WHERE "tenant_id" = NEW."tenant_id"
+        AND "tree_version_id" = NEW."tree_version_id"
+        AND "organization_id" = NEW."parent_organization_id"
+
+      UNION ALL
+
+      SELECT parent."organization_id", parent."parent_organization_id"
+      FROM "organization_tree_nodes" AS parent
+      JOIN parent_chain AS child
+        ON child."parent_organization_id" = parent."organization_id"
+      WHERE parent."tenant_id" = NEW."tenant_id"
+        AND parent."tree_version_id" = NEW."tree_version_id"
+    )
+    SELECT 1
+    FROM parent_chain
+    WHERE "organization_id" = NEW."organization_id"
+       OR "parent_organization_id" = NEW."organization_id"
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'Organization Tree cycle rejected';
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER "organization_tree_nodes_insert_guard"
+  BEFORE INSERT ON "organization_tree_nodes"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_guard_tree_node_insert"();
+
+CREATE FUNCTION "openschool_guard_tree_closure_insert"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "organization_tree_versions"
+    WHERE "tenant_id" = NEW."tenant_id"
+      AND "id" = NEW."tree_version_id"
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'Organization Tree version is sealed; insert a new version instead';
+  END IF;
+
+  IF NEW."ancestor_organization_id" <> NEW."descendant_organization_id" AND EXISTS (
+    SELECT 1
+    FROM "organization_tree_closure"
+    WHERE "tenant_id" = NEW."tenant_id"
+      AND "tree_version_id" = NEW."tree_version_id"
+      AND "ancestor_organization_id" = NEW."descendant_organization_id"
+      AND "descendant_organization_id" = NEW."ancestor_organization_id"
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'Reciprocal Organization Tree closure edge rejected';
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER "organization_tree_closure_insert_guard"
+  BEFORE INSERT ON "organization_tree_closure"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_guard_tree_closure_insert"();
+
+CREATE FUNCTION "openschool_validate_tree_version"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  root_count integer;
+BEGIN
+  SELECT COUNT(*) INTO root_count
+  FROM "organization_tree_nodes"
+  WHERE "tenant_id" = NEW."tenant_id"
+    AND "tree_version_id" = NEW."id"
+    AND "parent_organization_id" IS NULL;
+
+  IF root_count <> 1 THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = format(
+        'Organization Tree version must contain exactly one root; found %s',
+        root_count
+      );
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "organization_tree_nodes" AS child
+    WHERE child."tenant_id" = NEW."tenant_id"
+      AND child."tree_version_id" = NEW."id"
+      AND child."parent_organization_id" IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "organization_tree_nodes" AS parent
+        WHERE parent."tenant_id" = child."tenant_id"
+          AND parent."tree_version_id" = child."tree_version_id"
+          AND parent."organization_id" = child."parent_organization_id"
+      )
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'Organization Tree version contains a parent outside the version';
+  END IF;
+
+  IF EXISTS (
+    WITH RECURSIVE expected_closure AS (
+      SELECT
+        node."organization_id" AS "ancestor_organization_id",
+        node."organization_id" AS "descendant_organization_id",
+        0 AS "depth"
+      FROM "organization_tree_nodes" AS node
+      WHERE node."tenant_id" = NEW."tenant_id"
+        AND node."tree_version_id" = NEW."id"
+
+      UNION ALL
+
+      SELECT
+        node."parent_organization_id" AS "ancestor_organization_id",
+        edge."descendant_organization_id",
+        edge."depth" + 1
+      FROM expected_closure AS edge
+      JOIN "organization_tree_nodes" AS node
+        ON node."tenant_id" = NEW."tenant_id"
+       AND node."tree_version_id" = NEW."id"
+       AND node."organization_id" = edge."ancestor_organization_id"
+      WHERE node."parent_organization_id" IS NOT NULL
+    ),
+    actual_closure AS (
+      SELECT
+        "ancestor_organization_id",
+        "descendant_organization_id",
+        "depth"
+      FROM "organization_tree_closure"
+      WHERE "tenant_id" = NEW."tenant_id"
+        AND "tree_version_id" = NEW."id"
+    ),
+    difference AS (
+      (SELECT * FROM expected_closure EXCEPT SELECT * FROM actual_closure)
+      UNION ALL
+      (SELECT * FROM actual_closure EXCEPT SELECT * FROM expected_closure)
+    )
+    SELECT 1 FROM difference
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'Organization Tree closure is incomplete or inconsistent with its nodes';
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER "organization_tree_versions_validate_before_seal"
+  BEFORE INSERT ON "organization_tree_versions"
+  FOR EACH ROW EXECUTE FUNCTION "openschool_validate_tree_version"();

--- a/packages/db/migrations/0008_tenant_hierarchy_value_constraints.sql
+++ b/packages/db/migrations/0008_tenant_hierarchy_value_constraints.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "tenant_placements" ADD CONSTRAINT "tenant_placements_adapter_check" CHECK ("tenant_placements"."adapter" = 'pooled');--> statement-breakpoint
+ALTER TABLE "tenant_placements" ADD CONSTRAINT "tenant_placements_status_check" CHECK ("tenant_placements"."status" IN ('active', 'migrating', 'disabled'));--> statement-breakpoint
+ALTER TABLE "tenants" ADD CONSTRAINT "tenants_status_check" CHECK ("tenants"."status" IN ('active', 'suspended', 'archived'));--> statement-breakpoint
+ALTER TABLE "schools" ADD CONSTRAINT "schools_profile_check" CHECK ("schools"."profile" IN ('primary', 'secondary', 'all_through', 'special', 'other'));--> statement-breakpoint
+ALTER TABLE "education_organizations" ADD CONSTRAINT "education_organizations_type_check" CHECK ("education_organizations"."type" IN ('ministry', 'school_board', 'district', 'network', 'region', 'other'));--> statement-breakpoint
+ALTER TABLE "education_organizations" ADD CONSTRAINT "education_organizations_status_check" CHECK ("education_organizations"."status" IN ('active', 'archived'));

--- a/packages/db/migrations/meta/0003_snapshot.json
+++ b/packages/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1914 @@
+{
+  "id": "b3e95670-5160-4ca5-9972-204cc3253052",
+  "prevId": "9cd4349d-88cc-4650-a027-abb68305b9ed",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "schools_org_id_organizations_id_fk": {
+          "name": "schools_org_id_organizations_id_fk",
+          "tableFrom": "schools",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "version"]
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "classes_school_id_schools_id_fk": {
+          "name": "classes_school_id_schools_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "schools",
+          "columnsFrom": ["school_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "students_school_id_schools_id_fk": {
+          "name": "students_school_id_schools_id_fk",
+          "tableFrom": "students",
+          "tableTo": "schools",
+          "columnsFrom": ["school_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "student_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "users",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "parent_student_student_id_students_id_fk": {
+          "name": "parent_student_student_id_students_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "students",
+          "columnsFrom": ["student_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teachers_on_class_class_id_classes_id_fk": {
+          "name": "teachers_on_class_class_id_classes_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "classes",
+          "columnsFrom": ["class_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_org_org_id_organizations_id_fk": {
+          "name": "users_on_org_org_id_organizations_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_school_school_id_schools_id_fk": {
+          "name": "users_on_school_school_id_schools_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "schools",
+          "columnsFrom": ["school_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_student_id_students_id_fk": {
+          "name": "enrollments_student_id_students_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "students",
+          "columnsFrom": ["student_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "enrollments_class_id_classes_id_fk": {
+          "name": "enrollments_class_id_classes_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "classes",
+          "columnsFrom": ["class_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "grades_enrollment_id_enrollments_id_fk": {
+          "name": "grades_enrollment_id_enrollments_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "enrollments",
+          "columnsFrom": ["enrollment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "users",
+          "columnsFrom": ["graded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0004_snapshot.json
+++ b/packages/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1914 @@
+{
+  "id": "ed86c45e-4fc0-4f03-8471-a0791f97b240",
+  "prevId": "b3e95670-5160-4ca5-9972-204cc3253052",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "columns": ["tenant_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "columns": ["slug"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": ["slug"],
+          "nullsNotDistinct": false
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "schools_org_id_organizations_id_fk": {
+          "name": "schools_org_id_organizations_id_fk",
+          "tableFrom": "schools",
+          "columnsFrom": ["org_id"],
+          "tableTo": "organizations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "columns": ["tenant_id", "slug"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "columns": ["tenant_id", "slug"],
+          "nullsNotDistinct": false
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "columns": ["legacy_organization_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "tableTo": "organization_tree_versions",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "tableTo": "organization_tree_versions",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "columns": ["tenant_id", "version"],
+          "nullsNotDistinct": false
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "columns": ["tenant_id", "effective_from"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "classes_school_id_schools_id_fk": {
+          "name": "classes_school_id_schools_id_fk",
+          "tableFrom": "classes",
+          "columnsFrom": ["school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "students_school_id_schools_id_fk": {
+          "name": "students_school_id_schools_id_fk",
+          "tableFrom": "students",
+          "columnsFrom": ["school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "columns": ["tenant_id", "student_number"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["parent_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "parent_student_student_id_students_id_fk": {
+          "name": "parent_student_student_id_students_id_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["student_id"],
+          "tableTo": "students",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "teachers_on_class_class_id_classes_id_fk": {
+          "name": "teachers_on_class_class_id_classes_id_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "users_on_org_org_id_organizations_id_fk": {
+          "name": "users_on_org_org_id_organizations_id_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["org_id"],
+          "tableTo": "organizations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "users_on_school_school_id_schools_id_fk": {
+          "name": "users_on_school_school_id_schools_id_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "enrollments_student_id_students_id_fk": {
+          "name": "enrollments_student_id_students_id_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["student_id"],
+          "tableTo": "students",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "enrollments_class_id_classes_id_fk": {
+          "name": "enrollments_class_id_classes_id_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "grades_enrollment_id_enrollments_id_fk": {
+          "name": "grades_enrollment_id_enrollments_id_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["enrollment_id"],
+          "tableTo": "enrollments",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["graded_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0005_snapshot.json
+++ b/packages/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,2172 @@
+{
+  "id": "0482dcf0-68be-4e41-ae78-54cafc9ceaf8",
+  "prevId": "ed86c45e-4fc0-4f03-8471-a0791f97b240",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schools_tenant_organization_idx": {
+          "name": "schools_tenant_organization_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "schools_tenant_organization_fk": {
+          "name": "schools_tenant_organization_fk",
+          "tableFrom": "schools",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "education_organizations_legacy_organization_fk": {
+          "name": "education_organizations_legacy_organization_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "legacy_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "version"]
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classes_tenant_school_idx": {
+          "name": "classes_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "classes_tenant_school_fk": {
+          "name": "classes_tenant_school_fk",
+          "tableFrom": "classes",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_tenant_school_idx": {
+          "name": "students_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "students_tenant_school_fk": {
+          "name": "students_tenant_school_fk",
+          "tableFrom": "students",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "student_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_student_tenant_parent_idx": {
+          "name": "parent_student_tenant_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "users",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "parent_student_tenant_student_fk": {
+          "name": "parent_student_tenant_student_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_student_tenant_id_id_unique": {
+          "name": "parent_student_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teachers_on_class_tenant_user_idx": {
+          "name": "teachers_on_class_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teachers_on_class_tenant_class_fk": {
+          "name": "teachers_on_class_tenant_class_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teachers_on_class_tenant_id_id_unique": {
+          "name": "teachers_on_class_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_org_tenant_user_idx": {
+          "name": "users_on_org_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_org_tenant_organization_fk": {
+          "name": "users_on_org_tenant_organization_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_org_tenant_id_id_unique": {
+          "name": "users_on_org_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_school_tenant_user_idx": {
+          "name": "users_on_school_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_school_tenant_school_fk": {
+          "name": "users_on_school_tenant_school_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_school_tenant_id_id_unique": {
+          "name": "users_on_school_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "enrollments_tenant_student_idx": {
+          "name": "enrollments_tenant_student_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollments_tenant_class_idx": {
+          "name": "enrollments_tenant_class_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_student_fk": {
+          "name": "enrollments_tenant_student_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_class_fk": {
+          "name": "enrollments_tenant_class_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grades_tenant_enrollment_idx": {
+          "name": "grades_tenant_enrollment_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrollment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "users",
+          "columnsFrom": ["graded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grades_tenant_enrollment_fk": {
+          "name": "grades_tenant_enrollment_fk",
+          "tableFrom": "grades",
+          "tableTo": "enrollments",
+          "columnsFrom": ["tenant_id", "enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grades_tenant_id_id_unique": {
+          "name": "grades_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0006_snapshot.json
+++ b/packages/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,2179 @@
+{
+  "id": "8f21a7a3-192b-40b7-b47c-13ccb0ca5826",
+  "prevId": "0482dcf0-68be-4e41-ae78-54cafc9ceaf8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schools_tenant_organization_idx": {
+          "name": "schools_tenant_organization_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "schools_tenant_organization_fk": {
+          "name": "schools_tenant_organization_fk",
+          "tableFrom": "schools",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "education_organizations_legacy_organization_fk": {
+          "name": "education_organizations_legacy_organization_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "legacy_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "version"]
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classes_tenant_school_idx": {
+          "name": "classes_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "classes_tenant_school_fk": {
+          "name": "classes_tenant_school_fk",
+          "tableFrom": "classes",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_tenant_school_idx": {
+          "name": "students_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "students_tenant_school_fk": {
+          "name": "students_tenant_school_fk",
+          "tableFrom": "students",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "student_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_student_tenant_parent_idx": {
+          "name": "parent_student_tenant_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "users",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "parent_student_tenant_student_fk": {
+          "name": "parent_student_tenant_student_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_student_tenant_id_id_unique": {
+          "name": "parent_student_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teachers_on_class_tenant_user_idx": {
+          "name": "teachers_on_class_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teachers_on_class_tenant_class_fk": {
+          "name": "teachers_on_class_tenant_class_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teachers_on_class_tenant_id_id_unique": {
+          "name": "teachers_on_class_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_org_tenant_user_idx": {
+          "name": "users_on_org_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_org_tenant_organization_fk": {
+          "name": "users_on_org_tenant_organization_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_org_tenant_id_id_unique": {
+          "name": "users_on_org_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_school_tenant_user_idx": {
+          "name": "users_on_school_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_school_tenant_school_fk": {
+          "name": "users_on_school_tenant_school_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_school_tenant_id_id_unique": {
+          "name": "users_on_school_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "enrollments_tenant_student_idx": {
+          "name": "enrollments_tenant_student_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollments_tenant_class_idx": {
+          "name": "enrollments_tenant_class_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_student_fk": {
+          "name": "enrollments_tenant_student_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_class_fk": {
+          "name": "enrollments_tenant_class_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grades_tenant_enrollment_idx": {
+          "name": "grades_tenant_enrollment_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrollment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "users",
+          "columnsFrom": ["graded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grades_tenant_enrollment_fk": {
+          "name": "grades_tenant_enrollment_fk",
+          "tableFrom": "grades",
+          "tableTo": "enrollments",
+          "columnsFrom": ["tenant_id", "enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grades_tenant_id_id_unique": {
+          "name": "grades_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0007_snapshot.json
+++ b/packages/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,2179 @@
+{
+  "id": "3124b9c9-795d-446b-b106-182c4c3e00d9",
+  "prevId": "8f21a7a3-192b-40b7-b47c-13ccb0ca5826",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "columns": ["tenant_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "columns": ["slug"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": ["slug"],
+          "nullsNotDistinct": false
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schools_tenant_organization_idx": {
+          "name": "schools_tenant_organization_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "schools_tenant_organization_fk": {
+          "name": "schools_tenant_organization_fk",
+          "tableFrom": "schools",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "tableTo": "organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "columns": ["tenant_id", "slug"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "education_organizations_legacy_organization_fk": {
+          "name": "education_organizations_legacy_organization_fk",
+          "tableFrom": "education_organizations",
+          "columnsFrom": ["tenant_id", "legacy_organization_id"],
+          "tableTo": "organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "columns": ["tenant_id", "slug"],
+          "nullsNotDistinct": false
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "columns": ["legacy_organization_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "tableTo": "organization_tree_versions",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "tableTo": "organization_tree_versions",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "columns": ["tenant_id", "version"],
+          "nullsNotDistinct": false
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "columns": ["tenant_id", "effective_from"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classes_tenant_school_idx": {
+          "name": "classes_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "classes_tenant_school_fk": {
+          "name": "classes_tenant_school_fk",
+          "tableFrom": "classes",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_tenant_school_idx": {
+          "name": "students_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "students_tenant_school_fk": {
+          "name": "students_tenant_school_fk",
+          "tableFrom": "students",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "columns": ["tenant_id", "student_number"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_student_tenant_parent_idx": {
+          "name": "parent_student_tenant_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["parent_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "parent_student_tenant_student_fk": {
+          "name": "parent_student_tenant_student_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "tableTo": "students",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_student_tenant_id_id_unique": {
+          "name": "parent_student_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teachers_on_class_tenant_user_idx": {
+          "name": "teachers_on_class_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "teachers_on_class_tenant_class_fk": {
+          "name": "teachers_on_class_tenant_class_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teachers_on_class_tenant_id_id_unique": {
+          "name": "teachers_on_class_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_org_tenant_user_idx": {
+          "name": "users_on_org_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "users_on_org_tenant_organization_fk": {
+          "name": "users_on_org_tenant_organization_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "tableTo": "organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_org_tenant_id_id_unique": {
+          "name": "users_on_org_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_school_tenant_user_idx": {
+          "name": "users_on_school_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "users_on_school_tenant_school_fk": {
+          "name": "users_on_school_tenant_school_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_school_tenant_id_id_unique": {
+          "name": "users_on_school_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "enrollments_tenant_student_idx": {
+          "name": "enrollments_tenant_student_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "enrollments_tenant_class_idx": {
+          "name": "enrollments_tenant_class_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "enrollments_tenant_student_fk": {
+          "name": "enrollments_tenant_student_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "tableTo": "students",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "enrollments_tenant_class_fk": {
+          "name": "enrollments_tenant_class_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grades_tenant_enrollment_idx": {
+          "name": "grades_tenant_enrollment_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrollment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["graded_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "grades_tenant_enrollment_fk": {
+          "name": "grades_tenant_enrollment_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["tenant_id", "enrollment_id"],
+          "tableTo": "enrollments",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grades_tenant_id_id_unique": {
+          "name": "grades_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0008_snapshot.json
+++ b/packages/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,2207 @@
+{
+  "id": "8c956e10-8755-4a6f-9c7b-d61ab5fb7e07",
+  "prevId": "3124b9c9-795d-446b-b106-182c4c3e00d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tenant_placements_adapter_check": {
+          "name": "tenant_placements_adapter_check",
+          "value": "\"tenant_placements\".\"adapter\" = 'pooled'"
+        },
+        "tenant_placements_status_check": {
+          "name": "tenant_placements_status_check",
+          "value": "\"tenant_placements\".\"status\" IN ('active', 'migrating', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tenants_status_check": {
+          "name": "tenants_status_check",
+          "value": "\"tenants\".\"status\" IN ('active', 'suspended', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schools_tenant_organization_idx": {
+          "name": "schools_tenant_organization_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "schools_tenant_organization_fk": {
+          "name": "schools_tenant_organization_fk",
+          "tableFrom": "schools",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "schools_profile_check": {
+          "name": "schools_profile_check",
+          "value": "\"schools\".\"profile\" IN ('primary', 'secondary', 'all_through', 'special', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "education_organizations_legacy_organization_fk": {
+          "name": "education_organizations_legacy_organization_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "legacy_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "education_organizations_type_check": {
+          "name": "education_organizations_type_check",
+          "value": "\"education_organizations\".\"type\" IN ('ministry', 'school_board', 'district', 'network', 'region', 'other')"
+        },
+        "education_organizations_status_check": {
+          "name": "education_organizations_status_check",
+          "value": "\"education_organizations\".\"status\" IN ('active', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "version"]
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classes_tenant_school_idx": {
+          "name": "classes_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "classes_tenant_school_fk": {
+          "name": "classes_tenant_school_fk",
+          "tableFrom": "classes",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_tenant_school_idx": {
+          "name": "students_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "students_tenant_school_fk": {
+          "name": "students_tenant_school_fk",
+          "tableFrom": "students",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "student_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_student_tenant_parent_idx": {
+          "name": "parent_student_tenant_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "users",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "parent_student_tenant_student_fk": {
+          "name": "parent_student_tenant_student_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_student_tenant_id_id_unique": {
+          "name": "parent_student_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teachers_on_class_tenant_user_idx": {
+          "name": "teachers_on_class_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teachers_on_class_tenant_class_fk": {
+          "name": "teachers_on_class_tenant_class_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teachers_on_class_tenant_id_id_unique": {
+          "name": "teachers_on_class_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_org_tenant_user_idx": {
+          "name": "users_on_org_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_org_tenant_organization_fk": {
+          "name": "users_on_org_tenant_organization_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_org_tenant_id_id_unique": {
+          "name": "users_on_org_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_school_tenant_user_idx": {
+          "name": "users_on_school_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_school_tenant_school_fk": {
+          "name": "users_on_school_tenant_school_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_school_tenant_id_id_unique": {
+          "name": "users_on_school_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "enrollments_tenant_student_idx": {
+          "name": "enrollments_tenant_student_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollments_tenant_class_idx": {
+          "name": "enrollments_tenant_class_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_student_fk": {
+          "name": "enrollments_tenant_student_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_class_fk": {
+          "name": "enrollments_tenant_class_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grades_tenant_enrollment_idx": {
+          "name": "grades_tenant_enrollment_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrollment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "users",
+          "columnsFrom": ["graded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grades_tenant_enrollment_fk": {
+          "name": "grades_tenant_enrollment_fk",
+          "tableFrom": "grades",
+          "tableTo": "enrollments",
+          "columnsFrom": ["tenant_id", "enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grades_tenant_id_id_unique": {
+          "name": "grades_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -22,6 +22,48 @@
       "when": 1766919148348,
       "tag": "0002_clammy_gravity",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785688871336,
+      "tag": "0003_tenant_hierarchy_additive",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1785688903344,
+      "tag": "0004_tenant_hierarchy_backfill",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1785689061829,
+      "tag": "0005_tenant_hierarchy_constraints",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785689175734,
+      "tag": "0006_school_profile",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785689179731,
+      "tag": "0007_tenant_hierarchy_guards",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785694222661,
+      "tag": "0008_tenant_hierarchy_value_constraints",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,9 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:security-poc": "bun run src/security-poc.ts",
+    "db:tenant-foundation-poc": "bun run src/tenant-foundation-poc.ts",
+    "db:prepare-upgrade-fixture": "bun run src/prepare-upgrade-fixture.ts",
+    "db:verify-upgrade-fixture": "bun run src/verify-upgrade-fixture.ts",
     "db:studio": "drizzle-kit studio",
     "db:seed": "bun run src/seed.ts"
   },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,2 +1,4 @@
 export * from './schema'
 export * from './client'
+export * from './organization-tree'
+export * from './tenant-hierarchy'

--- a/packages/db/src/organization-tree.test.ts
+++ b/packages/db/src/organization-tree.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  type OrganizationTreeNodeInput,
+  OrganizationTreeValidationError,
+  buildOrganizationClosure,
+  getDescendantOrganizationIds,
+  getSiblingOrganizationIds,
+  moveOrganization,
+  resolveSchoolGovernanceAt,
+  resolveTreeVersionAt,
+} from './organization-tree'
+
+const originalTree = [
+  { organizationId: 'ministry', parentOrganizationId: null },
+  { organizationId: 'board', parentOrganizationId: 'ministry' },
+  { organizationId: 'network', parentOrganizationId: 'ministry' },
+  { organizationId: 'district', parentOrganizationId: 'board' },
+] satisfies OrganizationTreeNodeInput[]
+
+describe('Organization Tree', () => {
+  it('builds self and ancestor closure edges for inserted nodes', () => {
+    const closure = buildOrganizationClosure(originalTree)
+
+    assert.deepEqual(getDescendantOrganizationIds(closure, 'ministry'), [
+      'board',
+      'network',
+      'district',
+    ])
+    assert.deepEqual(getDescendantOrganizationIds(closure, 'board', true), ['board', 'district'])
+    assert.deepEqual(getSiblingOrganizationIds(originalTree, 'board'), ['network'])
+  })
+
+  it('creates a new valid shape for a move without mutating the prior version', () => {
+    const movedTree = moveOrganization(originalTree, 'district', 'network')
+    const movedClosure = buildOrganizationClosure(movedTree)
+
+    assert.equal(
+      originalTree.find((node) => node.organizationId === 'district')?.parentOrganizationId,
+      'board'
+    )
+    assert.equal(
+      movedTree.find((node) => node.organizationId === 'district')?.parentOrganizationId,
+      'network'
+    )
+    assert.deepEqual(getDescendantOrganizationIds(movedClosure, 'board'), [])
+    assert.deepEqual(getDescendantOrganizationIds(movedClosure, 'network'), ['district'])
+  })
+
+  it('rejects missing parents, self-parenting, duplicate nodes, and cycles', () => {
+    const cases: Array<{
+      code: OrganizationTreeValidationError['code']
+      nodes: OrganizationTreeNodeInput[]
+    }> = [
+      {
+        code: 'missing_parent',
+        nodes: [{ organizationId: 'board', parentOrganizationId: 'missing' }],
+      },
+      {
+        code: 'self_parent',
+        nodes: [{ organizationId: 'board', parentOrganizationId: 'board' }],
+      },
+      {
+        code: 'duplicate_organization',
+        nodes: [
+          { organizationId: 'board', parentOrganizationId: null },
+          { organizationId: 'board', parentOrganizationId: null },
+        ],
+      },
+      {
+        code: 'cycle',
+        nodes: [
+          { organizationId: 'board', parentOrganizationId: 'network' },
+          { organizationId: 'network', parentOrganizationId: 'board' },
+        ],
+      },
+      {
+        code: 'invalid_root_count',
+        nodes: [
+          { organizationId: 'board', parentOrganizationId: null },
+          { organizationId: 'network', parentOrganizationId: null },
+        ],
+      },
+    ]
+
+    for (const testCase of cases) {
+      assert.throws(
+        () => buildOrganizationClosure(testCase.nodes),
+        (error) => error instanceof OrganizationTreeValidationError && error.code === testCase.code
+      )
+    }
+  })
+
+  it('resolves historical tree versions and School governance by effective time', () => {
+    const versions = [
+      { id: 'v1', effectiveFrom: new Date('2026-01-01T00:00:00Z') },
+      { id: 'v2', effectiveFrom: new Date('2026-08-01T00:00:00Z') },
+    ]
+    const assignments = [
+      {
+        id: 'g1',
+        schoolId: 'school',
+        educationOrganizationId: 'board',
+        validFrom: new Date('2026-01-01T00:00:00Z'),
+        validUntil: new Date('2026-08-01T00:00:00Z'),
+      },
+      {
+        id: 'g2',
+        schoolId: 'school',
+        educationOrganizationId: 'network',
+        validFrom: new Date('2026-08-01T00:00:00Z'),
+        validUntil: null,
+      },
+    ]
+
+    assert.equal(resolveTreeVersionAt(versions, new Date('2026-07-31T23:59:59Z'))?.id, 'v1')
+    assert.equal(resolveTreeVersionAt(versions, new Date('2026-08-01T00:00:00Z'))?.id, 'v2')
+    assert.equal(
+      resolveSchoolGovernanceAt(assignments, 'school', new Date('2026-07-31T23:59:59Z'))
+        ?.educationOrganizationId,
+      'board'
+    )
+    assert.equal(
+      resolveSchoolGovernanceAt(assignments, 'school', new Date('2026-08-01T00:00:00Z'))
+        ?.educationOrganizationId,
+      'network'
+    )
+  })
+})

--- a/packages/db/src/organization-tree.ts
+++ b/packages/db/src/organization-tree.ts
@@ -1,0 +1,205 @@
+export interface OrganizationTreeNodeInput {
+  organizationId: string
+  parentOrganizationId: string | null
+}
+
+export interface OrganizationClosureEdge {
+  ancestorOrganizationId: string
+  descendantOrganizationId: string
+  depth: number
+}
+
+export interface EffectiveTreeVersion {
+  id: string
+  effectiveFrom: Date
+}
+
+export interface EffectiveSchoolGovernance {
+  id: string
+  schoolId: string
+  educationOrganizationId: string
+  validFrom: Date
+  validUntil: Date | null
+}
+
+export type OrganizationTreeValidationCode =
+  | 'duplicate_organization'
+  | 'missing_parent'
+  | 'self_parent'
+  | 'cycle'
+  | 'invalid_root_count'
+  | 'missing_organization'
+
+export class OrganizationTreeValidationError extends Error {
+  constructor(
+    readonly code: OrganizationTreeValidationCode,
+    message: string
+  ) {
+    super(message)
+    this.name = 'OrganizationTreeValidationError'
+  }
+}
+
+function indexNodes(nodes: readonly OrganizationTreeNodeInput[]): Map<string, string | null> {
+  const parents = new Map<string, string | null>()
+
+  for (const node of nodes) {
+    if (parents.has(node.organizationId)) {
+      throw new OrganizationTreeValidationError(
+        'duplicate_organization',
+        `Organization ${node.organizationId} appears more than once in the tree version`
+      )
+    }
+    if (node.organizationId === node.parentOrganizationId) {
+      throw new OrganizationTreeValidationError(
+        'self_parent',
+        `Organization ${node.organizationId} cannot be its own parent`
+      )
+    }
+    parents.set(node.organizationId, node.parentOrganizationId)
+  }
+
+  for (const [organizationId, parentOrganizationId] of parents) {
+    if (parentOrganizationId !== null && !parents.has(parentOrganizationId)) {
+      throw new OrganizationTreeValidationError(
+        'missing_parent',
+        `Organization ${organizationId} references missing parent ${parentOrganizationId}`
+      )
+    }
+  }
+
+  return parents
+}
+
+export function buildOrganizationClosure(
+  nodes: readonly OrganizationTreeNodeInput[]
+): OrganizationClosureEdge[] {
+  const parents = indexNodes(nodes)
+  const edges: OrganizationClosureEdge[] = []
+
+  for (const organizationId of parents.keys()) {
+    const path = new Set<string>()
+    let ancestorId: string | null = organizationId
+    let depth = 0
+
+    while (ancestorId !== null) {
+      if (path.has(ancestorId)) {
+        throw new OrganizationTreeValidationError(
+          'cycle',
+          `Organization tree contains a cycle involving ${ancestorId}`
+        )
+      }
+      path.add(ancestorId)
+      edges.push({
+        ancestorOrganizationId: ancestorId,
+        descendantOrganizationId: organizationId,
+        depth,
+      })
+      ancestorId = parents.get(ancestorId) ?? null
+      depth += 1
+    }
+  }
+
+  const rootCount = nodes.filter((node) => node.parentOrganizationId === null).length
+  if (rootCount !== 1) {
+    throw new OrganizationTreeValidationError(
+      'invalid_root_count',
+      `Organization Tree version must contain exactly one root; found ${rootCount}`
+    )
+  }
+
+  return edges.sort(
+    (left, right) =>
+      left.ancestorOrganizationId.localeCompare(right.ancestorOrganizationId) ||
+      left.depth - right.depth ||
+      left.descendantOrganizationId.localeCompare(right.descendantOrganizationId)
+  )
+}
+
+export function moveOrganization(
+  nodes: readonly OrganizationTreeNodeInput[],
+  organizationId: string,
+  parentOrganizationId: string | null
+): OrganizationTreeNodeInput[] {
+  if (!nodes.some((node) => node.organizationId === organizationId)) {
+    throw new OrganizationTreeValidationError(
+      'missing_organization',
+      `Cannot move missing organization ${organizationId}`
+    )
+  }
+
+  const moved = nodes.map((node) =>
+    node.organizationId === organizationId ? { ...node, parentOrganizationId } : { ...node }
+  )
+  buildOrganizationClosure(moved)
+  return moved
+}
+
+export function getDescendantOrganizationIds(
+  edges: readonly OrganizationClosureEdge[],
+  ancestorOrganizationId: string,
+  includeSelf = false
+): string[] {
+  return edges
+    .filter(
+      (edge) =>
+        edge.ancestorOrganizationId === ancestorOrganizationId && (includeSelf || edge.depth > 0)
+    )
+    .sort((left, right) => left.depth - right.depth)
+    .map((edge) => edge.descendantOrganizationId)
+}
+
+export function getSiblingOrganizationIds(
+  nodes: readonly OrganizationTreeNodeInput[],
+  organizationId: string
+): string[] {
+  const node = nodes.find((candidate) => candidate.organizationId === organizationId)
+  if (!node) {
+    throw new OrganizationTreeValidationError(
+      'missing_organization',
+      `Cannot find siblings for missing organization ${organizationId}`
+    )
+  }
+
+  return nodes
+    .filter(
+      (candidate) =>
+        candidate.organizationId !== organizationId &&
+        candidate.parentOrganizationId === node.parentOrganizationId
+    )
+    .map((candidate) => candidate.organizationId)
+    .sort()
+}
+
+export function resolveTreeVersionAt(
+  versions: readonly EffectiveTreeVersion[],
+  at: Date
+): EffectiveTreeVersion | null {
+  return (
+    versions
+      .filter((version) => version.effectiveFrom.getTime() <= at.getTime())
+      .sort((left, right) => right.effectiveFrom.getTime() - left.effectiveFrom.getTime())[0] ??
+    null
+  )
+}
+
+export function resolveSchoolGovernanceAt(
+  assignments: readonly EffectiveSchoolGovernance[],
+  schoolId: string,
+  at: Date
+): EffectiveSchoolGovernance | null {
+  const active = assignments.filter(
+    (assignment) =>
+      assignment.schoolId === schoolId &&
+      assignment.validFrom.getTime() <= at.getTime() &&
+      (assignment.validUntil === null || at.getTime() < assignment.validUntil.getTime())
+  )
+
+  if (active.length > 1) {
+    throw new Error(
+      `School ${schoolId} has overlapping governance assignments at ${at.toISOString()}`
+    )
+  }
+
+  return active[0] ?? null
+}

--- a/packages/db/src/prepare-upgrade-fixture.ts
+++ b/packages/db/src/prepare-upgrade-fixture.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getServerEnv } from '@openschool/config/server'
+import postgres from 'postgres'
+
+interface Journal {
+  entries: Array<{ tag: string; when: number }>
+}
+
+function assertLocalDisposableDatabase(databaseUrl: URL): void {
+  const loopbackHosts = new Set(['127.0.0.1', 'localhost', '[::1]'])
+  if (process.env.ALLOW_TENANT_FOUNDATION_POC !== 'true') {
+    throw new Error('Upgrade fixture refused: ALLOW_TENANT_FOUNDATION_POC must be exactly "true".')
+  }
+  if (!loopbackHosts.has(databaseUrl.hostname)) {
+    throw new Error('Upgrade fixture refused: database host must be loopback.')
+  }
+}
+
+async function run(): Promise<void> {
+  const databaseUrl = new URL(getServerEnv().DATABASE_URL)
+  assertLocalDisposableDatabase(databaseUrl)
+
+  const client = postgres(databaseUrl.toString(), { max: 1, prepare: false })
+  const currentDirectory = dirname(fileURLToPath(import.meta.url))
+  const migrationsDirectory = resolve(currentDirectory, '../migrations')
+  const journal = JSON.parse(
+    readFileSync(resolve(migrationsDirectory, 'meta/_journal.json'), 'utf8')
+  ) as Journal
+  const baselineEntries = journal.entries.slice(0, 3)
+  assert.deepEqual(
+    baselineEntries.map(({ tag }) => tag),
+    ['0000_nosy_zodiak', '0001_vengeful_magneto', '0002_clammy_gravity']
+  )
+
+  try {
+    const [{ isEmpty }] = await client<Array<{ isEmpty: boolean }>>`
+      select to_regclass('public.organizations') is null as "isEmpty"
+    `
+    assert.equal(isEmpty, true, 'Upgrade fixture requires an empty disposable database')
+
+    await client.begin(async (transaction) => {
+      await transaction.unsafe('create schema if not exists drizzle')
+      await transaction.unsafe(`
+        create table if not exists drizzle.__drizzle_migrations (
+          id serial primary key,
+          hash text not null,
+          created_at bigint
+        )
+      `)
+
+      for (const entry of baselineEntries) {
+        const migrationSql = readFileSync(resolve(migrationsDirectory, `${entry.tag}.sql`), 'utf8')
+        for (const statement of migrationSql.split('--> statement-breakpoint')) {
+          if (statement.trim()) {
+            await transaction.unsafe(statement)
+          }
+        }
+        await transaction`
+          insert into drizzle.__drizzle_migrations (hash, created_at)
+          values (${createHash('sha256').update(migrationSql).digest('hex')}, ${entry.when})
+        `
+      }
+
+      await transaction.unsafe(`
+        insert into organizations (id, name, slug) values
+          ('10000000-0000-4000-8000-000000000001', 'Legacy Board A', 'legacy-board-a'),
+          ('20000000-0000-4000-8000-000000000001', 'Legacy Trust B', 'legacy-trust-b');
+
+        insert into schools (id, org_id, name, slug, academic_year, status) values
+          ('10000000-0000-4000-8000-000000000101', '10000000-0000-4000-8000-000000000001', 'Legacy Primary', 'legacy-primary', '2026-2027', 'active'),
+          ('10000000-0000-4000-8000-000000000102', '10000000-0000-4000-8000-000000000001', 'Legacy High', 'legacy-high', '2026-2027', 'active'),
+          ('20000000-0000-4000-8000-000000000101', '20000000-0000-4000-8000-000000000001', 'Legacy Community', 'legacy-community', '2026-2027', 'active');
+
+        insert into users (id, email) values
+          ('10000000-0000-4000-8000-000000000201', 'legacy.admin@example.test'),
+          ('10000000-0000-4000-8000-000000000202', 'legacy.parent@example.test');
+
+        insert into classes (id, school_id, name, academic_year, status) values
+          ('10000000-0000-4000-8000-000000000301', '10000000-0000-4000-8000-000000000101', 'Grade 5', '2026-2027', 'active'),
+          ('20000000-0000-4000-8000-000000000301', '20000000-0000-4000-8000-000000000101', 'Grade 7', '2026-2027', 'active');
+
+        insert into students (id, school_id, first_name, last_name, student_number, status) values
+          ('10000000-0000-4000-8000-000000000401', '10000000-0000-4000-8000-000000000101', 'Legacy', 'Student', 'SHARED-001', 'active'),
+          ('20000000-0000-4000-8000-000000000401', '20000000-0000-4000-8000-000000000101', 'Other', 'Student', 'OTHER-001', 'active');
+
+        insert into users_on_org (id, user_id, org_id, role) values
+          ('10000000-0000-4000-8000-000000000501', '10000000-0000-4000-8000-000000000201', '10000000-0000-4000-8000-000000000001', 'org_admin');
+        insert into users_on_school (id, user_id, school_id, role) values
+          ('10000000-0000-4000-8000-000000000511', '10000000-0000-4000-8000-000000000201', '10000000-0000-4000-8000-000000000101', 'school_admin');
+        insert into teachers_on_class (id, user_id, class_id, is_primary) values
+          ('10000000-0000-4000-8000-000000000521', '10000000-0000-4000-8000-000000000201', '10000000-0000-4000-8000-000000000301', true);
+        insert into parent_student (id, parent_id, student_id, relationship) values
+          ('10000000-0000-4000-8000-000000000531', '10000000-0000-4000-8000-000000000202', '10000000-0000-4000-8000-000000000401', 'guardian');
+        insert into enrollments (id, student_id, class_id, status) values
+          ('10000000-0000-4000-8000-000000000601', '10000000-0000-4000-8000-000000000401', '10000000-0000-4000-8000-000000000301', 'active');
+        insert into grades (id, enrollment_id, assignment_name, score) values
+          ('10000000-0000-4000-8000-000000000701', '10000000-0000-4000-8000-000000000601', 'Legacy assessment', 88);
+      `)
+    })
+
+    console.log('Prepared representative legacy schema and data through migration 0002.')
+  } finally {
+    await client.end()
+  }
+}
+
+await run()

--- a/packages/db/src/schema/classes.ts
+++ b/packages/db/src/schema/classes.ts
@@ -1,21 +1,49 @@
-import { integer, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import {
+  foreignKey,
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core'
 import { schools } from './schools'
 import { ENTITY_STATUS } from './status'
+import { tenants } from './tenancy'
 
-export const classes = pgTable('classes', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  schoolId: uuid('school_id')
-    .references(() => schools.id)
-    .notNull(),
-  name: text('name').notNull(),
-  gradeLevel: integer('grade_level'),
-  academicYear: text('academic_year').notNull(),
-  status: text('status', { enum: ['active', 'archived', 'read_only'] })
-    .default(ENTITY_STATUS.ACTIVE)
-    .notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-})
+export const classes = pgTable(
+  'classes',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    schoolId: uuid('school_id').notNull(),
+    name: text('name').notNull(),
+    gradeLevel: integer('grade_level'),
+    academicYear: text('academic_year').notNull(),
+    status: text('status', { enum: ['active', 'archived', 'read_only'] })
+      .default(ENTITY_STATUS.ACTIVE)
+      .notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('classes_tenant_id_id_unique').on(table.tenantId, table.id),
+    foreignKey({
+      name: 'classes_tenant_school_fk',
+      columns: [table.tenantId, table.schoolId],
+      foreignColumns: [schools.tenantId, schools.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('classes_tenant_school_idx').on(table.tenantId, table.schoolId),
+  ]
+)
 
 export type Class = typeof classes.$inferSelect
 export type NewClass = typeof classes.$inferInsert

--- a/packages/db/src/schema/education-organizations.ts
+++ b/packages/db/src/schema/education-organizations.ts
@@ -1,0 +1,233 @@
+import { sql } from 'drizzle-orm'
+import {
+  check,
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core'
+import { organizations } from './organizations'
+import { schools } from './schools'
+import { tenants } from './tenancy'
+
+export const educationOrganizations = pgTable(
+  'education_organizations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, { onDelete: 'restrict', onUpdate: 'restrict' })
+      .notNull(),
+    legacyOrganizationId: uuid('legacy_organization_id'),
+    name: text('name').notNull(),
+    slug: text('slug').notNull(),
+    type: text('type', {
+      enum: ['ministry', 'school_board', 'district', 'network', 'region', 'other'],
+    }).notNull(),
+    status: text('status', { enum: ['active', 'archived'] })
+      .default('active')
+      .notNull(),
+    settings: jsonb('settings').default({}).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    unique('education_organizations_tenant_id_id_unique').on(table.tenantId, table.id),
+    unique('education_organizations_tenant_id_slug_unique').on(table.tenantId, table.slug),
+    unique('education_organizations_legacy_organization_id_unique').on(table.legacyOrganizationId),
+    foreignKey({
+      name: 'education_organizations_legacy_organization_fk',
+      columns: [table.tenantId, table.legacyOrganizationId],
+      foreignColumns: [organizations.tenantId, organizations.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('education_organizations_tenant_type_idx').on(table.tenantId, table.type),
+    check(
+      'education_organizations_type_check',
+      sql`${table.type} IN ('ministry', 'school_board', 'district', 'network', 'region', 'other')`
+    ),
+    check('education_organizations_status_check', sql`${table.status} IN ('active', 'archived')`),
+  ]
+)
+
+export const organizationTreeVersions = pgTable(
+  'organization_tree_versions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, { onDelete: 'restrict', onUpdate: 'restrict' })
+      .notNull(),
+    version: integer('version').notNull(),
+    effectiveFrom: timestamp('effective_from', { withTimezone: true }).notNull(),
+    reason: text('reason').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    unique('organization_tree_versions_tenant_id_id_unique').on(table.tenantId, table.id),
+    unique('organization_tree_versions_tenant_id_version_unique').on(table.tenantId, table.version),
+    unique('organization_tree_versions_tenant_effective_from_unique').on(
+      table.tenantId,
+      table.effectiveFrom
+    ),
+    index('organization_tree_versions_effective_lookup_idx').on(
+      table.tenantId,
+      table.effectiveFrom
+    ),
+    check('organization_tree_versions_version_positive', sql`${table.version} > 0`),
+  ]
+)
+
+export const organizationTreeNodes = pgTable(
+  'organization_tree_nodes',
+  {
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, { onDelete: 'restrict', onUpdate: 'restrict' })
+      .notNull(),
+    treeVersionId: uuid('tree_version_id').notNull(),
+    organizationId: uuid('organization_id').notNull(),
+    parentOrganizationId: uuid('parent_organization_id'),
+  },
+  (table) => [
+    primaryKey({
+      name: 'organization_tree_nodes_pk',
+      columns: [table.tenantId, table.treeVersionId, table.organizationId],
+    }),
+    foreignKey({
+      name: 'organization_tree_nodes_version_fk',
+      columns: [table.tenantId, table.treeVersionId],
+      foreignColumns: [organizationTreeVersions.tenantId, organizationTreeVersions.id],
+    }).onDelete('restrict'),
+    foreignKey({
+      name: 'organization_tree_nodes_organization_fk',
+      columns: [table.tenantId, table.organizationId],
+      foreignColumns: [educationOrganizations.tenantId, educationOrganizations.id],
+    }).onDelete('restrict'),
+    foreignKey({
+      name: 'organization_tree_nodes_parent_fk',
+      columns: [table.tenantId, table.parentOrganizationId],
+      foreignColumns: [educationOrganizations.tenantId, educationOrganizations.id],
+    }).onDelete('restrict'),
+    index('organization_tree_nodes_parent_idx').on(
+      table.tenantId,
+      table.treeVersionId,
+      table.parentOrganizationId
+    ),
+    check(
+      'organization_tree_nodes_not_self_parent',
+      sql`${table.parentOrganizationId} IS NULL OR ${table.parentOrganizationId} <> ${table.organizationId}`
+    ),
+  ]
+)
+
+export const organizationTreeClosure = pgTable(
+  'organization_tree_closure',
+  {
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, { onDelete: 'restrict', onUpdate: 'restrict' })
+      .notNull(),
+    treeVersionId: uuid('tree_version_id').notNull(),
+    ancestorOrganizationId: uuid('ancestor_organization_id').notNull(),
+    descendantOrganizationId: uuid('descendant_organization_id').notNull(),
+    depth: integer('depth').notNull(),
+  },
+  (table) => [
+    primaryKey({
+      name: 'organization_tree_closure_pk',
+      columns: [
+        table.tenantId,
+        table.treeVersionId,
+        table.ancestorOrganizationId,
+        table.descendantOrganizationId,
+      ],
+    }),
+    foreignKey({
+      name: 'organization_tree_closure_version_fk',
+      columns: [table.tenantId, table.treeVersionId],
+      foreignColumns: [organizationTreeVersions.tenantId, organizationTreeVersions.id],
+    }).onDelete('restrict'),
+    foreignKey({
+      name: 'organization_tree_closure_ancestor_fk',
+      columns: [table.tenantId, table.ancestorOrganizationId],
+      foreignColumns: [educationOrganizations.tenantId, educationOrganizations.id],
+    }).onDelete('restrict'),
+    foreignKey({
+      name: 'organization_tree_closure_descendant_fk',
+      columns: [table.tenantId, table.descendantOrganizationId],
+      foreignColumns: [educationOrganizations.tenantId, educationOrganizations.id],
+    }).onDelete('restrict'),
+    index('organization_tree_closure_descendants_idx').on(
+      table.tenantId,
+      table.treeVersionId,
+      table.ancestorOrganizationId,
+      table.depth,
+      table.descendantOrganizationId
+    ),
+    index('organization_tree_closure_ancestors_idx').on(
+      table.tenantId,
+      table.treeVersionId,
+      table.descendantOrganizationId,
+      table.depth,
+      table.ancestorOrganizationId
+    ),
+    check('organization_tree_closure_depth_nonnegative', sql`${table.depth} >= 0`),
+    check(
+      'organization_tree_closure_self_depth',
+      sql`(${table.ancestorOrganizationId} = ${table.descendantOrganizationId}) = (${table.depth} = 0)`
+    ),
+  ]
+)
+
+export const schoolGovernanceAssignments = pgTable(
+  'school_governance_assignments',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, { onDelete: 'restrict', onUpdate: 'restrict' })
+      .notNull(),
+    schoolId: uuid('school_id').notNull(),
+    educationOrganizationId: uuid('education_organization_id').notNull(),
+    validFrom: timestamp('valid_from', { withTimezone: true }).notNull(),
+    validUntil: timestamp('valid_until', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    unique('school_governance_assignments_tenant_id_id_unique').on(table.tenantId, table.id),
+    foreignKey({
+      name: 'school_governance_assignments_school_fk',
+      columns: [table.tenantId, table.schoolId],
+      foreignColumns: [schools.tenantId, schools.id],
+    }).onDelete('restrict'),
+    foreignKey({
+      name: 'school_governance_assignments_organization_fk',
+      columns: [table.tenantId, table.educationOrganizationId],
+      foreignColumns: [educationOrganizations.tenantId, educationOrganizations.id],
+    }).onDelete('restrict'),
+    index('school_governance_assignments_effective_lookup_idx').on(
+      table.tenantId,
+      table.schoolId,
+      table.validFrom,
+      table.validUntil
+    ),
+    check(
+      'school_governance_assignments_valid_period',
+      sql`${table.validUntil} IS NULL OR ${table.validUntil} > ${table.validFrom}`
+    ),
+  ]
+)
+
+export type EducationOrganization = typeof educationOrganizations.$inferSelect
+export type NewEducationOrganization = typeof educationOrganizations.$inferInsert
+export type OrganizationTreeVersion = typeof organizationTreeVersions.$inferSelect
+export type NewOrganizationTreeVersion = typeof organizationTreeVersions.$inferInsert
+export type OrganizationTreeNode = typeof organizationTreeNodes.$inferSelect
+export type NewOrganizationTreeNode = typeof organizationTreeNodes.$inferInsert
+export type OrganizationTreeClosureEdge = typeof organizationTreeClosure.$inferSelect
+export type NewOrganizationTreeClosureEdge = typeof organizationTreeClosure.$inferInsert
+export type SchoolGovernanceAssignment = typeof schoolGovernanceAssignments.$inferSelect
+export type NewSchoolGovernanceAssignment = typeof schoolGovernanceAssignments.$inferInsert

--- a/packages/db/src/schema/enrollments.ts
+++ b/packages/db/src/schema/enrollments.ts
@@ -1,18 +1,43 @@
-import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { foreignKey, index, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core'
 import { classes } from './classes'
 import { students } from './student'
+import { tenants } from './tenancy'
 
-export const enrollments = pgTable('enrollments', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  studentId: uuid('student_id')
-    .references(() => students.id)
-    .notNull(),
-  classId: uuid('class_id')
-    .references(() => classes.id)
-    .notNull(),
-  enrolledAt: timestamp('enrolled_at').defaultNow().notNull(),
-  status: text('status', { enum: ['active', 'withdrawn', 'graduated'] }).default('active'),
-})
+export const enrollments = pgTable(
+  'enrollments',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    studentId: uuid('student_id').notNull(),
+    classId: uuid('class_id').notNull(),
+    enrolledAt: timestamp('enrolled_at').defaultNow().notNull(),
+    status: text('status', { enum: ['active', 'withdrawn', 'graduated'] }).default('active'),
+  },
+  (table) => [
+    unique('enrollments_tenant_id_id_unique').on(table.tenantId, table.id),
+    foreignKey({
+      name: 'enrollments_tenant_student_fk',
+      columns: [table.tenantId, table.studentId],
+      foreignColumns: [students.tenantId, students.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    foreignKey({
+      name: 'enrollments_tenant_class_fk',
+      columns: [table.tenantId, table.classId],
+      foreignColumns: [classes.tenantId, classes.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('enrollments_tenant_student_idx').on(table.tenantId, table.studentId),
+    index('enrollments_tenant_class_idx').on(table.tenantId, table.classId),
+  ]
+)
 
 export type Enrollment = typeof enrollments.$inferSelect
 export type NewEnrollment = typeof enrollments.$inferInsert

--- a/packages/db/src/schema/grades.ts
+++ b/packages/db/src/schema/grades.ts
@@ -1,20 +1,48 @@
-import { numeric, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import {
+  foreignKey,
+  index,
+  numeric,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core'
 import { enrollments } from './enrollments'
+import { tenants } from './tenancy'
 import { users } from './users'
 
-export const grades = pgTable('grades', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  enrollmentId: uuid('enrollment_id')
-    .references(() => enrollments.id)
-    .notNull(),
-  assignmentName: text('assignment_name').notNull(),
-  score: numeric('score', { precision: 5, scale: 2 }),
-  maxScore: numeric('max_score', { precision: 5, scale: 2 }).default('100'),
-  gradedBy: uuid('graded_by').references(() => users.id),
-  gradedAt: timestamp('graded_at'),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-})
+export const grades = pgTable(
+  'grades',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    enrollmentId: uuid('enrollment_id').notNull(),
+    assignmentName: text('assignment_name').notNull(),
+    score: numeric('score', { precision: 5, scale: 2 }),
+    maxScore: numeric('max_score', { precision: 5, scale: 2 }).default('100'),
+    gradedBy: uuid('graded_by').references(() => users.id),
+    gradedAt: timestamp('graded_at'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('grades_tenant_id_id_unique').on(table.tenantId, table.id),
+    foreignKey({
+      name: 'grades_tenant_enrollment_fk',
+      columns: [table.tenantId, table.enrollmentId],
+      foreignColumns: [enrollments.tenantId, enrollments.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('grades_tenant_enrollment_idx').on(table.tenantId, table.enrollmentId),
+  ]
+)
 
 export type Grade = typeof grades.$inferSelect
 export type NewGrade = typeof grades.$inferInsert

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,5 +1,7 @@
+export * from './tenancy'
 export * from './organizations'
 export * from './schools'
+export * from './education-organizations'
 export * from './classes'
 export * from './users'
 export * from './student'

--- a/packages/db/src/schema/memberships.ts
+++ b/packages/db/src/schema/memberships.ts
@@ -1,63 +1,145 @@
-import { boolean, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import {
+  boolean,
+  foreignKey,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core'
 import { classes } from './classes'
 import { organizations } from './organizations'
 import { schools } from './schools'
 import { students } from './student'
+import { tenants } from './tenancy'
 import { users } from './users'
 
 // User → Organization membership
-export const usersOnOrg = pgTable('users_on_org', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  userId: uuid('user_id')
-    .references(() => users.id)
-    .notNull(),
-  orgId: uuid('org_id')
-    .references(() => organizations.id)
-    .notNull(),
-  role: text('role', { enum: ['org_admin', 'org_viewer'] }).notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-})
+export const usersOnOrg = pgTable(
+  'users_on_org',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    userId: uuid('user_id')
+      .references(() => users.id)
+      .notNull(),
+    orgId: uuid('org_id').notNull(),
+    role: text('role', { enum: ['org_admin', 'org_viewer'] }).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('users_on_org_tenant_id_id_unique').on(table.tenantId, table.id),
+    foreignKey({
+      name: 'users_on_org_tenant_organization_fk',
+      columns: [table.tenantId, table.orgId],
+      foreignColumns: [organizations.tenantId, organizations.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('users_on_org_tenant_user_idx').on(table.tenantId, table.userId),
+  ]
+)
 
 // User → School membership
-export const usersOnSchool = pgTable('users_on_school', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  userId: uuid('user_id')
-    .references(() => users.id)
-    .notNull(),
-  schoolId: uuid('school_id')
-    .references(() => schools.id)
-    .notNull(),
-  role: text('role', { enum: ['school_admin', 'staff', 'teacher'] }).notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-})
+export const usersOnSchool = pgTable(
+  'users_on_school',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    userId: uuid('user_id')
+      .references(() => users.id)
+      .notNull(),
+    schoolId: uuid('school_id').notNull(),
+    role: text('role', { enum: ['school_admin', 'staff', 'teacher'] }).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('users_on_school_tenant_id_id_unique').on(table.tenantId, table.id),
+    foreignKey({
+      name: 'users_on_school_tenant_school_fk',
+      columns: [table.tenantId, table.schoolId],
+      foreignColumns: [schools.tenantId, schools.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('users_on_school_tenant_user_idx').on(table.tenantId, table.userId),
+  ]
+)
 
 // Teacher → Class assignment
-export const teachersOnClass = pgTable('teachers_on_class', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  userId: uuid('user_id')
-    .references(() => users.id)
-    .notNull(),
-  classId: uuid('class_id')
-    .references(() => classes.id)
-    .notNull(),
-  isPrimary: boolean('is_primary').default(false),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-})
+export const teachersOnClass = pgTable(
+  'teachers_on_class',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    userId: uuid('user_id')
+      .references(() => users.id)
+      .notNull(),
+    classId: uuid('class_id').notNull(),
+    isPrimary: boolean('is_primary').default(false),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('teachers_on_class_tenant_id_id_unique').on(table.tenantId, table.id),
+    foreignKey({
+      name: 'teachers_on_class_tenant_class_fk',
+      columns: [table.tenantId, table.classId],
+      foreignColumns: [classes.tenantId, classes.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('teachers_on_class_tenant_user_idx').on(table.tenantId, table.userId),
+  ]
+)
 
 // Parent → Student relationship
-export const parentStudent = pgTable('parent_student', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  parentId: uuid('parent_id')
-    .references(() => users.id)
-    .notNull(),
-  studentId: uuid('student_id')
-    .references(() => students.id)
-    .notNull(),
-  relationship: text('relationship', {
-    enum: ['mother', 'father', 'guardian', 'other'],
-  }).notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-})
+export const parentStudent = pgTable(
+  'parent_student',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    parentId: uuid('parent_id')
+      .references(() => users.id)
+      .notNull(),
+    studentId: uuid('student_id').notNull(),
+    relationship: text('relationship', {
+      enum: ['mother', 'father', 'guardian', 'other'],
+    }).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('parent_student_tenant_id_id_unique').on(table.tenantId, table.id),
+    foreignKey({
+      name: 'parent_student_tenant_student_fk',
+      columns: [table.tenantId, table.studentId],
+      foreignColumns: [students.tenantId, students.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('parent_student_tenant_parent_idx').on(table.tenantId, table.parentId),
+  ]
+)
 
 export type UsersOnOrg = typeof usersOnOrg.$inferSelect
 export type UsersOnSchool = typeof usersOnSchool.$inferSelect

--- a/packages/db/src/schema/organizations.ts
+++ b/packages/db/src/schema/organizations.ts
@@ -1,13 +1,24 @@
-import { jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { jsonb, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core'
+import { tenants } from './tenancy'
 
-export const organizations = pgTable('organizations', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  name: text('name').notNull(),
-  slug: text('slug').unique().notNull(),
-  settings: jsonb('settings').default({}),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-})
+export const organizations = pgTable(
+  'organizations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    name: text('name').notNull(),
+    slug: text('slug').unique().notNull(),
+    settings: jsonb('settings').default({}),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [unique('organizations_tenant_id_id_unique').on(table.tenantId, table.id)]
+)
 
 export type Organization = typeof organizations.$inferSelect
 export type NewOrganization = typeof organizations.$inferInsert

--- a/packages/db/src/schema/schools.ts
+++ b/packages/db/src/schema/schools.ts
@@ -1,25 +1,65 @@
-import { jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
+import {
+  check,
+  foreignKey,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core'
 import { organizations } from './organizations'
 import { ENTITY_STATUS } from './status'
+import { tenants } from './tenancy'
 
-export const schools = pgTable('schools', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id')
-    .references(() => organizations.id)
-    .notNull(),
-  name: text('name').notNull(),
-  slug: text('slug').notNull(),
-  address: text('address'),
-  phone: text('phone'),
-  academicYear: text('academic_year'),
-  terms: jsonb('terms').default([]),
-  status: text('status', { enum: ['active', 'archived', 'read_only'] })
-    .default(ENTITY_STATUS.ACTIVE)
-    .notNull(),
-  settings: jsonb('settings').default({}),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-})
+export const schools = pgTable(
+  'schools',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    orgId: uuid('org_id').notNull(),
+    name: text('name').notNull(),
+    slug: text('slug').notNull(),
+    profile: text('profile', {
+      enum: ['primary', 'secondary', 'all_through', 'special', 'other'],
+    })
+      .default('other')
+      .notNull(),
+    address: text('address'),
+    phone: text('phone'),
+    academicYear: text('academic_year'),
+    terms: jsonb('terms').default([]),
+    status: text('status', { enum: ['active', 'archived', 'read_only'] })
+      .default(ENTITY_STATUS.ACTIVE)
+      .notNull(),
+    settings: jsonb('settings').default({}),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('schools_tenant_id_id_unique').on(table.tenantId, table.id),
+    unique('schools_tenant_id_slug_unique').on(table.tenantId, table.slug),
+    foreignKey({
+      name: 'schools_tenant_organization_fk',
+      columns: [table.tenantId, table.orgId],
+      foreignColumns: [organizations.tenantId, organizations.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('schools_tenant_organization_idx').on(table.tenantId, table.orgId),
+    check(
+      'schools_profile_check',
+      sql`${table.profile} IN ('primary', 'secondary', 'all_through', 'special', 'other')`
+    ),
+  ]
+)
 
 export type School = typeof schools.$inferSelect
 export type NewSchool = typeof schools.$inferInsert

--- a/packages/db/src/schema/student.ts
+++ b/packages/db/src/schema/student.ts
@@ -1,23 +1,52 @@
-import { date, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import {
+  date,
+  foreignKey,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core'
 import { schools } from './schools'
 import { ENTITY_STATUS } from './status'
+import { tenants } from './tenancy'
 
-export const students = pgTable('students', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  schoolId: uuid('school_id')
-    .references(() => schools.id)
-    .notNull(),
-  firstName: text('first_name').notNull(),
-  lastName: text('last_name').notNull(),
-  dateOfBirth: date('date_of_birth'),
-  studentNumber: text('student_number').unique(),
-  email: text('email'),
-  status: text('status', { enum: ['active', 'archived', 'read_only'] })
-    .default(ENTITY_STATUS.ACTIVE)
-    .notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-})
+export const students = pgTable(
+  'students',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      })
+      .notNull(),
+    schoolId: uuid('school_id').notNull(),
+    firstName: text('first_name').notNull(),
+    lastName: text('last_name').notNull(),
+    dateOfBirth: date('date_of_birth'),
+    studentNumber: text('student_number'),
+    email: text('email'),
+    status: text('status', { enum: ['active', 'archived', 'read_only'] })
+      .default(ENTITY_STATUS.ACTIVE)
+      .notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('students_tenant_id_id_unique').on(table.tenantId, table.id),
+    unique('students_tenant_id_student_number_unique').on(table.tenantId, table.studentNumber),
+    foreignKey({
+      name: 'students_tenant_school_fk',
+      columns: [table.tenantId, table.schoolId],
+      foreignColumns: [schools.tenantId, schools.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('students_tenant_school_idx').on(table.tenantId, table.schoolId),
+  ]
+)
 
 export type Student = typeof students.$inferSelect
 export type NewStudent = typeof students.$inferInsert

--- a/packages/db/src/schema/tenancy.ts
+++ b/packages/db/src/schema/tenancy.ts
@@ -1,0 +1,53 @@
+import { sql } from 'drizzle-orm'
+import { check, jsonb, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core'
+
+export const tenants = pgTable(
+  'tenants',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    name: text('name').notNull(),
+    slug: text('slug').unique().notNull(),
+    status: text('status', { enum: ['active', 'suspended', 'archived'] })
+      .default('active')
+      .notNull(),
+    settings: jsonb('settings').default({}).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    check('tenants_status_check', sql`${table.status} IN ('active', 'suspended', 'archived')`),
+  ]
+)
+
+export const tenantPlacements = pgTable(
+  'tenant_placements',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, { onDelete: 'restrict', onUpdate: 'restrict' })
+      .notNull(),
+    adapter: text('adapter', { enum: ['pooled'] })
+      .default('pooled')
+      .notNull(),
+    placementKey: text('placement_key').default('primary').notNull(),
+    region: text('region'),
+    status: text('status', { enum: ['active', 'migrating', 'disabled'] })
+      .default('active')
+      .notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    unique('tenant_placements_tenant_id_unique').on(table.tenantId),
+    check('tenant_placements_adapter_check', sql`${table.adapter} = 'pooled'`),
+    check(
+      'tenant_placements_status_check',
+      sql`${table.status} IN ('active', 'migrating', 'disabled')`
+    ),
+  ]
+)
+
+export type Tenant = typeof tenants.$inferSelect
+export type NewTenant = typeof tenants.$inferInsert
+export type TenantPlacement = typeof tenantPlacements.$inferSelect
+export type NewTenantPlacement = typeof tenantPlacements.$inferInsert

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -2,61 +2,208 @@ import { getServerEnv } from '@openschool/config/server'
 import { inArray } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
+import * as schema from './schema'
 import {
   classes,
+  educationOrganizations,
   enrollments,
   grades,
+  organizationTreeVersions,
   organizations,
   parentStudent,
+  schoolGovernanceAssignments,
   schools,
   students,
   teachersOnClass,
+  tenantPlacements,
+  tenants,
   users,
   usersOnOrg,
   usersOnSchool,
 } from './schema'
+import { insertOrganizationTreeVersion } from './tenant-hierarchy'
+
+const HORIZON_TENANT_ID = '00000000-0000-4000-8000-000000000001'
+const ISLAND_TENANT_ID = '00000000-0000-4000-8000-000000000002'
+const HORIZON_BOARD_ID = '00000000-0000-4000-8000-000000000011'
+const HORIZON_NETWORK_ID = '00000000-0000-4000-8000-000000000012'
+const HORIZON_DISTRICT_ID = '00000000-0000-4000-8000-000000000013'
+const ISLAND_DISTRICT_ID = '00000000-0000-4000-8000-000000000021'
 
 const seed = {
-  organizations: [
+  tenants: [
     {
-      id: '00000000-0000-4000-8000-000000000001',
-      name: 'Horizon Education Board',
-      slug: 'horizon-education-board',
+      id: HORIZON_TENANT_ID,
+      name: 'Horizon Education System',
+      slug: 'horizon-education-system',
       settings: { locale: 'en', timezone: 'America/Lower_Princes' },
     },
     {
-      id: '00000000-0000-4000-8000-000000000002',
+      id: ISLAND_TENANT_ID,
+      name: 'Island Schools Trust',
+      slug: 'island-schools-trust-tenant',
+      settings: { locale: 'en', timezone: 'America/Lower_Princes' },
+    },
+  ] satisfies Array<typeof tenants.$inferInsert>,
+  tenantPlacements: [
+    {
+      id: '00000000-0000-4000-8000-000000000031',
+      tenantId: HORIZON_TENANT_ID,
+      adapter: 'pooled',
+      placementKey: 'primary',
+      region: 'sx',
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000032',
+      tenantId: ISLAND_TENANT_ID,
+      adapter: 'pooled',
+      placementKey: 'primary',
+      region: 'sx',
+    },
+  ] satisfies Array<typeof tenantPlacements.$inferInsert>,
+  organizations: [
+    {
+      id: HORIZON_TENANT_ID,
+      tenantId: HORIZON_TENANT_ID,
+      name: 'Horizon Ministry of Education',
+      slug: 'horizon-ministry-of-education',
+      settings: { locale: 'en', timezone: 'America/Lower_Princes' },
+    },
+    {
+      id: ISLAND_TENANT_ID,
+      tenantId: ISLAND_TENANT_ID,
       name: 'Island Schools Trust',
       slug: 'island-schools-trust',
       settings: { locale: 'en', timezone: 'America/Lower_Princes' },
     },
   ] satisfies Array<typeof organizations.$inferInsert>,
+  educationOrganizations: [
+    {
+      id: HORIZON_TENANT_ID,
+      tenantId: HORIZON_TENANT_ID,
+      legacyOrganizationId: HORIZON_TENANT_ID,
+      name: 'Horizon Ministry of Education',
+      slug: 'horizon-ministry',
+      type: 'ministry',
+    },
+    {
+      id: HORIZON_BOARD_ID,
+      tenantId: HORIZON_TENANT_ID,
+      name: 'Horizon Public School Board',
+      slug: 'horizon-public-board',
+      type: 'school_board',
+    },
+    {
+      id: HORIZON_NETWORK_ID,
+      tenantId: HORIZON_TENANT_ID,
+      name: 'Horizon Secondary Network',
+      slug: 'horizon-secondary-network',
+      type: 'network',
+    },
+    {
+      id: HORIZON_DISTRICT_ID,
+      tenantId: HORIZON_TENANT_ID,
+      name: 'Eastern Primary District',
+      slug: 'eastern-primary-district',
+      type: 'district',
+    },
+    {
+      id: ISLAND_TENANT_ID,
+      tenantId: ISLAND_TENANT_ID,
+      legacyOrganizationId: ISLAND_TENANT_ID,
+      name: 'Island Schools Trust',
+      slug: 'island-schools-trust',
+      type: 'network',
+    },
+    {
+      id: ISLAND_DISTRICT_ID,
+      tenantId: ISLAND_TENANT_ID,
+      name: 'Island Community District',
+      slug: 'island-community-district',
+      type: 'district',
+    },
+  ] satisfies Array<typeof educationOrganizations.$inferInsert>,
+  treeVersions: [
+    {
+      id: HORIZON_TENANT_ID,
+      tenantId: HORIZON_TENANT_ID,
+      version: 1,
+      effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+      reason: 'Representative ministry, board, network, and district hierarchy',
+      nodes: [
+        { organizationId: HORIZON_TENANT_ID, parentOrganizationId: null },
+        { organizationId: HORIZON_BOARD_ID, parentOrganizationId: HORIZON_TENANT_ID },
+        { organizationId: HORIZON_NETWORK_ID, parentOrganizationId: HORIZON_TENANT_ID },
+        { organizationId: HORIZON_DISTRICT_ID, parentOrganizationId: HORIZON_BOARD_ID },
+      ],
+    },
+    {
+      id: ISLAND_TENANT_ID,
+      tenantId: ISLAND_TENANT_ID,
+      version: 1,
+      effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+      reason: 'Representative second-Tenant hierarchy',
+      nodes: [
+        { organizationId: ISLAND_TENANT_ID, parentOrganizationId: null },
+        { organizationId: ISLAND_DISTRICT_ID, parentOrganizationId: ISLAND_TENANT_ID },
+      ],
+    },
+  ],
   schools: [
     {
       id: '00000000-0000-4000-8000-000000000101',
-      orgId: '00000000-0000-4000-8000-000000000001',
+      tenantId: HORIZON_TENANT_ID,
+      orgId: HORIZON_TENANT_ID,
       name: 'Horizon Primary School',
       slug: 'horizon-primary',
+      profile: 'primary',
       academicYear: '2026-2027',
       terms: [{ name: 'Term 1', startsOn: '2026-08-17', endsOn: '2026-12-18' }],
     },
     {
       id: '00000000-0000-4000-8000-000000000102',
-      orgId: '00000000-0000-4000-8000-000000000001',
+      tenantId: HORIZON_TENANT_ID,
+      orgId: HORIZON_TENANT_ID,
       name: 'Horizon High School',
       slug: 'horizon-high',
+      profile: 'secondary',
       academicYear: '2026-2027',
       terms: [{ name: 'Semester 1', startsOn: '2026-08-17', endsOn: '2026-12-18' }],
     },
     {
       id: '00000000-0000-4000-8000-000000000103',
-      orgId: '00000000-0000-4000-8000-000000000002',
+      tenantId: ISLAND_TENANT_ID,
+      orgId: ISLAND_TENANT_ID,
       name: 'Island Community School',
       slug: 'island-community',
+      profile: 'all_through',
       academicYear: '2026-2027',
       terms: [{ name: 'Term 1', startsOn: '2026-08-17', endsOn: '2026-12-18' }],
     },
   ] satisfies Array<typeof schools.$inferInsert>,
+  schoolGovernanceAssignments: [
+    {
+      id: '00000000-0000-4000-8000-000000000041',
+      tenantId: HORIZON_TENANT_ID,
+      schoolId: '00000000-0000-4000-8000-000000000101',
+      educationOrganizationId: HORIZON_DISTRICT_ID,
+      validFrom: new Date('2026-01-01T00:00:00Z'),
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000042',
+      tenantId: HORIZON_TENANT_ID,
+      schoolId: '00000000-0000-4000-8000-000000000102',
+      educationOrganizationId: HORIZON_NETWORK_ID,
+      validFrom: new Date('2026-01-01T00:00:00Z'),
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000043',
+      tenantId: ISLAND_TENANT_ID,
+      schoolId: '00000000-0000-4000-8000-000000000103',
+      educationOrganizationId: ISLAND_DISTRICT_ID,
+      validFrom: new Date('2026-01-01T00:00:00Z'),
+    },
+  ] satisfies Array<typeof schoolGovernanceAssignments.$inferInsert>,
   users: [
     {
       id: '00000000-0000-4000-8000-000000000201',
@@ -104,6 +251,7 @@ const seed = {
   classes: [
     {
       id: '00000000-0000-4000-8000-000000000301',
+      tenantId: HORIZON_TENANT_ID,
       schoolId: '00000000-0000-4000-8000-000000000101',
       name: 'Grade 5',
       gradeLevel: 5,
@@ -111,6 +259,7 @@ const seed = {
     },
     {
       id: '00000000-0000-4000-8000-000000000302',
+      tenantId: HORIZON_TENANT_ID,
       schoolId: '00000000-0000-4000-8000-000000000102',
       name: 'Grade 10 Mathematics',
       gradeLevel: 10,
@@ -118,6 +267,7 @@ const seed = {
     },
     {
       id: '00000000-0000-4000-8000-000000000303',
+      tenantId: ISLAND_TENANT_ID,
       schoolId: '00000000-0000-4000-8000-000000000103',
       name: 'Grade 7',
       gradeLevel: 7,
@@ -127,6 +277,7 @@ const seed = {
   students: [
     {
       id: '00000000-0000-4000-8000-000000000401',
+      tenantId: HORIZON_TENANT_ID,
       schoolId: '00000000-0000-4000-8000-000000000101',
       firstName: 'Mia',
       lastName: 'Morgan',
@@ -135,6 +286,7 @@ const seed = {
     },
     {
       id: '00000000-0000-4000-8000-000000000402',
+      tenantId: HORIZON_TENANT_ID,
       schoolId: '00000000-0000-4000-8000-000000000102',
       firstName: 'Noah',
       lastName: 'Brown',
@@ -143,6 +295,7 @@ const seed = {
     },
     {
       id: '00000000-0000-4000-8000-000000000403',
+      tenantId: ISLAND_TENANT_ID,
       schoolId: '00000000-0000-4000-8000-000000000103',
       firstName: 'Ava',
       lastName: 'Martinez',
@@ -153,18 +306,21 @@ const seed = {
   usersOnOrg: [
     {
       id: '00000000-0000-4000-8000-000000000501',
+      tenantId: HORIZON_TENANT_ID,
       userId: '00000000-0000-4000-8000-000000000201',
       orgId: '00000000-0000-4000-8000-000000000001',
       role: 'org_admin',
     },
     {
       id: '00000000-0000-4000-8000-000000000502',
+      tenantId: HORIZON_TENANT_ID,
       userId: '00000000-0000-4000-8000-000000000206',
       orgId: '00000000-0000-4000-8000-000000000001',
       role: 'org_viewer',
     },
     {
       id: '00000000-0000-4000-8000-000000000503',
+      tenantId: ISLAND_TENANT_ID,
       userId: '00000000-0000-4000-8000-000000000207',
       orgId: '00000000-0000-4000-8000-000000000002',
       role: 'org_admin',
@@ -173,18 +329,21 @@ const seed = {
   usersOnSchool: [
     {
       id: '00000000-0000-4000-8000-000000000511',
+      tenantId: HORIZON_TENANT_ID,
       userId: '00000000-0000-4000-8000-000000000202',
       schoolId: '00000000-0000-4000-8000-000000000101',
       role: 'school_admin',
     },
     {
       id: '00000000-0000-4000-8000-000000000512',
+      tenantId: HORIZON_TENANT_ID,
       userId: '00000000-0000-4000-8000-000000000203',
       schoolId: '00000000-0000-4000-8000-000000000102',
       role: 'teacher',
     },
     {
       id: '00000000-0000-4000-8000-000000000513',
+      tenantId: HORIZON_TENANT_ID,
       userId: '00000000-0000-4000-8000-000000000204',
       schoolId: '00000000-0000-4000-8000-000000000102',
       role: 'staff',
@@ -193,6 +352,7 @@ const seed = {
   teachersOnClass: [
     {
       id: '00000000-0000-4000-8000-000000000521',
+      tenantId: HORIZON_TENANT_ID,
       userId: '00000000-0000-4000-8000-000000000203',
       classId: '00000000-0000-4000-8000-000000000302',
       isPrimary: true,
@@ -201,6 +361,7 @@ const seed = {
   parentStudent: [
     {
       id: '00000000-0000-4000-8000-000000000531',
+      tenantId: HORIZON_TENANT_ID,
       parentId: '00000000-0000-4000-8000-000000000205',
       studentId: '00000000-0000-4000-8000-000000000402',
       relationship: 'father',
@@ -209,16 +370,19 @@ const seed = {
   enrollments: [
     {
       id: '00000000-0000-4000-8000-000000000601',
+      tenantId: HORIZON_TENANT_ID,
       studentId: '00000000-0000-4000-8000-000000000401',
       classId: '00000000-0000-4000-8000-000000000301',
     },
     {
       id: '00000000-0000-4000-8000-000000000602',
+      tenantId: HORIZON_TENANT_ID,
       studentId: '00000000-0000-4000-8000-000000000402',
       classId: '00000000-0000-4000-8000-000000000302',
     },
     {
       id: '00000000-0000-4000-8000-000000000603',
+      tenantId: ISLAND_TENANT_ID,
       studentId: '00000000-0000-4000-8000-000000000403',
       classId: '00000000-0000-4000-8000-000000000303',
     },
@@ -226,6 +390,7 @@ const seed = {
   grades: [
     {
       id: '00000000-0000-4000-8000-000000000701',
+      tenantId: HORIZON_TENANT_ID,
       enrollmentId: '00000000-0000-4000-8000-000000000602',
       assignmentName: 'Algebra readiness check',
       score: '86.00',
@@ -248,21 +413,57 @@ function assertCount(label: string, actual: number, expected: number): void {
 }
 
 const sql = postgres(getServerEnv().DATABASE_URL, { prepare: false, max: 1 })
-const db = drizzle(sql)
+const db = drizzle(sql, { schema })
 
 try {
   await db.transaction(async (tx) => {
+    for (const row of seed.tenants) {
+      await tx
+        .insert(tenants)
+        .values(row)
+        .onConflictDoUpdate({ target: tenants.id, set: valuesWithoutId(row) })
+    }
+    for (const row of seed.tenantPlacements) {
+      await tx
+        .insert(tenantPlacements)
+        .values(row)
+        .onConflictDoUpdate({
+          target: tenantPlacements.tenantId,
+          set: valuesWithoutId(row),
+        })
+    }
     for (const row of seed.organizations) {
       await tx
         .insert(organizations)
         .values(row)
         .onConflictDoUpdate({ target: organizations.id, set: valuesWithoutId(row) })
     }
+    for (const row of seed.educationOrganizations) {
+      await tx
+        .insert(educationOrganizations)
+        .values(row)
+        .onConflictDoUpdate({
+          target: educationOrganizations.id,
+          set: valuesWithoutId(row),
+        })
+    }
+    for (const treeVersion of seed.treeVersions) {
+      await insertOrganizationTreeVersion(tx, treeVersion)
+    }
     for (const row of seed.schools) {
       await tx
         .insert(schools)
         .values(row)
         .onConflictDoUpdate({ target: schools.id, set: valuesWithoutId(row) })
+    }
+    for (const row of seed.schoolGovernanceAssignments) {
+      await tx
+        .insert(schoolGovernanceAssignments)
+        .values(row)
+        .onConflictDoUpdate({
+          target: schoolGovernanceAssignments.id,
+          set: valuesWithoutId(row),
+        })
     }
     for (const row of seed.users) {
       await tx
@@ -320,6 +521,15 @@ try {
     }
   })
 
+  const seededTenants = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(
+      inArray(
+        tenants.id,
+        seed.tenants.map(({ id }) => id)
+      )
+    )
   const seededOrganizations = await db
     .select({ id: organizations.id })
     .from(organizations)
@@ -375,15 +585,57 @@ try {
       )
     )
 
+  const seededEducationOrganizations = await db
+    .select({ id: educationOrganizations.id })
+    .from(educationOrganizations)
+    .where(
+      inArray(
+        educationOrganizations.id,
+        seed.educationOrganizations.map(({ id }) => id)
+      )
+    )
+  const seededTreeVersions = await db
+    .select({ id: organizationTreeVersions.id })
+    .from(organizationTreeVersions)
+    .where(
+      inArray(
+        organizationTreeVersions.id,
+        seed.treeVersions.map(({ id }) => id)
+      )
+    )
+  const seededGovernanceAssignments = await db
+    .select({ id: schoolGovernanceAssignments.id })
+    .from(schoolGovernanceAssignments)
+    .where(
+      inArray(
+        schoolGovernanceAssignments.id,
+        seed.schoolGovernanceAssignments.map(({ id }) => id)
+      )
+    )
+
+  assertCount('tenants', seededTenants.length, seed.tenants.length)
   assertCount('organizations', seededOrganizations.length, seed.organizations.length)
+  assertCount(
+    'education organizations',
+    seededEducationOrganizations.length,
+    seed.educationOrganizations.length
+  )
+  assertCount('tree versions', seededTreeVersions.length, seed.treeVersions.length)
   assertCount('schools', seededSchools.length, seed.schools.length)
+  assertCount(
+    'School governance assignments',
+    seededGovernanceAssignments.length,
+    seed.schoolGovernanceAssignments.length
+  )
   assertCount('users', seededUsers.length, seed.users.length)
   assertCount('students', seededStudents.length, seed.students.length)
   assertCount('organization roles', seededOrgRoles.length, seed.usersOnOrg.length)
   assertCount('school roles', seededSchoolRoles.length, seed.usersOnSchool.length)
 
   console.log(
-    `Seed verified: ${seededOrganizations.length} organizations, ${seededSchools.length} schools, ` +
+    `Seed verified: ${seededTenants.length} tenants, ` +
+      `${seededEducationOrganizations.length} education organizations, ` +
+      `${seededSchools.length} schools, ` +
       `${seededUsers.length} users, ${seededStudents.length} students, ` +
       `${seededOrgRoles.length + seededSchoolRoles.length} role assignments.`
   )

--- a/packages/db/src/tenant-foundation-poc.ts
+++ b/packages/db/src/tenant-foundation-poc.ts
@@ -31,8 +31,6 @@ interface PostgresErrorLike {
   code?: string
 }
 
-class ExpectedProofRollback extends Error {}
-
 function isPostgresErrorWithCode(error: unknown, code: string): boolean {
   return typeof error === 'object' && error !== null && (error as PostgresErrorLike).code === code
 }
@@ -125,6 +123,16 @@ async function run(): Promise<void> {
             ${TENANT_A}, ${TENANT_A_PRIMARY}, ${TENANT_A_BOARD}, '2026-06-01T00:00:00Z'
           )
         `
+      })
+    )
+    await expectSqlState('sealed tree insert', '55000', () =>
+      db.transaction(async (tx) => {
+        await tx.insert(organizationTreeNodes).values({
+          tenantId: TENANT_A,
+          treeVersionId: TENANT_A_ROOT,
+          organizationId: TENANT_A_ROOT,
+          parentOrganizationId: null,
+        })
       })
     )
 
@@ -227,25 +235,6 @@ async function run(): Promise<void> {
         assert.deepEqual(historicalGovernance, [{ educationOrganizationId: TENANT_A_DISTRICT }])
         assert.deepEqual(currentGovernance, [{ educationOrganizationId: TENANT_A_NETWORK }])
 
-        await expectSqlState('sealed tree update', '55000', () =>
-          tx.transaction(async (savepoint) => {
-            await savepoint
-              .update(organizationTreeVersions)
-              .set({ reason: 'forbidden mutation' })
-              .where(eq(organizationTreeVersions.id, TREE_V2))
-          })
-        )
-        await expectSqlState('sealed tree insert', '55000', () =>
-          tx.transaction(async (savepoint) => {
-            await savepoint.insert(organizationTreeNodes).values({
-              tenantId: TENANT_A,
-              treeVersionId: TREE_V2,
-              organizationId: TENANT_A_ROOT,
-              parentOrganizationId: null,
-            })
-          })
-        )
-
         await tx.execute(drizzleSql`set local enable_seqscan = off`)
         const closurePlan = await tx.execute(drizzleSql`
           explain (format json)
@@ -264,9 +253,12 @@ async function run(): Promise<void> {
         assert.match(JSON.stringify(closurePlan), /organization_tree_closure_descendants_idx/)
         assert.match(JSON.stringify(schoolPlan), /schools_tenant_organization_idx/)
 
-        throw new ExpectedProofRollback('rollback proof-only hierarchy changes')
+        await tx
+          .update(organizationTreeVersions)
+          .set({ reason: 'forbidden mutation rolls back proof-only hierarchy changes' })
+          .where(eq(organizationTreeVersions.id, TREE_V2))
       }),
-      (error: unknown) => error instanceof ExpectedProofRollback
+      (error: unknown) => isPostgresErrorWithCode(error, '55000')
     )
 
     await expectSqlState('Organization Tree cycle', '23514', () =>

--- a/packages/db/src/tenant-foundation-poc.ts
+++ b/packages/db/src/tenant-foundation-poc.ts
@@ -29,10 +29,24 @@ const TREE_INVALID = '00000000-0000-4000-8000-000000000802'
 
 interface PostgresErrorLike {
   code?: string
+  cause?: unknown
 }
 
 function isPostgresErrorWithCode(error: unknown, code: string): boolean {
-  return typeof error === 'object' && error !== null && (error as PostgresErrorLike).code === code
+  let current = error
+
+  for (let depth = 0; depth < 5; depth += 1) {
+    if (typeof current !== 'object' || current === null) {
+      return false
+    }
+    const postgresError = current as PostgresErrorLike
+    if (postgresError.code === code) {
+      return true
+    }
+    current = postgresError.cause
+  }
+
+  return false
 }
 
 function assertLocalDisposableDatabase(databaseUrl: URL): void {

--- a/packages/db/src/tenant-foundation-poc.ts
+++ b/packages/db/src/tenant-foundation-poc.ts
@@ -1,0 +1,339 @@
+import assert from 'node:assert/strict'
+import { getServerEnv } from '@openschool/config/server'
+import { and, desc, sql as drizzleSql, eq, lte } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import * as schema from './schema'
+import {
+  organizationTreeClosure,
+  organizationTreeNodes,
+  organizationTreeVersions,
+  schoolGovernanceAssignments,
+  schools,
+} from './schema'
+import { insertOrganizationTreeVersion } from './tenant-hierarchy'
+
+const TENANT_A = '00000000-0000-4000-8000-000000000001'
+const TENANT_B = '00000000-0000-4000-8000-000000000002'
+const TENANT_A_ROOT = TENANT_A
+const TENANT_A_BOARD = '00000000-0000-4000-8000-000000000011'
+const TENANT_A_NETWORK = '00000000-0000-4000-8000-000000000012'
+const TENANT_A_DISTRICT = '00000000-0000-4000-8000-000000000013'
+const TENANT_A_PRIMARY = '00000000-0000-4000-8000-000000000101'
+const TENANT_A_HIGH = '00000000-0000-4000-8000-000000000102'
+const TENANT_B_SCHOOL = '00000000-0000-4000-8000-000000000103'
+const TENANT_A_STUDENT = '00000000-0000-4000-8000-000000000401'
+const TENANT_A_GOVERNANCE = '00000000-0000-4000-8000-000000000041'
+const TREE_V2 = '00000000-0000-4000-8000-000000000801'
+const TREE_INVALID = '00000000-0000-4000-8000-000000000802'
+
+interface PostgresErrorLike {
+  code?: string
+}
+
+class ExpectedProofRollback extends Error {}
+
+function isPostgresErrorWithCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && (error as PostgresErrorLike).code === code
+}
+
+function assertLocalDisposableDatabase(databaseUrl: URL): void {
+  const loopbackHosts = new Set(['127.0.0.1', 'localhost', '[::1]'])
+
+  if (process.env.ALLOW_TENANT_FOUNDATION_POC !== 'true') {
+    throw new Error(
+      'Tenant foundation proof refused: ALLOW_TENANT_FOUNDATION_POC must be exactly "true".'
+    )
+  }
+  if (!loopbackHosts.has(databaseUrl.hostname)) {
+    throw new Error(
+      `Tenant foundation proof refused: DATABASE_URL host must be loopback, received ${databaseUrl.hostname}.`
+    )
+  }
+}
+
+async function expectSqlState(
+  label: string,
+  code: string,
+  operation: () => Promise<unknown>
+): Promise<void> {
+  await assert.rejects(operation, (error: unknown) => {
+    assert.equal(
+      isPostgresErrorWithCode(error, code),
+      true,
+      `${label} should fail with SQLSTATE ${code}`
+    )
+    return true
+  })
+}
+
+async function run(): Promise<void> {
+  const databaseUrl = new URL(getServerEnv().DATABASE_URL)
+  assertLocalDisposableDatabase(databaseUrl)
+
+  // Intentional raw-PostgreSQL exception: SQLSTATE, EXPLAIN output, trigger
+  // behavior, and deferred constraints are the interface under test.
+  const client = postgres(databaseUrl.toString(), { max: 1, prepare: false })
+  const db = drizzle(client, { schema })
+
+  try {
+    const seededProfiles = await db
+      .select({ id: schools.id, profile: schools.profile, tenantId: schools.tenantId })
+      .from(schools)
+      .where(eq(schools.tenantId, TENANT_A))
+
+    assert.deepEqual(
+      seededProfiles.sort((left, right) => left.id.localeCompare(right.id)),
+      [
+        { id: TENANT_A_PRIMARY, profile: 'primary', tenantId: TENANT_A },
+        { id: TENANT_A_HIGH, profile: 'secondary', tenantId: TENANT_A },
+      ]
+    )
+
+    await expectSqlState('cross-Tenant class reference', '23503', () =>
+      client.begin(async (transaction) => {
+        await transaction`
+          insert into classes (tenant_id, school_id, name, academic_year)
+          values (${TENANT_B}, ${TENANT_A_PRIMARY}, 'forbidden', '2026-2027')
+        `
+      })
+    )
+    await expectSqlState('cross-Tenant School governance', '23503', () =>
+      client.begin(async (transaction) => {
+        await transaction`
+          insert into school_governance_assignments (
+            tenant_id, school_id, education_organization_id, valid_from
+          ) values (
+            ${TENANT_A}, ${TENANT_B_SCHOOL}, ${TENANT_A_ROOT}, '2027-01-01T00:00:00Z'
+          )
+        `
+      })
+    )
+    await expectSqlState('immutable tenant key', '23514', () =>
+      client.begin(async (transaction) => {
+        await transaction`
+          update students set tenant_id = ${TENANT_B} where id = ${TENANT_A_STUDENT}
+        `
+      })
+    )
+    await expectSqlState('overlapping School governance', '23P01', () =>
+      client.begin(async (transaction) => {
+        await transaction`
+          insert into school_governance_assignments (
+            tenant_id, school_id, education_organization_id, valid_from
+          ) values (
+            ${TENANT_A}, ${TENANT_A_PRIMARY}, ${TENANT_A_BOARD}, '2026-06-01T00:00:00Z'
+          )
+        `
+      })
+    )
+
+    await assert.rejects(
+      db.transaction(async (tx) => {
+        await insertOrganizationTreeVersion(tx, {
+          id: TREE_V2,
+          tenantId: TENANT_A,
+          version: 2,
+          effectiveFrom: new Date('2026-08-01T00:00:00Z'),
+          reason: 'Proof move: transfer district from board to network',
+          nodes: [
+            { organizationId: TENANT_A_ROOT, parentOrganizationId: null },
+            { organizationId: TENANT_A_BOARD, parentOrganizationId: TENANT_A_ROOT },
+            { organizationId: TENANT_A_NETWORK, parentOrganizationId: TENANT_A_ROOT },
+            { organizationId: TENANT_A_DISTRICT, parentOrganizationId: TENANT_A_NETWORK },
+          ],
+        })
+
+        const networkDescendants = await tx
+          .select({ id: organizationTreeClosure.descendantOrganizationId })
+          .from(organizationTreeClosure)
+          .where(
+            and(
+              eq(organizationTreeClosure.tenantId, TENANT_A),
+              eq(organizationTreeClosure.treeVersionId, TREE_V2),
+              eq(organizationTreeClosure.ancestorOrganizationId, TENANT_A_NETWORK),
+              eq(organizationTreeClosure.depth, 1)
+            )
+          )
+        assert.deepEqual(networkDescendants, [{ id: TENANT_A_DISTRICT }])
+
+        const siblings = await tx
+          .select({ id: organizationTreeNodes.organizationId })
+          .from(organizationTreeNodes)
+          .where(
+            and(
+              eq(organizationTreeNodes.tenantId, TENANT_A),
+              eq(organizationTreeNodes.treeVersionId, TREE_V2),
+              eq(organizationTreeNodes.parentOrganizationId, TENANT_A_ROOT)
+            )
+          )
+        assert.deepEqual(
+          siblings.map(({ id }) => id).sort(),
+          [TENANT_A_BOARD, TENANT_A_NETWORK].sort()
+        )
+
+        const historicalVersion = await tx
+          .select({ id: organizationTreeVersions.id })
+          .from(organizationTreeVersions)
+          .where(
+            and(
+              eq(organizationTreeVersions.tenantId, TENANT_A),
+              lte(organizationTreeVersions.effectiveFrom, new Date('2026-07-31T23:59:59Z'))
+            )
+          )
+          .orderBy(desc(organizationTreeVersions.effectiveFrom))
+          .limit(1)
+        const currentVersion = await tx
+          .select({ id: organizationTreeVersions.id })
+          .from(organizationTreeVersions)
+          .where(
+            and(
+              eq(organizationTreeVersions.tenantId, TENANT_A),
+              lte(organizationTreeVersions.effectiveFrom, new Date('2026-08-01T00:00:00Z'))
+            )
+          )
+          .orderBy(desc(organizationTreeVersions.effectiveFrom))
+          .limit(1)
+        assert.deepEqual(historicalVersion, [{ id: TENANT_A_ROOT }])
+        assert.deepEqual(currentVersion, [{ id: TREE_V2 }])
+
+        await tx
+          .update(schoolGovernanceAssignments)
+          .set({ validUntil: new Date('2026-08-01T00:00:00Z') })
+          .where(eq(schoolGovernanceAssignments.id, TENANT_A_GOVERNANCE))
+        await tx.insert(schoolGovernanceAssignments).values({
+          id: '00000000-0000-4000-8000-000000000804',
+          tenantId: TENANT_A,
+          schoolId: TENANT_A_PRIMARY,
+          educationOrganizationId: TENANT_A_NETWORK,
+          validFrom: new Date('2026-08-01T00:00:00Z'),
+        })
+        const historicalGovernance = await tx.execute(drizzleSql`
+          select education_organization_id as "educationOrganizationId"
+          from school_governance_assignments
+          where tenant_id = ${TENANT_A}
+            and school_id = ${TENANT_A_PRIMARY}
+            and valid_from <= '2026-07-31T23:59:59Z'::timestamptz
+            and (valid_until is null or valid_until > '2026-07-31T23:59:59Z'::timestamptz)
+        `)
+        const currentGovernance = await tx.execute(drizzleSql`
+          select education_organization_id as "educationOrganizationId"
+          from school_governance_assignments
+          where tenant_id = ${TENANT_A}
+            and school_id = ${TENANT_A_PRIMARY}
+            and valid_from <= '2026-08-01T00:00:00Z'::timestamptz
+            and (valid_until is null or valid_until > '2026-08-01T00:00:00Z'::timestamptz)
+        `)
+        assert.deepEqual(historicalGovernance, [{ educationOrganizationId: TENANT_A_DISTRICT }])
+        assert.deepEqual(currentGovernance, [{ educationOrganizationId: TENANT_A_NETWORK }])
+
+        await expectSqlState('sealed tree update', '55000', () =>
+          tx.transaction(async (savepoint) => {
+            await savepoint
+              .update(organizationTreeVersions)
+              .set({ reason: 'forbidden mutation' })
+              .where(eq(organizationTreeVersions.id, TREE_V2))
+          })
+        )
+        await expectSqlState('sealed tree insert', '55000', () =>
+          tx.transaction(async (savepoint) => {
+            await savepoint.insert(organizationTreeNodes).values({
+              tenantId: TENANT_A,
+              treeVersionId: TREE_V2,
+              organizationId: TENANT_A_ROOT,
+              parentOrganizationId: null,
+            })
+          })
+        )
+
+        await tx.execute(drizzleSql`set local enable_seqscan = off`)
+        const closurePlan = await tx.execute(drizzleSql`
+          explain (format json)
+          select descendant_organization_id
+          from organization_tree_closure
+          where tenant_id = ${TENANT_A}
+            and tree_version_id = ${TREE_V2}
+            and ancestor_organization_id = ${TENANT_A_NETWORK}
+          order by depth, descendant_organization_id
+        `)
+        const schoolPlan = await tx.execute(drizzleSql`
+          explain (format json)
+          select id from schools
+          where tenant_id = ${TENANT_A} and org_id = ${TENANT_A_ROOT}
+        `)
+        assert.match(JSON.stringify(closurePlan), /organization_tree_closure_descendants_idx/)
+        assert.match(JSON.stringify(schoolPlan), /schools_tenant_organization_idx/)
+
+        throw new ExpectedProofRollback('rollback proof-only hierarchy changes')
+      }),
+      (error: unknown) => error instanceof ExpectedProofRollback
+    )
+
+    await expectSqlState('Organization Tree cycle', '23514', () =>
+      db.transaction(async (tx) => {
+        await tx.insert(organizationTreeNodes).values({
+          tenantId: TENANT_A,
+          treeVersionId: TREE_INVALID,
+          organizationId: TENANT_A_BOARD,
+          parentOrganizationId: TENANT_A_NETWORK,
+        })
+        await tx.insert(organizationTreeNodes).values({
+          tenantId: TENANT_A,
+          treeVersionId: TREE_INVALID,
+          organizationId: TENANT_A_NETWORK,
+          parentOrganizationId: TENANT_A_BOARD,
+        })
+      })
+    )
+
+    await expectSqlState('incomplete Organization Tree closure', '23514', () =>
+      db.transaction(async (tx) => {
+        await tx.insert(organizationTreeNodes).values([
+          {
+            tenantId: TENANT_A,
+            treeVersionId: TREE_INVALID,
+            organizationId: TENANT_A_ROOT,
+            parentOrganizationId: null,
+          },
+          {
+            tenantId: TENANT_A,
+            treeVersionId: TREE_INVALID,
+            organizationId: TENANT_A_BOARD,
+            parentOrganizationId: TENANT_A_ROOT,
+          },
+        ])
+        await tx.insert(organizationTreeClosure).values([
+          {
+            tenantId: TENANT_A,
+            treeVersionId: TREE_INVALID,
+            ancestorOrganizationId: TENANT_A_ROOT,
+            descendantOrganizationId: TENANT_A_ROOT,
+            depth: 0,
+          },
+          {
+            tenantId: TENANT_A,
+            treeVersionId: TREE_INVALID,
+            ancestorOrganizationId: TENANT_A_BOARD,
+            descendantOrganizationId: TENANT_A_BOARD,
+            depth: 0,
+          },
+        ])
+        await tx.insert(organizationTreeVersions).values({
+          id: TREE_INVALID,
+          tenantId: TENANT_A,
+          version: 99,
+          effectiveFrom: new Date('2099-01-01T00:00:00Z'),
+          reason: 'must fail',
+        })
+      })
+    )
+
+    console.log(
+      'Tenant foundation proof passed: composite isolation, immutable tenant keys, cycle-safe versioned hierarchy, historical governance, School profiles, and index plans.'
+    )
+  } finally {
+    await client.end()
+  }
+}
+
+await run()

--- a/packages/db/src/tenant-hierarchy.ts
+++ b/packages/db/src/tenant-hierarchy.ts
@@ -1,0 +1,70 @@
+import { and, eq } from 'drizzle-orm'
+import type { createClient } from './client'
+import { type OrganizationTreeNodeInput, buildOrganizationClosure } from './organization-tree'
+import { organizationTreeClosure, organizationTreeNodes, organizationTreeVersions } from './schema'
+
+type Database = ReturnType<typeof createClient>
+type DatabaseTransaction = Parameters<Parameters<Database['transaction']>[0]>[0]
+
+export interface OrganizationTreeVersionInput {
+  id: string
+  tenantId: string
+  version: number
+  effectiveFrom: Date
+  reason: string
+  nodes: readonly OrganizationTreeNodeInput[]
+}
+
+/**
+ * Persists and seals one immutable Organization Tree version.
+ *
+ * The database guards require nodes and closure edges to be written before the
+ * version row. Deferred foreign keys make the whole version visible atomically
+ * at commit; once the version exists, later inserts, updates, and deletes fail.
+ */
+export async function insertOrganizationTreeVersion(
+  tx: DatabaseTransaction,
+  input: OrganizationTreeVersionInput
+): Promise<'created' | 'already_exists'> {
+  const existingVersion = await tx
+    .select({ id: organizationTreeVersions.id })
+    .from(organizationTreeVersions)
+    .where(
+      and(
+        eq(organizationTreeVersions.tenantId, input.tenantId),
+        eq(organizationTreeVersions.id, input.id)
+      )
+    )
+    .limit(1)
+
+  if (existingVersion.length > 0) {
+    return 'already_exists'
+  }
+
+  const closure = buildOrganizationClosure(input.nodes)
+
+  await tx.insert(organizationTreeNodes).values(
+    input.nodes.map((node) => ({
+      tenantId: input.tenantId,
+      treeVersionId: input.id,
+      organizationId: node.organizationId,
+      parentOrganizationId: node.parentOrganizationId,
+    }))
+  )
+  await tx.insert(organizationTreeClosure).values(
+    closure.map((edge) => ({
+      tenantId: input.tenantId,
+      treeVersionId: input.id,
+      ...edge,
+    }))
+  )
+  await tx.insert(organizationTreeVersions).values({
+    id: input.id,
+    tenantId: input.tenantId,
+    version: input.version,
+    effectiveFrom: input.effectiveFrom,
+    reason: input.reason,
+  })
+
+  return 'created'
+}

--- a/packages/db/src/verify-upgrade-fixture.ts
+++ b/packages/db/src/verify-upgrade-fixture.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { getServerEnv } from '@openschool/config/server'
+import postgres from 'postgres'
+
+interface PostgresErrorLike {
+  code?: string
+}
+
+function isPostgresErrorWithCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && (error as PostgresErrorLike).code === code
+}
+
+function assertLocalDisposableDatabase(databaseUrl: URL): void {
+  const loopbackHosts = new Set(['127.0.0.1', 'localhost', '[::1]'])
+  if (process.env.ALLOW_TENANT_FOUNDATION_POC !== 'true') {
+    throw new Error('Upgrade verification refused: explicit proof flag is required.')
+  }
+  if (!loopbackHosts.has(databaseUrl.hostname)) {
+    throw new Error('Upgrade verification refused: database host must be loopback.')
+  }
+}
+
+async function run(): Promise<void> {
+  const databaseUrl = new URL(getServerEnv().DATABASE_URL)
+  assertLocalDisposableDatabase(databaseUrl)
+  const client = postgres(databaseUrl.toString(), { max: 1, prepare: false })
+
+  try {
+    const [counts] = await client<
+      Array<{
+        tenants: number
+        organizations: number
+        roots: number
+        schools: number
+        assignments: number
+        missingTenantRows: number
+      }>
+    >`
+      select
+        (select count(*)::int from tenants) as tenants,
+        (select count(*)::int from organizations) as organizations,
+        (
+          select count(*)::int
+          from education_organizations
+          where legacy_organization_id is not null
+        ) as roots,
+        (select count(*)::int from schools) as schools,
+        (select count(*)::int from school_governance_assignments) as assignments,
+        (
+          select sum(row_count)::int
+          from (
+            select count(*) filter (where tenant_id is null) as row_count from organizations
+            union all select count(*) filter (where tenant_id is null) from schools
+            union all select count(*) filter (where tenant_id is null) from classes
+            union all select count(*) filter (where tenant_id is null) from students
+            union all select count(*) filter (where tenant_id is null) from users_on_org
+            union all select count(*) filter (where tenant_id is null) from users_on_school
+            union all select count(*) filter (where tenant_id is null) from teachers_on_class
+            union all select count(*) filter (where tenant_id is null) from parent_student
+            union all select count(*) filter (where tenant_id is null) from enrollments
+            union all select count(*) filter (where tenant_id is null) from grades
+          ) tenant_nulls
+        ) as "missingTenantRows"
+    `
+    assert.deepEqual(counts, {
+      assignments: 3,
+      missingTenantRows: 0,
+      organizations: 2,
+      roots: 2,
+      schools: 3,
+      tenants: 2,
+    })
+
+    await assert.rejects(
+      client.begin(async (transaction) => {
+        await transaction`
+          insert into classes (tenant_id, school_id, name, academic_year)
+          values (
+            '20000000-0000-4000-8000-000000000001',
+            '10000000-0000-4000-8000-000000000101',
+            'forbidden',
+            '2026-2027'
+          )
+        `
+      }),
+      (error: unknown) => isPostgresErrorWithCode(error, '23503')
+    )
+
+    console.log(
+      'Upgrade verification passed: legacy rows retained, Tenant roots and School governance imported, tenant keys complete, and cross-Tenant references rejected.'
+    )
+  } finally {
+    await client.end()
+  }
+}
+
+await run()

--- a/turbo.json
+++ b/turbo.json
@@ -39,6 +39,18 @@
       "cache": false,
       "env": ["ALLOW_SECURITY_POC", "DATABASE_URL"]
     },
+    "db:tenant-foundation-poc": {
+      "cache": false,
+      "env": ["ALLOW_TENANT_FOUNDATION_POC", "DATABASE_URL"]
+    },
+    "db:prepare-upgrade-fixture": {
+      "cache": false,
+      "env": ["ALLOW_TENANT_FOUNDATION_POC", "DATABASE_URL"]
+    },
+    "db:verify-upgrade-fixture": {
+      "cache": false,
+      "env": ["ALLOW_TENANT_FOUNDATION_POC", "DATABASE_URL"]
+    },
     "db:seed": {
       "cache": false
     },


### PR DESCRIPTION
## Summary

- add Tenant and pooled placement as the hard isolation/deployment boundary
- add typed, effective-dated Education Organization trees alongside the legacy flat organization model
- add non-overlapping School governance and one shared primary/secondary/all-through School model
- stage nullable isolation keys, verified legacy backfill, non-null cutover, composite foreign keys, Tenant-leading indexes, and immutable-key guards
- seal Organization Tree versions only after PostgreSQL verifies one root, in-version parents, cycle safety, and exact closure
- expand the representative seed to two Tenants, ministry/board/network/district branches, and primary/high/second-Tenant Schools
- prove clean migration/seed idempotence and migration-0002 upgrade behavior in separate PostgreSQL CI jobs

## Security boundaries

- no production RLS policy is enabled in this pull request
- no Account/Person or affiliation cutover is included
- `users` remains a global legacy account record pending #83
- audit Tenant scoping and atomicity remain assigned to #88
- legacy `organizations` remains available for dual-read rollback

## Migration / rollback

- `0003`: additive tables and nullable keys
- `0004`: lock, one-Tenant-per-legacy-organization backfill, consistency verification, root/governance import
- `0005`: non-null and Tenant-safe composite constraints/indexes
- `0006`: shared School profile
- `0007`: immutable keys, sealed versions, closure/cycle guards, governance overlap
- `0008`: database-enforced value constraints

Stop before `0005` if backfill verification fails. After cutover, restore the pre-migration backup or ship a forward repair; do not drop isolation keys.

## Verification

Local:

- `bun run check`
- `bun run lint`
- `bun run typecheck`
- `bun test` (26 passing)
- `bun run db:check`
- `bun run build` with the validated CI environment contract

GitHub Actions additionally runs:

- clean PostgreSQL migrate/seed/migrate/seed
- cross-Tenant FK, immutable-key, overlap, cycle, closure, history, profile, and EXPLAIN proof
- representative migration-0002 fixture upgrade, second migration pass, row/parity verification, and cross-Tenant rejection

Closes #82


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-aware education organization hierarchies, school governance periods, pooled placements, and school profiles.
  * Student creation now derives tenant context from the selected school and reports missing schools clearly.
  * Added tenant-scoped uniqueness and relationship protection across education data.
* **Bug Fixes**
  * Prevented cross-tenant references, overlapping governance periods, invalid organization trees, and unauthorized hierarchy changes.
* **Documentation**
  * Updated setup, capability, security, and migration documentation.
* **Tests**
  * Added automated validation for hierarchy behavior, tenant isolation, and database upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->