### PR TITLE
build: patch transitive nanoid vulnerability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -121,6 +121,7 @@
     "unrs-resolver",
   ],
   "overrides": {
+    "nanoid": "3.3.17",
     "postcss": "^8.5.25",
     "sharp": "^0.35.0",
   },
@@ -923,7 +924,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@trpc/server": "^11.0.0"
   },
   "overrides": {
+    "nanoid": "3.3.17",
     "postcss": "^8.5.25",
     "sharp": "^0.35.0"
   },


### PR DESCRIPTION
## Summary

- force transitive `nanoid` 3.x resolution from 3.3.16 to patched 3.3.17
- keep the resolution inside PostCSS's declared compatible range
- avoid adding a direct runtime dependency or broad framework upgrade

## Security context

Addresses GHSA-2v37-7h3g-55p8 / CVE-2026-67213, published July 29, 2026 and reviewed August 7, 2026. Versions below 3.3.17 can enter an infinite loop in custom generators when size is zero.

## Verification

- `bun install --frozen-lockfile`
- `bun pm why nanoid` resolves only 3.3.17
- `bun run audit:security`
- `bun run check`
- `bun run typecheck`
- `bun test` (161 passing)