### PR TITLE
feat: execute reviewed Person merges atomically

### DIFF
--- a/apps/web/src/server/person-merge-poc.ts
+++ b/apps/web/src/server/person-merge-poc.ts
@@ -45,8 +45,10 @@ const ORG_ADMIN_ACCOUNT = '00000000-0000-4000-8000-000000000201'
 const ORG_ADMIN_PERSON = '00000000-0000-4000-8000-000000000901'
 const RUN_ID = crypto.randomUUID()
 const NOW = new Date()
+const LINKED_ACCOUNT_ID = crypto.randomUUID()
 const SCHOOL_SESSION_ID = `person-merge-school-${RUN_ID}`
 const ORG_SESSION_ID = `person-merge-org-${RUN_ID}`
+const LINKED_SESSION_ID = `person-merge-linked-${RUN_ID}`
 
 function assertDisposable(): void {
   if (process.env.ALLOW_PERSON_MERGE_POC !== 'true') {
@@ -169,6 +171,13 @@ async function runProof(): Promise<void> {
   const [firstPersonId, secondPersonId] = [sourcePersonId, targetPersonId].sort()
   const duplicateCaseId = crypto.randomUUID()
   try {
+    await admin.insert(accounts).values({
+      id: LINKED_ACCOUNT_ID,
+      identityProvider: 'supabase',
+      providerSubject: `person-merge-proof-${RUN_ID}`,
+      primaryEmail: `person-merge-proof-${RUN_ID}@example.test`,
+      status: 'active',
+    })
     await admin.insert(accountSessions).values([
       {
         accountId: SCHOOL_ADMIN_ACCOUNT,
@@ -190,6 +199,15 @@ async function runProof(): Promise<void> {
         reauthenticatedAt: NOW,
         expiresAt: new Date(NOW.getTime() + 60 * 60_000),
       },
+      {
+        accountId: LINKED_ACCOUNT_ID,
+        providerSessionId: LINKED_SESSION_ID,
+        status: 'active',
+        assuranceLevel: 'aal1',
+        securityVersion: 1,
+        authenticatedAt: NOW,
+        expiresAt: new Date(NOW.getTime() + 60 * 60_000),
+      },
     ])
     await admin.insert(people).values([
       {
@@ -209,7 +227,7 @@ async function runProof(): Promise<void> {
     ])
     await admin.insert(accountLinks).values({
       tenantId: TENANT_ID,
-      accountId: ORG_ADMIN_ACCOUNT,
+      accountId: LINKED_ACCOUNT_ID,
       personId: sourcePersonId,
       status: 'active',
       validFrom: NOW,
@@ -440,12 +458,6 @@ async function runProof(): Promise<void> {
       true
     )
 
-    const [movedLink] = await admin
-      .select()
-      .from(accountLinks)
-      .where(eq(accountLinks.accountId, ORG_ADMIN_ACCOUNT))
-      .orderBy(asc(accountLinks.createdAt))
-    assert.ok(movedLink)
     const proofLinks = await admin
       .select()
       .from(accountLinks)
@@ -454,12 +466,12 @@ async function runProof(): Promise<void> {
     const [revokedSession] = await admin
       .select()
       .from(accountSessions)
-      .where(eq(accountSessions.providerSessionId, ORG_SESSION_ID))
+      .where(eq(accountSessions.providerSessionId, LINKED_SESSION_ID))
     assert.equal(revokedSession?.status, 'revoked')
     const [invalidatedAccount] = await admin
       .select()
       .from(accounts)
-      .where(eq(accounts.id, ORG_ADMIN_ACCOUNT))
+      .where(eq(accounts.id, LINKED_ACCOUNT_ID))
     assert.equal(Number(invalidatedAccount?.membershipVersion), 2)
     assert.equal(Number(invalidatedAccount?.securityVersion), 2)
 
@@ -531,7 +543,13 @@ async function runProof(): Promise<void> {
     try {
       await admin
         .delete(accountSessions)
-        .where(inArray(accountSessions.providerSessionId, [SCHOOL_SESSION_ID, ORG_SESSION_ID]))
+        .where(
+          inArray(accountSessions.providerSessionId, [
+            SCHOOL_SESSION_ID,
+            ORG_SESSION_ID,
+            LINKED_SESSION_ID,
+          ])
+        )
     } finally {
       await admin.$client.end({ timeout: 5 })
     }

--- a/apps/web/src/server/person-merge-poc.ts
+++ b/apps/web/src/server/person-merge-poc.ts
@@ -230,7 +230,7 @@ async function runProof(): Promise<void> {
           schoolApprovalDecision,
           {
             operationId: preview.operationId,
-            expectedOperationVersion: 1,
+            expectedOperationVersion: 2,
             expectedPreviewDigest: preview.previewDigest,
             reason: 'The initiating administrator must not approve',
           }
@@ -251,7 +251,7 @@ async function runProof(): Promise<void> {
           orgApprovalDecision,
           {
             operationId: preview.operationId,
-            expectedOperationVersion: 1,
+            expectedOperationVersion: 2,
             expectedPreviewDigest: preview.previewDigest,
             reason: 'A changed Person must invalidate the reviewed preview',
           }
@@ -270,13 +270,13 @@ async function runProof(): Promise<void> {
       orgApprovalDecision,
       {
         operationId: preview.operationId,
-        expectedOperationVersion: 1,
+        expectedOperationVersion: 2,
         expectedPreviewDigest: preview.previewDigest,
         reason: 'Independently verified current evidence and dependency digest',
       }
     )
     assert.equal(approval.status, 'approved')
-    assert.equal(approval.version, 2)
+    assert.equal(approval.version, 3)
 
     const [operation] = await admin
       .select()
@@ -303,7 +303,7 @@ async function runProof(): Promise<void> {
       .orderBy(asc(personMergeEvents.version))
     assert.deepEqual(
       events.map(({ eventType }) => eventType),
-      ['preview_created', 'approval_granted']
+      ['preview_created', 'preview_created', 'approval_granted']
     )
     assert.ok(
       (

--- a/apps/web/src/server/person-merge-poc.ts
+++ b/apps/web/src/server/person-merge-poc.ts
@@ -3,12 +3,19 @@ import { createHash } from 'node:crypto'
 import { getServerEnv } from '@openschool/config/server'
 import {
   type TenantDatabaseContext,
+  accountLinks,
   accountSessions,
+  accounts,
+  auditEvents,
+  auditOutbox,
   closeDatabaseExecutionPoolsForProof,
   createMigrationClient,
   people,
+  personDuplicateCaseEvents,
   personDuplicateCases,
+  personMergeAliases,
   personMergeEvents,
+  personMergeMoves,
   personMergeOperations,
   personMergePreviewItems,
   withPolicyTenantTransaction,
@@ -21,9 +28,13 @@ import {
   evaluatePolicy,
 } from '@openschool/rbac'
 import { TRPCError } from '@trpc/server'
-import { asc, eq, inArray } from 'drizzle-orm'
+import { asc, eq, inArray, sql } from 'drizzle-orm'
 import { toDatabasePolicyContext } from '../services/database-context'
-import { approvePersonMergePreview, createPersonMergePreview } from '../services/person-merges'
+import {
+  approvePersonMergePreview,
+  createPersonMergePreview,
+  executePersonMerge,
+} from '../services/person-merges'
 
 const TENANT_ID = '00000000-0000-4000-8000-000000000001'
 const SCHOOL_ID = '00000000-0000-4000-8000-000000000101'
@@ -92,7 +103,10 @@ function databaseContext(
 
 function allow(
   context: PolicyContext,
-  capability: typeof CAPABILITIES.PEOPLE_MERGES_PREVIEW | typeof CAPABILITIES.PEOPLE_MERGES_APPROVE
+  capability:
+    | typeof CAPABILITIES.PEOPLE_MERGES_PREVIEW
+    | typeof CAPABILITIES.PEOPLE_MERGES_APPROVE
+    | typeof CAPABILITIES.PEOPLE_MERGES_EXECUTE
 ): AllowedPolicyDecision {
   const decision = evaluatePolicy({
     bundle: CURRENT_POLICY_BUNDLE,
@@ -148,6 +162,7 @@ async function runProof(): Promise<void> {
   const admin = createMigrationClient()
   const schoolPreviewDecision = allow(schoolContext, CAPABILITIES.PEOPLE_MERGES_PREVIEW)
   const schoolApprovalDecision = allow(schoolContext, CAPABILITIES.PEOPLE_MERGES_APPROVE)
+  const schoolExecutionDecision = allow(schoolContext, CAPABILITIES.PEOPLE_MERGES_EXECUTE)
   const orgApprovalDecision = allow(orgContext, CAPABILITIES.PEOPLE_MERGES_APPROVE)
   const sourcePersonId = crypto.randomUUID()
   const targetPersonId = crypto.randomUUID()
@@ -192,6 +207,16 @@ async function runProof(): Promise<void> {
         source: 'native' as const,
       },
     ])
+    await admin.insert(accountLinks).values({
+      tenantId: TENANT_ID,
+      accountId: ORG_ADMIN_ACCOUNT,
+      personId: sourcePersonId,
+      status: 'active',
+      validFrom: NOW,
+      issuedByAccountId: SCHOOL_ADMIN_ACCOUNT,
+      issuanceReason: 'Person merge execution proof',
+      activatedAt: NOW,
+    })
     await admin.insert(personDuplicateCases).values({
       id: duplicateCaseId,
       tenantId: TENANT_ID,
@@ -305,6 +330,185 @@ async function runProof(): Promise<void> {
       events.map(({ eventType }) => eventType),
       ['preview_created', 'preview_created', 'approval_granted']
     )
+
+    await admin.execute(sql`
+      create or replace function openschool_private.reject_person_merge_execution_proof()
+      returns trigger language plpgsql as $$
+      begin
+        raise exception 'PERSON_MERGE_INJECTED_FAILURE';
+      end
+      $$
+    `)
+    await admin.execute(sql`
+      create trigger person_merge_execution_failure_proof
+      before insert on person_merge_aliases
+      for each row execute function openschool_private.reject_person_merge_execution_proof()
+    `)
+    try {
+      await assert.rejects(
+        executePersonMerge(
+          databaseContext('school', 'fault-rollback'),
+          schoolContext,
+          schoolExecutionDecision,
+          {
+            operationId: preview.operationId,
+            expectedOperationVersion: approval.version,
+            expectedPreviewDigest: approval.previewDigest,
+            reason: 'Prove every merge mutation rolls back after an injected failure',
+          }
+        ),
+        (error: unknown) => sqlState(error) === 'P0001'
+      )
+    } finally {
+      await admin.execute(sql`
+        drop trigger if exists person_merge_execution_failure_proof on person_merge_aliases
+      `)
+      await admin.execute(sql`
+        drop function if exists openschool_private.reject_person_merge_execution_proof()
+      `)
+    }
+    const [rolledBackOperation] = await admin
+      .select()
+      .from(personMergeOperations)
+      .where(eq(personMergeOperations.id, preview.operationId))
+    assert.equal(rolledBackOperation?.status, 'approved')
+    assert.equal(
+      (
+        await admin
+          .select({ id: personMergeAliases.id })
+          .from(personMergeAliases)
+          .where(eq(personMergeAliases.operationId, preview.operationId))
+      ).length,
+      0
+    )
+    assert.equal(
+      (
+        await admin
+          .select({ id: personMergeMoves.id })
+          .from(personMergeMoves)
+          .where(eq(personMergeMoves.operationId, preview.operationId))
+      ).length,
+      0
+    )
+
+    const execution = await executePersonMerge(
+      databaseContext('school', 'execution'),
+      schoolContext,
+      schoolExecutionDecision,
+      {
+        operationId: preview.operationId,
+        expectedOperationVersion: approval.version,
+        expectedPreviewDigest: approval.previewDigest,
+        reason: 'Execute the independently approved canonical identity reconciliation',
+      }
+    )
+    assert.equal(execution.status, 'executed')
+    assert.equal(execution.version, 4)
+    assert.equal(execution.invalidationCount, 1)
+    assert.match(execution.executionDigest, /^[0-9a-f]{64}$/)
+
+    const [executedOperation] = await admin
+      .select()
+      .from(personMergeOperations)
+      .where(eq(personMergeOperations.id, preview.operationId))
+    assert.equal(executedOperation?.status, 'executed')
+    assert.equal(executedOperation?.executionDigest, execution.executionDigest)
+    assert.equal(executedOperation?.executedByAccountId, SCHOOL_ADMIN_ACCOUNT)
+    const [alias] = await admin
+      .select()
+      .from(personMergeAliases)
+      .where(eq(personMergeAliases.operationId, preview.operationId))
+    assert.equal(alias?.sourcePersonId, sourcePersonId)
+    assert.equal(alias?.targetPersonId, targetPersonId)
+    assert.equal(alias?.status, 'active')
+    const moves = await admin
+      .select()
+      .from(personMergeMoves)
+      .where(eq(personMergeMoves.operationId, preview.operationId))
+      .orderBy(asc(personMergeMoves.sequence))
+    assert.ok(moves.length >= preview.dependencyCount)
+    assert.equal(
+      moves.some(({ action }) => action === 'invalidate'),
+      true
+    )
+    assert.equal(
+      moves.some(({ action }) => action === 'repoint'),
+      true
+    )
+    assert.equal(
+      moves.some(({ action }) => action === 'archive_source'),
+      true
+    )
+
+    const [movedLink] = await admin
+      .select()
+      .from(accountLinks)
+      .where(eq(accountLinks.accountId, ORG_ADMIN_ACCOUNT))
+      .orderBy(asc(accountLinks.createdAt))
+    assert.ok(movedLink)
+    const proofLinks = await admin
+      .select()
+      .from(accountLinks)
+      .where(eq(accountLinks.issuanceReason, 'Person merge execution proof'))
+    assert.equal(proofLinks[0]?.personId, targetPersonId)
+    const [revokedSession] = await admin
+      .select()
+      .from(accountSessions)
+      .where(eq(accountSessions.providerSessionId, ORG_SESSION_ID))
+    assert.equal(revokedSession?.status, 'revoked')
+    const [invalidatedAccount] = await admin
+      .select()
+      .from(accounts)
+      .where(eq(accounts.id, ORG_ADMIN_ACCOUNT))
+    assert.equal(Number(invalidatedAccount?.membershipVersion), 2)
+    assert.equal(Number(invalidatedAccount?.securityVersion), 2)
+
+    const mergedPeople = await admin
+      .select({ id: people.id, status: people.status })
+      .from(people)
+      .where(inArray(people.id, [sourcePersonId, targetPersonId]))
+    assert.equal(mergedPeople.find(({ id }) => id === sourcePersonId)?.status, 'archived')
+    assert.equal(mergedPeople.find(({ id }) => id === targetPersonId)?.status, 'active')
+    const [closedCase] = await admin
+      .select()
+      .from(personDuplicateCases)
+      .where(eq(personDuplicateCases.id, duplicateCaseId))
+    assert.equal(closedCase?.status, 'superseded')
+    const caseEvents = await admin
+      .select({ eventType: personDuplicateCaseEvents.eventType })
+      .from(personDuplicateCaseEvents)
+      .where(eq(personDuplicateCaseEvents.caseId, duplicateCaseId))
+    assert.equal(
+      caseEvents.some(({ eventType }) => eventType === 'merge_executed'),
+      true
+    )
+    const committedAudit = await admin
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(eq(auditEvents.targetId, preview.operationId))
+    assert.ok(committedAudit.length >= 1)
+    const committedOutbox = await admin
+      .select({ id: auditOutbox.id })
+      .from(auditOutbox)
+      .where(eq(auditOutbox.deduplicationKey, `person_merge.execute:${preview.operationId}`))
+    assert.equal(committedOutbox.length, 1)
+
+    assert.equal(
+      await failureFingerprint(
+        executePersonMerge(
+          databaseContext('school', 'repeat-denial'),
+          schoolContext,
+          schoolExecutionDecision,
+          {
+            operationId: preview.operationId,
+            expectedOperationVersion: approval.version,
+            expectedPreviewDigest: approval.previewDigest,
+            reason: 'A completed merge must not execute twice',
+          }
+        )
+      ),
+      'CONFLICT:MERGE_APPROVAL_CHANGED'
+    )
     assert.ok(
       (
         await admin
@@ -320,7 +524,7 @@ async function runProof(): Promise<void> {
     assert.equal(survivingPeople.length, 2)
 
     console.info(
-      'Person merge proof passed: locked preview, Person-change invalidation, distinct approval, same-actor denial, direct-write denial, append-only evidence, and no Person mutation.'
+      'Person merge proof passed: locked plan, distinct approval, injected-fault rollback, atomic dependency repointing, Account/session invalidation, immutable alias and move evidence, duplicate-case closure, audit outbox, and repeat-execution denial.'
     )
   } finally {
     await closeDatabaseExecutionPoolsForProof()

--- a/apps/web/src/server/person-merge-poc.ts
+++ b/apps/web/src/server/person-merge-poc.ts
@@ -450,7 +450,7 @@ async function runProof(): Promise<void> {
       true
     )
     assert.equal(
-      moves.some(({ action }) => action === 'repoint'),
+      moves.some(({ action }) => action === 'end_and_recreate'),
       true
     )
     assert.equal(
@@ -461,8 +461,17 @@ async function runProof(): Promise<void> {
     const proofLinks = await admin
       .select()
       .from(accountLinks)
-      .where(eq(accountLinks.issuanceReason, 'Person merge execution proof'))
-    assert.equal(proofLinks[0]?.personId, targetPersonId)
+      .where(eq(accountLinks.accountId, LINKED_ACCOUNT_ID))
+    assert.equal(
+      proofLinks.some(
+        ({ personId, status }) => personId === sourcePersonId && status === 'revoked'
+      ),
+      true
+    )
+    assert.equal(
+      proofLinks.some(({ personId, status }) => personId === targetPersonId && status === 'active'),
+      true
+    )
     const [revokedSession] = await admin
       .select()
       .from(accountSessions)

--- a/apps/web/src/server/routers/person-merges.ts
+++ b/apps/web/src/server/routers/person-merges.ts
@@ -1,4 +1,8 @@
-import { approvePersonMergePreview, createPersonMergePreview } from '@/services/person-merges'
+import {
+  approvePersonMergePreview,
+  createPersonMergePreview,
+  executePersonMerge,
+} from '@/services/person-merges'
 import { CAPABILITIES } from '@openschool/rbac'
 import { z } from 'zod'
 import { protectedProcedure, router } from '../trpc'
@@ -37,5 +41,19 @@ export const personMergesRouter = router({
     )
     .mutation(({ ctx, input }) =>
       approvePersonMergePreview(ctx.requestContext, ctx.policyContext, ctx.policyDecision, input)
+    ),
+  execute: protectedProcedure(CAPABILITIES.PEOPLE_MERGES_EXECUTE, {
+    requestedScope: 'school',
+  })
+    .input(
+      z.object({
+        operationId: z.uuid(),
+        expectedOperationVersion: z.number().int().positive(),
+        expectedPreviewDigest: z.string().regex(/^[0-9a-f]{64}$/),
+        reason: z.string().trim().min(3).max(512),
+      })
+    )
+    .mutation(({ ctx, input }) =>
+      executePersonMerge(ctx.requestContext, ctx.policyContext, ctx.policyDecision, input)
     ),
 })

--- a/apps/web/src/services/person-merges.ts
+++ b/apps/web/src/services/person-merges.ts
@@ -37,6 +37,22 @@ export interface PersonMergeApprovalResult extends Record<string, unknown> {
   approvedAt: Date
 }
 
+export interface ExecutePersonMergeInput {
+  operationId: string
+  expectedOperationVersion: number
+  expectedPreviewDigest: string
+  reason: string
+}
+
+export interface PersonMergeExecutionResult extends Record<string, unknown> {
+  operationId: string
+  status: 'executed'
+  version: number
+  executionDigest: string
+  invalidationCount: number
+  executedAt: Date
+}
+
 function assertPersonMergePreviewScope(
   databaseContext: TenantDatabaseContext,
   context: PolicyContext,
@@ -61,6 +77,22 @@ function assertPersonMergeApprovalScope(
   assertDatabasePolicyContext(databaseContext, context)
   if (
     decision.capability !== CAPABILITIES.PEOPLE_MERGES_APPROVE ||
+    !context.tenantId ||
+    decision.queryConstraints.length < 1 ||
+    decision.queryConstraints.some((constraint) => constraint.kind === 'platform')
+  ) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'POLICY_SCOPE_MISMATCH' })
+  }
+}
+
+function assertPersonMergeExecutionScope(
+  databaseContext: TenantDatabaseContext,
+  context: PolicyContext,
+  decision: AllowedPolicyDecision
+): void {
+  assertDatabasePolicyContext(databaseContext, context)
+  if (
+    decision.capability !== CAPABILITIES.PEOPLE_MERGES_EXECUTE ||
     !context.tenantId ||
     decision.queryConstraints.length < 1 ||
     decision.queryConstraints.some((constraint) => constraint.kind === 'platform')
@@ -101,6 +133,34 @@ function normalizePreviewError(error: unknown): unknown {
       return new TRPCError({
         code: 'CONFLICT',
         message: 'A merge workflow already exists for the source Person',
+        cause: error,
+      })
+    default:
+      return error
+  }
+}
+
+function normalizeExecutionError(error: unknown): unknown {
+  if (error instanceof TRPCError) return error
+  switch (databaseErrorCode(error)) {
+    case '40001':
+      return new TRPCError({ code: 'CONFLICT', message: 'MERGE_APPROVAL_CHANGED', cause: error })
+    case '42501':
+      return new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Merge operation not found',
+        cause: error,
+      })
+    case '22023':
+      return new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Merge execution is invalid',
+        cause: error,
+      })
+    case '23505':
+      return new TRPCError({
+        code: 'CONFLICT',
+        message: 'The Person merge was already executed',
         cause: error,
       })
     default:
@@ -250,6 +310,70 @@ export async function approvePersonMergePreview(
       throw new AggregateError(
         [normalized, auditError],
         'Person merge approval and failure audit both failed'
+      )
+    }
+    throw normalized
+  }
+}
+
+export async function executePersonMerge(
+  databaseContext: TenantDatabaseContext,
+  context: PolicyContext,
+  decision: AllowedPolicyDecision,
+  input: ExecutePersonMergeInput
+): Promise<PersonMergeExecutionResult> {
+  assertPersonMergeExecutionScope(databaseContext, context, decision)
+  const reason = input.reason.normalize('NFKC').trim().replace(/\s+/g, ' ')
+  if (reason.length < 3 || reason.length > 512) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Reason must be 3–512 characters' })
+  }
+  if (!/^[0-9a-f]{64}$/.test(input.expectedPreviewDigest)) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Preview digest is invalid' })
+  }
+
+  try {
+    return await withPolicyTenantTransaction(
+      databaseContext,
+      toDatabasePolicyContext(decision),
+      async (db) => {
+        const rows = await db.execute<PersonMergeExecutionResult>(sql`
+          select
+            operation_id as "operationId",
+            status,
+            version,
+            execution_digest as "executionDigest",
+            invalidation_count as "invalidationCount",
+            executed_at as "executedAt"
+          from openschool_private.execute_person_merge(
+            ${input.operationId}::uuid,
+            ${input.expectedOperationVersion}::integer,
+            ${input.expectedPreviewDigest},
+            ${reason}
+          )
+        `)
+        const result = rows[0]
+        if (!result) throw new TRPCError({ code: 'CONFLICT', message: 'MERGE_APPROVAL_CHANGED' })
+        // The database authority writes the success audit event and outbox row in the same
+        // transaction as the identity mutation; duplicating it here would weaken idempotency.
+        return result
+      }
+    )
+  } catch (error) {
+    const normalized = normalizeExecutionError(error)
+    try {
+      await recordAuditAttempt(databaseContext, context, decision, {
+        eventType: 'person_merge.execute',
+        outcome:
+          normalized instanceof TRPCError && normalized.code === 'NOT_FOUND' ? 'denied' : 'failed',
+        targetType: 'person_merge_operation',
+        targetId: input.operationId,
+        dataClasses: ['student_personal', 'credential'],
+        change: { changedFields: ['execution'] },
+      })
+    } catch (auditError) {
+      throw new AggregateError(
+        [normalized, auditError],
+        'Person merge execution and failure audit both failed'
       )
     }
     throw normalized

--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,7 @@
     "unrs-resolver",
   ],
   "overrides": {
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "^8.5.25",
     "sharp": "^0.35.0",
   },
@@ -924,7 +924,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 

--- a/docs/adr/0009-controlled-person-merge.md
+++ b/docs/adr/0009-controlled-person-merge.md
@@ -37,7 +37,14 @@ The control plane uses three forced-RLS tables: operations, append-only preview 
 append-only events. A dedicated `NOLOGIN`, `NOBYPASSRLS` manager role owns future guarded
 functions, while runtime retains read-only table grants and cannot inherit that role. Product
 authorization is versioned independently from duplicate review through the
-`tenant.people_merges.read`, `.preview`, and `.approve` capabilities.
+`tenant.people_merges.read`, `.preview`, `.approve`, and `.execute` capabilities.
+
+Execution adds a forced-RLS alias registry and append-only move ledger. The alias identifies the
+durable source-to-canonical mapping without deleting either Person. Each moved, ended, recreated,
+preserved, invalidated, or archived record receives a non-sensitive ledger key plus before/after
+fingerprints. The operation stores a plan version so execution can refuse approvals created before
+the planner could enumerate transitive authorization dependencies such as role assignments and
+sessions.
 
 This foundation intentionally exposes no execution function. Preview/approval, execution, and
 reversal ship as independently reviewable security increments; an intermediate deployment cannot
@@ -71,10 +78,11 @@ other sensitive values. UI labels are resolved through separately authorized Per
 ## Migration path and rollback
 
 Migration 0040 establishes the role, forced-RLS tables, immutable anchors, versioned capabilities,
-and a no-execution safety boundary. A later migration adds guarded preview and approval functions,
-followed by an execution ledger and then reversal/manual-recovery authority. The legacy
-`person_merge_evidence` prototype remains non-authoritative until its development callers are
-removed.
+and a no-execution safety boundary. Migration 0041 adds guarded preview and approval functions.
+Migration 0042 adds the versioned execution plan, durable alias registry, and immutable move ledger
+without yet exposing an executor. A later migration adds the guarded executor, followed by
+reversal/manual-recovery authority. The legacy `person_merge_evidence` prototype remains
+non-authoritative until its development callers are removed.
 
 Rollback may disable creation and approval, but must preserve operations, preview items, events,
 aliases, and audit evidence. Once execution exists, rollback must never restore a source Person by

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@trpc/server": "^11.0.0"
   },
   "overrides": {
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "^8.5.25",
     "sharp": "^0.35.0"
   },

--- a/packages/db/migrations/0042_brave_maelstrom.sql
+++ b/packages/db/migrations/0042_brave_maelstrom.sql
@@ -1,0 +1,406 @@
+CREATE TABLE "person_merge_aliases" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"review_school_id" uuid NOT NULL,
+	"operation_id" uuid NOT NULL,
+	"source_person_id" uuid NOT NULL,
+	"target_person_id" uuid NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"merged_at" timestamp with time zone NOT NULL,
+	"reversed_at" timestamp with time zone,
+	"reversed_by_account_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "person_merge_aliases_tenant_id_id_unique" UNIQUE("tenant_id","id"),
+	CONSTRAINT "person_merge_aliases_tenant_source_unique" UNIQUE("tenant_id","source_person_id"),
+	CONSTRAINT "person_merge_aliases_tenant_operation_unique" UNIQUE("tenant_id","operation_id"),
+	CONSTRAINT "person_merge_aliases_people_check" CHECK ("person_merge_aliases"."source_person_id" <> "person_merge_aliases"."target_person_id"),
+	CONSTRAINT "person_merge_aliases_status_check" CHECK ("person_merge_aliases"."status" IN ('active', 'reversed')),
+	CONSTRAINT "person_merge_aliases_version_check" CHECK ("person_merge_aliases"."version" > 0),
+	CONSTRAINT "person_merge_aliases_reversal_check" CHECK ("person_merge_aliases"."status" <> 'reversed'
+        OR ("person_merge_aliases"."reversed_at" IS NOT NULL AND "person_merge_aliases"."reversed_by_account_id" IS NOT NULL))
+);
+--> statement-breakpoint
+ALTER TABLE "person_merge_aliases" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "person_merge_moves" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"review_school_id" uuid NOT NULL,
+	"operation_id" uuid NOT NULL,
+	"sequence" integer NOT NULL,
+	"relation_name" text NOT NULL,
+	"source_record_key" text NOT NULL,
+	"replacement_record_key" text,
+	"action" text NOT NULL,
+	"before_fingerprint" text NOT NULL,
+	"after_fingerprint" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "person_merge_moves_tenant_id_id_unique" UNIQUE("tenant_id","id"),
+	CONSTRAINT "person_merge_moves_operation_sequence_unique" UNIQUE("tenant_id","operation_id","sequence"),
+	CONSTRAINT "person_merge_moves_operation_record_unique" UNIQUE("tenant_id","operation_id","relation_name","source_record_key"),
+	CONSTRAINT "person_merge_moves_sequence_check" CHECK ("person_merge_moves"."sequence" > 0),
+	CONSTRAINT "person_merge_moves_action_check" CHECK ("person_merge_moves"."action" IN ('repoint', 'end_and_recreate', 'preserve_history', 'invalidate', 'archive_source')),
+	CONSTRAINT "person_merge_moves_text_check" CHECK (char_length("person_merge_moves"."relation_name") BETWEEN 3 AND 128
+        AND char_length("person_merge_moves"."source_record_key") BETWEEN 1 AND 512
+        AND ("person_merge_moves"."replacement_record_key" IS NULL
+          OR char_length("person_merge_moves"."replacement_record_key") BETWEEN 1 AND 512)),
+	CONSTRAINT "person_merge_moves_hash_check" CHECK ("person_merge_moves"."before_fingerprint" ~ '^[0-9a-f]{64}$'
+        AND "person_merge_moves"."after_fingerprint" ~ '^[0-9a-f]{64}$')
+);
+--> statement-breakpoint
+ALTER TABLE "person_merge_moves" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "person_merge_operations" DROP CONSTRAINT "person_merge_operations_version_check";--> statement-breakpoint
+ALTER TABLE "person_merge_operations" DROP CONSTRAINT "person_merge_operations_hash_check";--> statement-breakpoint
+ALTER TABLE "person_merge_operations" DROP CONSTRAINT "person_merge_operations_count_check";--> statement-breakpoint
+ALTER TABLE "person_merge_operations" DROP CONSTRAINT "person_merge_operations_execution_check";--> statement-breakpoint
+ALTER TABLE "person_merge_operations" ADD COLUMN "plan_version" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "person_merge_operations" ADD COLUMN "execution_digest" text;--> statement-breakpoint
+ALTER TABLE "person_merge_operations" ADD COLUMN "invalidation_count" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "person_merge_aliases" ADD CONSTRAINT "person_merge_aliases_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "person_merge_aliases" ADD CONSTRAINT "person_merge_aliases_reversed_by_account_id_accounts_id_fk" FOREIGN KEY ("reversed_by_account_id") REFERENCES "public"."accounts"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "person_merge_aliases" ADD CONSTRAINT "person_merge_aliases_tenant_operation_fk" FOREIGN KEY ("tenant_id","operation_id") REFERENCES "public"."person_merge_operations"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "person_merge_aliases" ADD CONSTRAINT "person_merge_aliases_tenant_school_fk" FOREIGN KEY ("tenant_id","review_school_id") REFERENCES "public"."schools"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "person_merge_aliases" ADD CONSTRAINT "person_merge_aliases_tenant_source_fk" FOREIGN KEY ("tenant_id","source_person_id") REFERENCES "public"."people"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "person_merge_aliases" ADD CONSTRAINT "person_merge_aliases_tenant_target_fk" FOREIGN KEY ("tenant_id","target_person_id") REFERENCES "public"."people"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "person_merge_moves" ADD CONSTRAINT "person_merge_moves_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "person_merge_moves" ADD CONSTRAINT "person_merge_moves_tenant_operation_fk" FOREIGN KEY ("tenant_id","operation_id") REFERENCES "public"."person_merge_operations"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+ALTER TABLE "person_merge_moves" ADD CONSTRAINT "person_merge_moves_tenant_school_fk" FOREIGN KEY ("tenant_id","review_school_id") REFERENCES "public"."schools"("tenant_id","id") ON DELETE restrict ON UPDATE restrict;--> statement-breakpoint
+CREATE INDEX "person_merge_aliases_target_idx" ON "person_merge_aliases" USING btree ("tenant_id","target_person_id","status");--> statement-breakpoint
+CREATE INDEX "person_merge_moves_operation_idx" ON "person_merge_moves" USING btree ("tenant_id","operation_id","sequence","id");--> statement-breakpoint
+ALTER TABLE "person_merge_operations" ADD CONSTRAINT "person_merge_operations_version_check" CHECK ("person_merge_operations"."current_version" > 0 AND "person_merge_operations"."plan_version" > 0);--> statement-breakpoint
+ALTER TABLE "person_merge_operations" ADD CONSTRAINT "person_merge_operations_hash_check" CHECK ("person_merge_operations"."duplicate_evidence_hash" ~ '^[0-9a-f]{64}$'
+        AND "person_merge_operations"."preview_digest" ~ '^[0-9a-f]{64}$'
+        AND ("person_merge_operations"."execution_digest" IS NULL OR "person_merge_operations"."execution_digest" ~ '^[0-9a-f]{64}$'));--> statement-breakpoint
+ALTER TABLE "person_merge_operations" ADD CONSTRAINT "person_merge_operations_count_check" CHECK ("person_merge_operations"."dependency_count" >= 0 AND "person_merge_operations"."conflict_count" >= 0
+        AND "person_merge_operations"."conflict_count" <= "person_merge_operations"."dependency_count"
+        AND "person_merge_operations"."invalidation_count" >= 0);--> statement-breakpoint
+ALTER TABLE "person_merge_operations" ADD CONSTRAINT "person_merge_operations_execution_check" CHECK ("person_merge_operations"."status" NOT IN ('executed', 'reversed', 'manual_recovery')
+        OR ("person_merge_operations"."executed_by_account_id" IS NOT NULL AND "person_merge_operations"."executed_at" IS NOT NULL
+          AND "person_merge_operations"."execution_digest" IS NOT NULL));--> statement-breakpoint
+CREATE POLICY "person_merge_aliases_runtime_select" ON "person_merge_aliases" AS PERMISSIVE FOR SELECT TO "openschool_runtime" USING (
+  "person_merge_aliases"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_aliases"."tenant_id", "person_merge_aliases"."review_school_id")
+);--> statement-breakpoint
+CREATE POLICY "person_merge_aliases_runtime_write_deny" ON "person_merge_aliases" AS PERMISSIVE FOR ALL TO "openschool_runtime" USING (false) WITH CHECK (false);--> statement-breakpoint
+CREATE POLICY "person_merge_aliases_manager_all" ON "person_merge_aliases" AS PERMISSIVE FOR ALL TO "openschool_person_merge_manager" USING (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_aliases"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_aliases"."tenant_id", "person_merge_aliases"."review_school_id")
+) WITH CHECK (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_aliases"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_aliases"."tenant_id", "person_merge_aliases"."review_school_id")
+);--> statement-breakpoint
+CREATE POLICY "person_merge_moves_runtime_select" ON "person_merge_moves" AS PERMISSIVE FOR SELECT TO "openschool_runtime" USING (
+  "person_merge_moves"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_moves"."tenant_id", "person_merge_moves"."review_school_id")
+);--> statement-breakpoint
+CREATE POLICY "person_merge_moves_runtime_write_deny" ON "person_merge_moves" AS PERMISSIVE FOR ALL TO "openschool_runtime" USING (false) WITH CHECK (false);--> statement-breakpoint
+CREATE POLICY "person_merge_moves_manager_all" ON "person_merge_moves" AS PERMISSIVE FOR ALL TO "openschool_person_merge_manager" USING (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_moves"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_moves"."tenant_id", "person_merge_moves"."review_school_id")
+) WITH CHECK (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_moves"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_moves"."tenant_id", "person_merge_moves"."review_school_id")
+);--> statement-breakpoint
+ALTER POLICY "person_merge_events_runtime_select" ON "person_merge_events" TO openschool_runtime USING (
+  "person_merge_events"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_events"."tenant_id", "person_merge_events"."review_school_id")
+);--> statement-breakpoint
+ALTER POLICY "person_merge_events_manager_all" ON "person_merge_events" TO openschool_person_merge_manager USING (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_events"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_events"."tenant_id", "person_merge_events"."review_school_id")
+) WITH CHECK (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_events"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_events"."tenant_id", "person_merge_events"."review_school_id")
+);--> statement-breakpoint
+ALTER POLICY "person_merge_operations_runtime_select" ON "person_merge_operations" TO openschool_runtime USING (
+  "person_merge_operations"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_operations"."tenant_id", "person_merge_operations"."review_school_id")
+);--> statement-breakpoint
+ALTER POLICY "person_merge_operations_manager_all" ON "person_merge_operations" TO openschool_person_merge_manager USING (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_operations"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_operations"."tenant_id", "person_merge_operations"."review_school_id")
+) WITH CHECK (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_operations"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_operations"."tenant_id", "person_merge_operations"."review_school_id")
+);--> statement-breakpoint
+ALTER POLICY "person_merge_preview_items_runtime_select" ON "person_merge_preview_items" TO openschool_runtime USING (
+  "person_merge_preview_items"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_preview_items"."tenant_id", "person_merge_preview_items"."review_school_id")
+);--> statement-breakpoint
+ALTER POLICY "person_merge_preview_items_manager_all" ON "person_merge_preview_items" TO openschool_person_merge_manager USING (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_preview_items"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_preview_items"."tenant_id", "person_merge_preview_items"."review_school_id")
+) WITH CHECK (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND "person_merge_preview_items"."tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND 
+  nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.read',
+    'tenant.people_merges.preview',
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+
+  AND public.openschool_school_scope_allows("person_merge_preview_items"."tenant_id", "person_merge_preview_items"."review_school_id")
+);
+--> statement-breakpoint
+ALTER TABLE "person_merge_aliases" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "person_merge_moves" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+REVOKE ALL ON TABLE "person_merge_aliases", "person_merge_moves" FROM PUBLIC;
+--> statement-breakpoint
+GRANT SELECT ON TABLE "person_merge_aliases", "person_merge_moves"
+  TO "openschool_runtime";
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON TABLE "person_merge_aliases"
+  TO "openschool_person_merge_manager";
+--> statement-breakpoint
+GRANT SELECT, INSERT ON TABLE "person_merge_moves"
+  TO "openschool_person_merge_manager";
+--> statement-breakpoint
+CREATE TRIGGER "person_merge_moves_append_only"
+BEFORE UPDATE OR DELETE ON "person_merge_moves"
+FOR EACH ROW EXECUTE FUNCTION "openschool_private"."reject_person_merge_append_only_change"();
+--> statement-breakpoint
+CREATE FUNCTION "openschool_private"."protect_person_merge_alias_anchors"()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+  IF OLD.id IS DISTINCT FROM NEW.id
+    OR OLD.tenant_id IS DISTINCT FROM NEW.tenant_id
+    OR OLD.review_school_id IS DISTINCT FROM NEW.review_school_id
+    OR OLD.operation_id IS DISTINCT FROM NEW.operation_id
+    OR OLD.source_person_id IS DISTINCT FROM NEW.source_person_id
+    OR OLD.target_person_id IS DISTINCT FROM NEW.target_person_id
+    OR OLD.merged_at IS DISTINCT FROM NEW.merged_at
+    OR OLD.created_at IS DISTINCT FROM NEW.created_at
+  THEN
+    RAISE EXCEPTION 'person merge alias anchors are immutable' USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."protect_person_merge_alias_anchors"()
+  FROM PUBLIC;
+--> statement-breakpoint
+CREATE TRIGGER "person_merge_aliases_anchors_immutable"
+BEFORE UPDATE ON "person_merge_aliases"
+FOR EACH ROW EXECUTE FUNCTION "openschool_private"."protect_person_merge_alias_anchors"();
+--> statement-breakpoint
+CREATE TRIGGER "person_merge_aliases_no_delete"
+BEFORE DELETE ON "person_merge_aliases"
+FOR EACH ROW EXECUTE FUNCTION "openschool_private"."reject_person_merge_append_only_change"();
+--> statement-breakpoint
+CREATE FUNCTION "openschool_private"."protect_merged_person_alias"()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.person_merge_aliases AS alias
+    WHERE alias.tenant_id = OLD.tenant_id
+      AND alias.source_person_id = OLD.id
+      AND alias.status = 'active'
+  ) THEN
+    RAISE EXCEPTION 'merged Person aliases are immutable' USING ERRCODE = '42501';
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END
+$function$;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."protect_merged_person_alias"()
+  FROM PUBLIC;
+--> statement-breakpoint
+CREATE TRIGGER "people_merged_alias_immutable"
+BEFORE UPDATE OR DELETE ON "people"
+FOR EACH ROW EXECUTE FUNCTION "openschool_private"."protect_merged_person_alias"();
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "openschool_private"."protect_person_merge_operation_anchors"()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+  IF OLD.id IS DISTINCT FROM NEW.id
+    OR OLD.tenant_id IS DISTINCT FROM NEW.tenant_id
+    OR OLD.review_school_id IS DISTINCT FROM NEW.review_school_id
+    OR OLD.duplicate_case_id IS DISTINCT FROM NEW.duplicate_case_id
+    OR OLD.duplicate_case_version IS DISTINCT FROM NEW.duplicate_case_version
+    OR OLD.duplicate_evidence_hash IS DISTINCT FROM NEW.duplicate_evidence_hash
+    OR OLD.source_person_id IS DISTINCT FROM NEW.source_person_id
+    OR OLD.target_person_id IS DISTINCT FROM NEW.target_person_id
+    OR OLD.plan_version IS DISTINCT FROM NEW.plan_version
+    OR OLD.initiated_by_account_id IS DISTINCT FROM NEW.initiated_by_account_id
+    OR OLD.initiation_reason IS DISTINCT FROM NEW.initiation_reason
+    OR OLD.created_at IS DISTINCT FROM NEW.created_at
+  THEN
+    RAISE EXCEPTION 'person merge operation anchors are immutable' USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+--> statement-breakpoint
+DO $verification$
+BEGIN
+  IF NOT (
+    SELECT relrowsecurity AND relforcerowsecurity
+    FROM pg_class
+    WHERE oid = 'public.person_merge_aliases'::regclass
+  ) OR NOT (
+    SELECT relrowsecurity AND relforcerowsecurity
+    FROM pg_class
+    WHERE oid = 'public.person_merge_moves'::regclass
+  ) THEN
+    RAISE EXCEPTION 'Person merge execution ledger must force RLS';
+  END IF;
+
+  IF has_table_privilege('openschool_runtime', 'public.person_merge_aliases', 'INSERT')
+    OR has_table_privilege('openschool_runtime', 'public.person_merge_moves', 'INSERT')
+    OR pg_catalog.pg_has_role(
+      'openschool_runtime', 'openschool_person_merge_manager', 'member'
+    )
+  THEN
+    RAISE EXCEPTION 'Person merge execution ledger privileges are unsafe';
+  END IF;
+END
+$verification$;

--- a/packages/db/migrations/0042_brave_maelstrom.sql
+++ b/packages/db/migrations/0042_brave_maelstrom.sql
@@ -329,6 +329,7 @@ FOR EACH ROW EXECUTE FUNCTION "openschool_private"."reject_person_merge_append_o
 CREATE FUNCTION "openschool_private"."protect_merged_person_alias"()
 RETURNS trigger
 LANGUAGE plpgsql
+SECURITY DEFINER
 SET search_path = pg_catalog
 AS $function$
 BEGIN

--- a/packages/db/migrations/0043_person_merge_plan_v2.sql
+++ b/packages/db/migrations/0043_person_merge_plan_v2.sql
@@ -1,0 +1,775 @@
+-- Plan v2 extends the direct-Person inventory with transitive authorization and academic
+-- dependencies. The v1 functions remain private implementation details so callers cannot skip
+-- finalization or approve an incomplete plan.
+
+GRANT SELECT ON TABLE "role_template_assignments", "enrollments", "grades"
+  TO "openschool_person_merge_manager";
+--> statement-breakpoint
+GRANT SELECT ("id", "status", "membership_version", "security_version", "updated_at")
+  ON TABLE "accounts" TO "openschool_person_merge_manager";
+--> statement-breakpoint
+GRANT SELECT ("id", "account_id", "status", "security_version", "expires_at", "updated_at")
+  ON TABLE "account_sessions" TO "openschool_person_merge_manager";
+--> statement-breakpoint
+CREATE POLICY "role_template_assignments_person_merge_manager_select"
+  ON "role_template_assignments"
+  AS PERMISSIVE FOR SELECT TO "openschool_person_merge_manager" USING (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND nullif(current_setting('app.policy_capability', true), '') IN (
+      'tenant.people_merges.preview', 'tenant.people_merges.approve',
+      'tenant.people_merges.execute'
+    )
+  );
+--> statement-breakpoint
+CREATE POLICY "enrollments_person_merge_manager_select" ON "enrollments"
+  AS PERMISSIVE FOR SELECT TO "openschool_person_merge_manager" USING (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND nullif(current_setting('app.policy_capability', true), '') IN (
+      'tenant.people_merges.preview', 'tenant.people_merges.approve',
+      'tenant.people_merges.execute'
+    )
+  );
+--> statement-breakpoint
+CREATE POLICY "grades_person_merge_manager_select" ON "grades"
+  AS PERMISSIVE FOR SELECT TO "openschool_person_merge_manager" USING (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND nullif(current_setting('app.policy_capability', true), '') IN (
+      'tenant.people_merges.preview', 'tenant.people_merges.approve',
+      'tenant.people_merges.execute'
+    )
+  );
+--> statement-breakpoint
+CREATE POLICY "accounts_person_merge_manager_select" ON "accounts"
+  AS PERMISSIVE FOR SELECT TO "openschool_person_merge_manager" USING (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND nullif(current_setting('app.policy_capability', true), '') IN (
+      'tenant.people_merges.preview', 'tenant.people_merges.approve',
+      'tenant.people_merges.execute'
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.account_links AS link
+      WHERE link.account_id = accounts.id
+        AND link.tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+        AND link.person_id = nullif(
+          current_setting('app.merge_source_person_id', true), ''
+        )::uuid
+    )
+  );
+--> statement-breakpoint
+CREATE POLICY "account_sessions_person_merge_manager_select" ON "account_sessions"
+  AS PERMISSIVE FOR SELECT TO "openschool_person_merge_manager" USING (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND nullif(current_setting('app.policy_capability', true), '') IN (
+      'tenant.people_merges.preview', 'tenant.people_merges.approve',
+      'tenant.people_merges.execute'
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.account_links AS link
+      WHERE link.account_id = account_sessions.account_id
+        AND link.tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+        AND link.person_id = nullif(
+          current_setting('app.merge_source_person_id', true), ''
+        )::uuid
+    )
+  );
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "openschool_private"."protect_person_merge_operation_anchors"()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+  IF OLD.id IS DISTINCT FROM NEW.id
+    OR OLD.tenant_id IS DISTINCT FROM NEW.tenant_id
+    OR OLD.review_school_id IS DISTINCT FROM NEW.review_school_id
+    OR OLD.duplicate_case_id IS DISTINCT FROM NEW.duplicate_case_id
+    OR OLD.duplicate_case_version IS DISTINCT FROM NEW.duplicate_case_version
+    OR OLD.duplicate_evidence_hash IS DISTINCT FROM NEW.duplicate_evidence_hash
+    OR OLD.source_person_id IS DISTINCT FROM NEW.source_person_id
+    OR OLD.target_person_id IS DISTINCT FROM NEW.target_person_id
+    OR (
+      OLD.plan_version IS DISTINCT FROM NEW.plan_version
+      AND NOT (
+        OLD.plan_version = 1 AND NEW.plan_version = 2
+        AND OLD.current_version = 1 AND NEW.current_version = 2
+        AND OLD.status IN ('blocked', 'pending_approval')
+        AND NEW.status IN ('blocked', 'pending_approval')
+      )
+    )
+    OR OLD.initiated_by_account_id IS DISTINCT FROM NEW.initiated_by_account_id
+    OR OLD.initiation_reason IS DISTINCT FROM NEW.initiation_reason
+    OR OLD.created_at IS DISTINCT FROM NEW.created_at
+  THEN
+    RAISE EXCEPTION 'person merge operation anchors are immutable' USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+--> statement-breakpoint
+ALTER FUNCTION "openschool_private"."create_person_merge_preview"(
+  uuid, integer, uuid, uuid, text
+) RENAME TO "create_person_merge_preview_v1";
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."create_person_merge_preview_v1"(
+  uuid, integer, uuid, uuid, text
+) FROM PUBLIC, "openschool_runtime";
+--> statement-breakpoint
+CREATE FUNCTION "openschool_private"."finalize_person_merge_preview_v2"(
+  p_operation_id uuid,
+  p_expected_preview_digest text
+)
+RETURNS TABLE (
+  operation_id uuid,
+  status text,
+  dependency_count integer,
+  conflict_count integer,
+  preview_digest text,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, extensions, public
+SET timezone = 'UTC'
+AS $function$
+DECLARE
+  v_tenant_id uuid := nullif(current_setting('app.tenant_id', true), '')::uuid;
+  v_account_id uuid := nullif(current_setting('app.account_id', true), '')::uuid;
+  v_operation public.person_merge_operations%ROWTYPE;
+  v_dependency_count integer;
+  v_conflict_count integer;
+  v_status text;
+  v_preview_digest text;
+  v_now timestamptz := clock_timestamp();
+BEGIN
+  IF session_user <> 'openschool_runtime'
+    OR current_user <> 'openschool_person_merge_manager'
+    OR nullif(current_setting('app.policy_capability', true), '')
+      <> 'tenant.people_merges.preview'
+    OR v_tenant_id IS NULL OR v_account_id IS NULL
+    OR p_operation_id IS NULL
+    OR p_expected_preview_digest IS NULL
+    OR p_expected_preview_digest !~ '^[0-9a-f]{64}$'
+  THEN
+    RAISE EXCEPTION 'PERSON_MERGE_PLAN_CONTEXT_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT operation.* INTO v_operation
+  FROM public.person_merge_operations AS operation
+  WHERE operation.tenant_id = v_tenant_id AND operation.id = p_operation_id
+    AND operation.initiated_by_account_id = v_account_id
+    AND public.openschool_school_scope_allows(
+      operation.tenant_id, operation.review_school_id
+    )
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PERSON_MERGE_OPERATION_NOT_FOUND' USING ERRCODE = '42501';
+  END IF;
+  IF v_operation.current_version <> 1 OR v_operation.plan_version <> 1
+    OR v_operation.preview_digest <> p_expected_preview_digest
+    OR v_operation.status NOT IN ('blocked', 'pending_approval')
+  THEN
+    RAISE EXCEPTION 'PERSON_MERGE_PLAN_CHANGED' USING ERRCODE = '40001';
+  END IF;
+
+  PERFORM set_config('app.merge_source_person_id', v_operation.source_person_id::text, true);
+
+  INSERT INTO public.person_merge_preview_items (
+    tenant_id, review_school_id, operation_id, category, relation_name, record_key,
+    direction, disposition, row_fingerprint, metadata, created_at
+  )
+  SELECT v_tenant_id, v_operation.review_school_id, p_operation_id,
+    'authorization_history', 'role_template_assignments',
+    encode(digest(convert_to('role:' || assignment.id::text, 'UTF8'), 'sha256'), 'hex'),
+    'source',
+    CASE WHEN assignment.status IN ('active', 'suspended')
+      THEN 'end_and_recreate' ELSE 'preserve_history' END,
+    encode(digest(convert_to(to_jsonb(assignment)::text, 'UTF8'), 'sha256'), 'hex'),
+    jsonb_build_object('kind', 'derived_dependency', 'path', 'affiliation_role'), v_now
+  FROM public.role_template_assignments AS assignment
+  INNER JOIN public.affiliations AS affiliation
+    ON affiliation.tenant_id = assignment.tenant_id
+    AND affiliation.id = assignment.affiliation_id
+  WHERE affiliation.tenant_id = v_tenant_id
+    AND affiliation.person_id = v_operation.source_person_id;
+
+  INSERT INTO public.person_merge_preview_items (
+    tenant_id, review_school_id, operation_id, category, relation_name, record_key,
+    direction, disposition, row_fingerprint, metadata, created_at
+  )
+  SELECT v_tenant_id, v_operation.review_school_id, p_operation_id,
+    'authorization_history', 'accounts',
+    encode(digest(convert_to('account:' || account_row.id::text, 'UTF8'), 'sha256'), 'hex'),
+    'source', 'preserve_history',
+    encode(digest(convert_to(to_jsonb(account_row)::text, 'UTF8'), 'sha256'), 'hex'),
+    jsonb_build_object('kind', 'derived_dependency', 'path', 'account_invalidation'), v_now
+  FROM (
+    SELECT DISTINCT account.id, account.status, account.membership_version,
+      account.security_version, account.updated_at
+    FROM public.accounts AS account
+    INNER JOIN public.account_links AS link ON link.account_id = account.id
+    WHERE link.tenant_id = v_tenant_id
+      AND link.person_id = v_operation.source_person_id
+  ) AS account_row;
+
+  INSERT INTO public.person_merge_preview_items (
+    tenant_id, review_school_id, operation_id, category, relation_name, record_key,
+    direction, disposition, row_fingerprint, metadata, created_at
+  )
+  SELECT v_tenant_id, v_operation.review_school_id, p_operation_id,
+    'authorization_history', 'account_sessions',
+    encode(digest(convert_to('session:' || session_row.id::text, 'UTF8'), 'sha256'), 'hex'),
+    'source', 'preserve_history',
+    encode(digest(convert_to(to_jsonb(session_row)::text, 'UTF8'), 'sha256'), 'hex'),
+    jsonb_build_object('kind', 'derived_dependency', 'path', 'account_session'), v_now
+  FROM (
+    SELECT DISTINCT session.id, session.account_id, session.status,
+      session.security_version, session.expires_at, session.updated_at
+    FROM public.account_sessions AS session
+    INNER JOIN public.account_links AS link ON link.account_id = session.account_id
+    WHERE link.tenant_id = v_tenant_id
+      AND link.person_id = v_operation.source_person_id
+  ) AS session_row;
+
+  INSERT INTO public.person_merge_preview_items (
+    tenant_id, review_school_id, operation_id, category, relation_name, record_key,
+    direction, disposition, row_fingerprint, metadata, created_at
+  )
+  SELECT v_tenant_id, v_operation.review_school_id, p_operation_id,
+    'academic_history', 'grades',
+    encode(digest(convert_to('grade:' || grade_row.id::text, 'UTF8'), 'sha256'), 'hex'),
+    'source', 'preserve_history',
+    encode(digest(convert_to(to_jsonb(grade_row)::text, 'UTF8'), 'sha256'), 'hex'),
+    jsonb_build_object('kind', 'derived_dependency', 'path', 'legacy_enrollment_grade'), v_now
+  FROM public.people AS person
+  INNER JOIN public.enrollments AS enrollment
+    ON enrollment.tenant_id = person.tenant_id
+    AND enrollment.student_id = person.legacy_student_id
+  INNER JOIN public.grades AS grade_row
+    ON grade_row.tenant_id = enrollment.tenant_id
+    AND grade_row.enrollment_id = enrollment.id
+  WHERE person.tenant_id = v_tenant_id
+    AND person.id = v_operation.source_person_id;
+
+  -- A current target fact with the same business key requires an explicit field-level decision.
+  INSERT INTO public.person_merge_preview_items (
+    tenant_id, review_school_id, operation_id, category, relation_name, record_key,
+    direction, disposition, conflict_code, row_fingerprint, metadata, created_at
+  )
+  SELECT DISTINCT v_tenant_id, v_operation.review_school_id, p_operation_id,
+    conflict.category, conflict.relation_name,
+    encode(digest(convert_to(conflict.conflict_key, 'UTF8'), 'sha256'), 'hex'),
+    'none', 'block', conflict.conflict_code,
+    encode(digest(convert_to(conflict.conflict_key, 'UTF8'), 'sha256'), 'hex'),
+    jsonb_build_object('kind', 'target_conflict', 'path', conflict.path), v_now
+  FROM (
+    SELECT 'account_link'::text AS category, 'account_links'::text AS relation_name,
+      'TARGET_ACCOUNT_LINK_EXISTS'::text AS conflict_code,
+      'account_link'::text AS path,
+      'account:' || source.account_id::text AS conflict_key
+    FROM public.account_links AS source
+    INNER JOIN public.account_links AS target
+      ON target.tenant_id = source.tenant_id AND target.account_id = source.account_id
+      AND target.person_id = v_operation.target_person_id
+      AND target.status IN ('pending', 'active', 'suspended')
+    WHERE source.tenant_id = v_tenant_id
+      AND source.person_id = v_operation.source_person_id
+      AND source.status IN ('pending', 'active', 'suspended')
+    UNION ALL
+    SELECT 'affiliation', 'affiliations', 'TARGET_AFFILIATION_EXISTS', 'affiliation',
+      'affiliation:' || source.id::text
+    FROM public.affiliations AS source
+    INNER JOIN public.affiliations AS target
+      ON target.tenant_id = source.tenant_id AND target.person_id = v_operation.target_person_id
+      AND target.kind = source.kind AND target.scope_type = source.scope_type
+      AND target.education_organization_id IS NOT DISTINCT FROM source.education_organization_id
+      AND target.school_id IS NOT DISTINCT FROM source.school_id
+      AND target.class_id IS NOT DISTINCT FROM source.class_id
+      AND target.status IN ('active', 'suspended')
+    WHERE source.tenant_id = v_tenant_id
+      AND source.person_id = v_operation.source_person_id
+      AND source.status IN ('active', 'suspended')
+    UNION ALL
+    SELECT 'household_membership', 'household_memberships',
+      'TARGET_HOUSEHOLD_MEMBERSHIP_EXISTS', 'household',
+      'household:' || source.household_id::text
+    FROM public.household_memberships AS source
+    INNER JOIN public.household_memberships AS target
+      ON target.tenant_id = source.tenant_id AND target.household_id = source.household_id
+      AND target.person_id = v_operation.target_person_id AND target.status = 'active'
+    WHERE source.tenant_id = v_tenant_id
+      AND source.person_id = v_operation.source_person_id AND source.status = 'active'
+    UNION ALL
+    SELECT 'relationship', 'person_relationships',
+      'TARGET_RELATIONSHIP_EXISTS', 'relationship',
+      'relationship:' || source.id::text
+    FROM public.person_relationships AS source
+    INNER JOIN public.person_relationships AS target
+      ON target.tenant_id = source.tenant_id AND target.type = source.type
+      AND target.status IN ('active', 'suspended')
+      AND (
+        (
+          source.subject_person_id = v_operation.source_person_id
+          AND target.subject_person_id = v_operation.target_person_id
+          AND target.related_person_id = source.related_person_id
+        )
+        OR (
+          source.related_person_id = v_operation.source_person_id
+          AND target.related_person_id = v_operation.target_person_id
+          AND target.subject_person_id = source.subject_person_id
+        )
+      )
+    WHERE source.tenant_id = v_tenant_id
+      AND source.status IN ('active', 'suspended')
+      AND v_operation.source_person_id IN (
+        source.subject_person_id, source.related_person_id
+      )
+      AND v_operation.target_person_id NOT IN (
+        source.subject_person_id, source.related_person_id
+      )
+    UNION ALL
+    SELECT 'school_enrollment', 'school_enrollments',
+      'TARGET_SCHOOL_ENROLLMENT_EXISTS', 'school_enrollment',
+      'enrollment:' || source.school_id::text || ':' || source.enrollment_type
+    FROM public.school_enrollments AS source
+    INNER JOIN public.school_enrollments AS target
+      ON target.tenant_id = source.tenant_id AND target.school_id = source.school_id
+      AND target.person_id = v_operation.target_person_id
+      AND target.enrollment_type = source.enrollment_type AND target.status = 'enrolled'
+    WHERE source.tenant_id = v_tenant_id
+      AND source.person_id = v_operation.source_person_id AND source.status = 'enrolled'
+    UNION ALL
+    SELECT 'section_staff', 'section_staff_assignments',
+      'TARGET_SECTION_STAFF_EXISTS', 'section_staff',
+      'staff:' || source.section_id::text || ':' || source.role
+    FROM public.section_staff_assignments AS source
+    INNER JOIN public.section_staff_assignments AS target
+      ON target.tenant_id = source.tenant_id AND target.section_id = source.section_id
+      AND target.person_id = v_operation.target_person_id
+      AND target.role = source.role AND target.status = 'active'
+    WHERE source.tenant_id = v_tenant_id
+      AND source.person_id = v_operation.source_person_id AND source.status = 'active'
+    UNION ALL
+    SELECT 'section_roster', 'section_roster_memberships',
+      'TARGET_SECTION_ROSTER_EXISTS', 'section_roster',
+      'roster:' || source.section_id::text
+    FROM public.section_roster_memberships AS source
+    INNER JOIN public.section_roster_memberships AS target
+      ON target.tenant_id = source.tenant_id AND target.section_id = source.section_id
+      AND target.person_id = v_operation.target_person_id AND target.status = 'active'
+    WHERE source.tenant_id = v_tenant_id
+      AND source.person_id = v_operation.source_person_id AND source.status = 'active'
+  ) AS conflict;
+
+  SELECT count(*)::integer,
+    count(*) FILTER (WHERE item.disposition = 'block')::integer
+  INTO v_dependency_count, v_conflict_count
+  FROM public.person_merge_preview_items AS item
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id;
+  v_status := CASE WHEN v_conflict_count = 0 THEN 'pending_approval' ELSE 'blocked' END;
+
+  SELECT encode(
+    digest(
+      convert_to(
+        'plan:2:' || v_operation.duplicate_evidence_hash || ':' ||
+        v_operation.source_person_id::text || ':' || v_operation.target_person_id::text || ':' ||
+        coalesce(string_agg(
+          item.relation_name || ':' || item.record_key || ':' || item.direction || ':' ||
+          item.disposition || ':' || coalesce(item.conflict_code, '') || ':' ||
+          item.row_fingerprint,
+          '|' ORDER BY item.relation_name, item.record_key, item.direction
+        ), ''),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) INTO v_preview_digest
+  FROM public.person_merge_preview_items AS item
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id;
+
+  UPDATE public.person_merge_operations AS operation
+  SET plan_version = 2, current_version = 2, status = v_status,
+    dependency_count = v_dependency_count, conflict_count = v_conflict_count,
+    preview_digest = v_preview_digest, updated_at = v_now
+  WHERE operation.tenant_id = v_tenant_id AND operation.id = p_operation_id
+    AND operation.current_version = 1 AND operation.plan_version = 1;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PERSON_MERGE_PLAN_CHANGED' USING ERRCODE = '40001';
+  END IF;
+
+  INSERT INTO public.person_merge_events (
+    tenant_id, review_school_id, operation_id, version, event_type, operation_status,
+    preview_digest, reason, actor_account_id, created_at
+  ) VALUES (
+    v_tenant_id, v_operation.review_school_id, p_operation_id, 2,
+    'preview_created', v_status, v_preview_digest,
+    'Finalized dependency-complete merge plan version 2', v_account_id, v_now
+  );
+
+  RETURN QUERY SELECT p_operation_id, v_status, v_dependency_count,
+    v_conflict_count, v_preview_digest, v_now;
+END
+$function$;
+--> statement-breakpoint
+ALTER FUNCTION "openschool_private"."finalize_person_merge_preview_v2"(uuid, text)
+  OWNER TO "openschool_person_merge_manager";
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."finalize_person_merge_preview_v2"(uuid, text)
+  FROM PUBLIC, "openschool_runtime";
+--> statement-breakpoint
+CREATE FUNCTION "openschool_private"."create_person_merge_preview"(
+  p_case_id uuid,
+  p_expected_case_version integer,
+  p_source_person_id uuid,
+  p_target_person_id uuid,
+  p_reason text
+)
+RETURNS TABLE (
+  operation_id uuid,
+  status text,
+  dependency_count integer,
+  conflict_count integer,
+  preview_digest text,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, openschool_private
+SET timezone = 'UTC'
+AS $function$
+DECLARE
+  v_preview record;
+BEGIN
+  SELECT * INTO v_preview
+  FROM openschool_private.create_person_merge_preview_v1(
+    p_case_id, p_expected_case_version, p_source_person_id, p_target_person_id, p_reason
+  );
+  RETURN QUERY
+  SELECT * FROM openschool_private.finalize_person_merge_preview_v2(
+    v_preview.operation_id, v_preview.preview_digest
+  );
+END
+$function$;
+--> statement-breakpoint
+ALTER FUNCTION "openschool_private"."create_person_merge_preview"(
+  uuid, integer, uuid, uuid, text
+) OWNER TO "openschool_person_merge_manager";
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."create_person_merge_preview"(
+  uuid, integer, uuid, uuid, text
+) FROM PUBLIC;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION "openschool_private"."create_person_merge_preview"(
+  uuid, integer, uuid, uuid, text
+) TO "openschool_runtime";
+--> statement-breakpoint
+CREATE FUNCTION "openschool_private"."assert_person_merge_plan_v2_current"(
+  p_operation_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, extensions, public
+SET timezone = 'UTC'
+AS $function$
+DECLARE
+  v_tenant_id uuid := nullif(current_setting('app.tenant_id', true), '')::uuid;
+  v_operation public.person_merge_operations%ROWTYPE;
+  v_item record;
+  v_item_current boolean;
+  v_preview_count integer;
+  v_current_count integer;
+  v_target_conflict boolean;
+BEGIN
+  IF session_user <> 'openschool_runtime'
+    OR current_user <> 'openschool_person_merge_manager'
+    OR nullif(current_setting('app.policy_capability', true), '') NOT IN (
+      'tenant.people_merges.approve', 'tenant.people_merges.execute'
+    )
+    OR v_tenant_id IS NULL OR p_operation_id IS NULL
+  THEN
+    RAISE EXCEPTION 'PERSON_MERGE_PLAN_CONTEXT_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT operation.* INTO v_operation
+  FROM public.person_merge_operations AS operation
+  WHERE operation.tenant_id = v_tenant_id AND operation.id = p_operation_id
+    AND operation.plan_version = 2
+    AND public.openschool_school_scope_allows(
+      operation.tenant_id, operation.review_school_id
+    );
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PERSON_MERGE_PLAN_VERSION_UNSUPPORTED' USING ERRCODE = '40001';
+  END IF;
+  PERFORM set_config('app.merge_source_person_id', v_operation.source_person_id::text, true);
+
+  FOR v_item IN
+    SELECT item.relation_name, item.row_fingerprint
+    FROM public.person_merge_preview_items AS item
+    WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+      AND item.metadata->>'kind' = 'derived_dependency'
+    ORDER BY item.relation_name, item.record_key
+  LOOP
+    v_item_current := false;
+    CASE v_item.relation_name
+      WHEN 'role_template_assignments' THEN
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.role_template_assignments AS assignment
+          INNER JOIN public.affiliations AS affiliation
+            ON affiliation.tenant_id = assignment.tenant_id
+            AND affiliation.id = assignment.affiliation_id
+          WHERE affiliation.tenant_id = v_tenant_id
+            AND affiliation.person_id = v_operation.source_person_id
+            AND encode(
+              digest(convert_to(to_jsonb(assignment)::text, 'UTF8'), 'sha256'), 'hex'
+            ) = v_item.row_fingerprint
+        ) INTO v_item_current;
+      WHEN 'accounts' THEN
+        SELECT EXISTS (
+          SELECT 1
+          FROM (
+            SELECT DISTINCT account.id, account.status, account.membership_version,
+              account.security_version, account.updated_at
+            FROM public.accounts AS account
+            INNER JOIN public.account_links AS link ON link.account_id = account.id
+            WHERE link.tenant_id = v_tenant_id
+              AND link.person_id = v_operation.source_person_id
+          ) AS account_row
+          WHERE encode(
+            digest(convert_to(to_jsonb(account_row)::text, 'UTF8'), 'sha256'), 'hex'
+          ) = v_item.row_fingerprint
+        ) INTO v_item_current;
+      WHEN 'account_sessions' THEN
+        SELECT EXISTS (
+          SELECT 1
+          FROM (
+            SELECT DISTINCT session.id, session.account_id, session.status,
+              session.security_version, session.expires_at, session.updated_at
+            FROM public.account_sessions AS session
+            INNER JOIN public.account_links AS link ON link.account_id = session.account_id
+            WHERE link.tenant_id = v_tenant_id
+              AND link.person_id = v_operation.source_person_id
+          ) AS session_row
+          WHERE encode(
+            digest(convert_to(to_jsonb(session_row)::text, 'UTF8'), 'sha256'), 'hex'
+          ) = v_item.row_fingerprint
+        ) INTO v_item_current;
+      WHEN 'grades' THEN
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.people AS person
+          INNER JOIN public.enrollments AS enrollment
+            ON enrollment.tenant_id = person.tenant_id
+            AND enrollment.student_id = person.legacy_student_id
+          INNER JOIN public.grades AS grade_row
+            ON grade_row.tenant_id = enrollment.tenant_id
+            AND grade_row.enrollment_id = enrollment.id
+          WHERE person.tenant_id = v_tenant_id
+            AND person.id = v_operation.source_person_id
+            AND encode(
+              digest(convert_to(to_jsonb(grade_row)::text, 'UTF8'), 'sha256'), 'hex'
+            ) = v_item.row_fingerprint
+        ) INTO v_item_current;
+      ELSE
+        RAISE EXCEPTION 'PERSON_MERGE_DERIVED_DEPENDENCY_UNREVIEWED'
+          USING ERRCODE = '22023';
+    END CASE;
+    IF NOT v_item_current THEN
+      RAISE EXCEPTION 'PERSON_MERGE_DERIVED_DEPENDENCY_CHANGED'
+        USING ERRCODE = '40001';
+    END IF;
+  END LOOP;
+
+  SELECT count(*)::integer INTO v_preview_count
+  FROM public.person_merge_preview_items AS item
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.metadata->>'kind' = 'derived_dependency';
+  SELECT
+    (SELECT count(*) FROM public.role_template_assignments AS assignment
+      INNER JOIN public.affiliations AS affiliation
+        ON affiliation.tenant_id = assignment.tenant_id
+        AND affiliation.id = assignment.affiliation_id
+      WHERE affiliation.tenant_id = v_tenant_id
+        AND affiliation.person_id = v_operation.source_person_id)
+    + (SELECT count(DISTINCT account.id) FROM public.accounts AS account
+      INNER JOIN public.account_links AS link ON link.account_id = account.id
+      WHERE link.tenant_id = v_tenant_id
+        AND link.person_id = v_operation.source_person_id)
+    + (SELECT count(DISTINCT session.id) FROM public.account_sessions AS session
+      INNER JOIN public.account_links AS link ON link.account_id = session.account_id
+      WHERE link.tenant_id = v_tenant_id
+        AND link.person_id = v_operation.source_person_id)
+    + (SELECT count(*) FROM public.people AS person
+      INNER JOIN public.enrollments AS enrollment
+        ON enrollment.tenant_id = person.tenant_id
+        AND enrollment.student_id = person.legacy_student_id
+      INNER JOIN public.grades AS grade_row
+        ON grade_row.tenant_id = enrollment.tenant_id
+        AND grade_row.enrollment_id = enrollment.id
+      WHERE person.tenant_id = v_tenant_id
+        AND person.id = v_operation.source_person_id)
+  INTO v_current_count;
+  IF v_current_count <> v_preview_count THEN
+    RAISE EXCEPTION 'PERSON_MERGE_DERIVED_DEPENDENCY_SET_CHANGED'
+      USING ERRCODE = '40001';
+  END IF;
+
+  SELECT
+    EXISTS (
+      SELECT 1 FROM public.account_links AS source
+      INNER JOIN public.account_links AS target
+        ON target.tenant_id = source.tenant_id AND target.account_id = source.account_id
+        AND target.person_id = v_operation.target_person_id
+        AND target.status IN ('pending', 'active', 'suspended')
+      WHERE source.tenant_id = v_tenant_id
+        AND source.person_id = v_operation.source_person_id
+        AND source.status IN ('pending', 'active', 'suspended')
+    ) OR EXISTS (
+      SELECT 1 FROM public.affiliations AS source
+      INNER JOIN public.affiliations AS target
+        ON target.tenant_id = source.tenant_id AND target.person_id = v_operation.target_person_id
+        AND target.kind = source.kind AND target.scope_type = source.scope_type
+        AND target.education_organization_id IS NOT DISTINCT FROM source.education_organization_id
+        AND target.school_id IS NOT DISTINCT FROM source.school_id
+        AND target.class_id IS NOT DISTINCT FROM source.class_id
+        AND target.status IN ('active', 'suspended')
+      WHERE source.tenant_id = v_tenant_id
+        AND source.person_id = v_operation.source_person_id
+        AND source.status IN ('active', 'suspended')
+    ) OR EXISTS (
+      SELECT 1 FROM public.household_memberships AS source
+      INNER JOIN public.household_memberships AS target
+        ON target.tenant_id = source.tenant_id AND target.household_id = source.household_id
+        AND target.person_id = v_operation.target_person_id AND target.status = 'active'
+      WHERE source.tenant_id = v_tenant_id
+        AND source.person_id = v_operation.source_person_id AND source.status = 'active'
+    ) OR EXISTS (
+      SELECT 1 FROM public.school_enrollments AS source
+      INNER JOIN public.school_enrollments AS target
+        ON target.tenant_id = source.tenant_id AND target.school_id = source.school_id
+        AND target.person_id = v_operation.target_person_id
+        AND target.enrollment_type = source.enrollment_type AND target.status = 'enrolled'
+      WHERE source.tenant_id = v_tenant_id
+        AND source.person_id = v_operation.source_person_id AND source.status = 'enrolled'
+    ) OR EXISTS (
+      SELECT 1 FROM public.section_staff_assignments AS source
+      INNER JOIN public.section_staff_assignments AS target
+        ON target.tenant_id = source.tenant_id AND target.section_id = source.section_id
+        AND target.person_id = v_operation.target_person_id
+        AND target.role = source.role AND target.status = 'active'
+      WHERE source.tenant_id = v_tenant_id
+        AND source.person_id = v_operation.source_person_id AND source.status = 'active'
+    ) OR EXISTS (
+      SELECT 1 FROM public.section_roster_memberships AS source
+      INNER JOIN public.section_roster_memberships AS target
+        ON target.tenant_id = source.tenant_id AND target.section_id = source.section_id
+        AND target.person_id = v_operation.target_person_id AND target.status = 'active'
+      WHERE source.tenant_id = v_tenant_id
+        AND source.person_id = v_operation.source_person_id AND source.status = 'active'
+    )
+  INTO v_target_conflict;
+  IF v_target_conflict THEN
+    RAISE EXCEPTION 'PERSON_MERGE_TARGET_CONFLICT_CHANGED' USING ERRCODE = '40001';
+  END IF;
+END
+$function$;
+--> statement-breakpoint
+ALTER FUNCTION "openschool_private"."assert_person_merge_plan_v2_current"(uuid)
+  OWNER TO "openschool_person_merge_manager";
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."assert_person_merge_plan_v2_current"(uuid)
+  FROM PUBLIC, "openschool_runtime";
+--> statement-breakpoint
+ALTER FUNCTION "openschool_private"."approve_person_merge_preview"(
+  uuid, integer, text, text
+) RENAME TO "approve_person_merge_preview_v1";
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."approve_person_merge_preview_v1"(
+  uuid, integer, text, text
+) FROM PUBLIC, "openschool_runtime";
+--> statement-breakpoint
+CREATE FUNCTION "openschool_private"."approve_person_merge_preview"(
+  p_operation_id uuid,
+  p_expected_operation_version integer,
+  p_expected_preview_digest text,
+  p_reason text
+)
+RETURNS TABLE (
+  operation_id uuid,
+  status text,
+  version integer,
+  preview_digest text,
+  approved_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, openschool_private
+SET timezone = 'UTC'
+AS $function$
+DECLARE
+  v_approval record;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.person_merge_operations AS operation
+    WHERE operation.tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+      AND operation.id = p_operation_id
+      AND operation.plan_version = 2
+  ) THEN
+    RAISE EXCEPTION 'PERSON_MERGE_PLAN_VERSION_UNSUPPORTED' USING ERRCODE = '40001';
+  END IF;
+
+  SELECT * INTO v_approval
+  FROM openschool_private.approve_person_merge_preview_v1(
+    p_operation_id, p_expected_operation_version, p_expected_preview_digest, p_reason
+  );
+  PERFORM openschool_private.assert_person_merge_plan_v2_current(p_operation_id);
+  RETURN QUERY SELECT v_approval.operation_id, v_approval.status, v_approval.version,
+    v_approval.preview_digest, v_approval.approved_at;
+END
+$function$;
+--> statement-breakpoint
+ALTER FUNCTION "openschool_private"."approve_person_merge_preview"(
+  uuid, integer, text, text
+) OWNER TO "openschool_person_merge_manager";
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."approve_person_merge_preview"(
+  uuid, integer, text, text
+) FROM PUBLIC;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION "openschool_private"."approve_person_merge_preview"(
+  uuid, integer, text, text
+) TO "openschool_runtime";
+--> statement-breakpoint
+DO $verification$
+BEGIN
+  IF has_function_privilege(
+    'openschool_runtime',
+    'openschool_private.create_person_merge_preview_v1(uuid,integer,uuid,uuid,text)',
+    'EXECUTE'
+  ) OR has_function_privilege(
+    'openschool_runtime',
+    'openschool_private.finalize_person_merge_preview_v2(uuid,text)',
+    'EXECUTE'
+  ) OR has_function_privilege(
+    'openschool_runtime',
+    'openschool_private.approve_person_merge_preview_v1(uuid,integer,text,text)',
+    'EXECUTE'
+  ) OR has_function_privilege(
+    'openschool_runtime',
+    'openschool_private.assert_person_merge_plan_v2_current(uuid)',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'Person merge plan v2 implementation helpers are exposed';
+  END IF;
+END
+$verification$;

--- a/packages/db/migrations/0043_person_merge_plan_v2.sql
+++ b/packages/db/migrations/0043_person_merge_plan_v2.sql
@@ -181,6 +181,106 @@ BEGIN
 
   PERFORM set_config('app.merge_source_person_id', v_operation.source_person_id::text, true);
 
+  -- Version 1 discovers every Person foreign key. Version 2 distinguishes current facts that
+  -- must move from terminal evidence that must remain attached to the historical Person.
+  UPDATE public.person_merge_preview_items AS item
+  SET disposition = 'preserve_history', conflict_code = NULL,
+    metadata = item.metadata || jsonb_build_object('lifecycle', 'terminal')
+  FROM public.account_links AS link
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.relation_name = 'account_links'
+    AND link.tenant_id = v_tenant_id AND link.person_id = v_operation.source_person_id
+    AND link.status IN ('revoked', 'expired')
+    AND encode(digest(convert_to(to_jsonb(link)::text, 'UTF8'), 'sha256'), 'hex')
+      = item.row_fingerprint;
+
+  UPDATE public.person_merge_preview_items AS item
+  SET disposition = 'preserve_history', conflict_code = NULL,
+    metadata = item.metadata || jsonb_build_object('lifecycle', 'terminal')
+  FROM public.affiliations AS affiliation
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.relation_name = 'affiliations'
+    AND affiliation.tenant_id = v_tenant_id
+    AND affiliation.person_id = v_operation.source_person_id
+    AND affiliation.status = 'revoked'
+    AND encode(digest(convert_to(to_jsonb(affiliation)::text, 'UTF8'), 'sha256'), 'hex')
+      = item.row_fingerprint;
+
+  UPDATE public.person_merge_preview_items AS item
+  SET disposition = 'preserve_history', conflict_code = NULL,
+    metadata = item.metadata || jsonb_build_object('lifecycle', 'terminal')
+  FROM public.person_relationships AS relationship
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.relation_name = 'person_relationships'
+    AND relationship.tenant_id = v_tenant_id AND relationship.status = 'revoked'
+    AND v_operation.source_person_id IN (
+      relationship.subject_person_id, relationship.related_person_id
+    )
+    AND encode(digest(convert_to(to_jsonb(relationship)::text, 'UTF8'), 'sha256'), 'hex')
+      = item.row_fingerprint;
+
+  UPDATE public.person_merge_preview_items AS item
+  SET disposition = 'preserve_history', conflict_code = NULL,
+    metadata = item.metadata || jsonb_build_object('lifecycle', 'terminal')
+  FROM public.household_memberships AS membership
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.relation_name = 'household_memberships'
+    AND membership.tenant_id = v_tenant_id
+    AND membership.person_id = v_operation.source_person_id
+    AND membership.status = 'ended'
+    AND encode(digest(convert_to(to_jsonb(membership)::text, 'UTF8'), 'sha256'), 'hex')
+      = item.row_fingerprint;
+
+  UPDATE public.person_merge_preview_items AS item
+  SET disposition = 'preserve_history', conflict_code = NULL,
+    metadata = item.metadata || jsonb_build_object('lifecycle', 'terminal')
+  FROM public.school_enrollments AS enrollment
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.relation_name = 'school_enrollments'
+    AND enrollment.tenant_id = v_tenant_id
+    AND enrollment.person_id = v_operation.source_person_id
+    AND enrollment.status <> 'enrolled'
+    AND encode(digest(convert_to(to_jsonb(enrollment)::text, 'UTF8'), 'sha256'), 'hex')
+      = item.row_fingerprint;
+
+  UPDATE public.person_merge_preview_items AS item
+  SET disposition = 'preserve_history', conflict_code = NULL,
+    metadata = item.metadata || jsonb_build_object('lifecycle', 'terminal')
+  FROM public.section_staff_assignments AS assignment
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.relation_name = 'section_staff_assignments'
+    AND assignment.tenant_id = v_tenant_id
+    AND assignment.person_id = v_operation.source_person_id
+    AND assignment.status = 'ended'
+    AND encode(digest(convert_to(to_jsonb(assignment)::text, 'UTF8'), 'sha256'), 'hex')
+      = item.row_fingerprint;
+
+  UPDATE public.person_merge_preview_items AS item
+  SET disposition = 'preserve_history', conflict_code = NULL,
+    metadata = item.metadata || jsonb_build_object('lifecycle', 'terminal')
+  FROM public.section_roster_memberships AS membership
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.relation_name = 'section_roster_memberships'
+    AND membership.tenant_id = v_tenant_id
+    AND membership.person_id = v_operation.source_person_id
+    AND membership.status = 'ended'
+    AND encode(digest(convert_to(to_jsonb(membership)::text, 'UTF8'), 'sha256'), 'hex')
+      = item.row_fingerprint;
+
+  UPDATE public.person_merge_preview_items AS item
+  SET disposition = CASE WHEN invitation.status = 'pending'
+      THEN 'block' ELSE 'preserve_history' END,
+    conflict_code = CASE WHEN invitation.status = 'pending'
+      THEN 'PENDING_INVITATION_REQUIRES_RESOLUTION' ELSE NULL END,
+    metadata = item.metadata || jsonb_build_object('lifecycle', invitation.status)
+  FROM public.account_invitations AS invitation
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.relation_name = 'account_invitations'
+    AND invitation.tenant_id = v_tenant_id
+    AND invitation.person_id = v_operation.source_person_id
+    AND encode(digest(convert_to(to_jsonb(invitation)::text, 'UTF8'), 'sha256'), 'hex')
+      = item.row_fingerprint;
+
   INSERT INTO public.person_merge_preview_items (
     tenant_id, review_school_id, operation_id, category, relation_name, record_key,
     direction, disposition, row_fingerprint, metadata, created_at

--- a/packages/db/migrations/0044_person_merge_execution.sql
+++ b/packages/db/migrations/0044_person_merge_execution.sql
@@ -1,0 +1,783 @@
+ALTER TABLE "person_duplicate_case_events" DROP CONSTRAINT "person_duplicate_case_events_type_check";--> statement-breakpoint
+ALTER TABLE "person_duplicate_case_events" ADD CONSTRAINT "person_duplicate_case_events_type_check" CHECK ("person_duplicate_case_events"."event_type" IN ('candidate_detected', 'evidence_refreshed', 'evidence_no_longer_matches', 'marked_distinct', 'merge_approval_requested', 'merge_executed'));
+--> statement-breakpoint
+-- Execution is deliberately owned by the existing NOLOGIN merge manager. The runtime may call
+-- only the reviewed entry point; it never inherits the manager or receives table write grants.
+GRANT UPDATE ON TABLE "accounts", "account_sessions"
+  TO "openschool_person_merge_manager";
+--> statement-breakpoint
+GRANT INSERT ON TABLE "person_duplicate_case_events", "audit_events", "audit_outbox"
+  TO "openschool_person_merge_manager";
+--> statement-breakpoint
+ALTER POLICY "people_person_merge_manager_select" ON "people" USING (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.preview', 'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+);
+--> statement-breakpoint
+ALTER POLICY "people_person_merge_manager_lock" ON "people" USING (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND nullif(current_setting('app.policy_capability', true), '') IN (
+    'tenant.people_merges.preview', 'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
+  )
+) WITH CHECK (
+  session_user = 'openschool_runtime'
+  AND current_user = 'openschool_person_merge_manager'
+  AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+  AND nullif(current_setting('app.policy_capability', true), '')
+    = 'tenant.people_merges.execute'
+);
+--> statement-breakpoint
+ALTER POLICY "person_duplicate_cases_person_merge_manager_lock"
+  ON "person_duplicate_cases" USING (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND nullif(current_setting('app.policy_capability', true), '') IN (
+      'tenant.people_merges.preview', 'tenant.people_merges.approve',
+      'tenant.people_merges.execute'
+    )
+    AND public.openschool_school_scope_allows(tenant_id, review_school_id)
+  ) WITH CHECK (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND nullif(current_setting('app.policy_capability', true), '')
+      = 'tenant.people_merges.execute'
+    AND public.openschool_school_scope_allows(tenant_id, review_school_id)
+  );
+--> statement-breakpoint
+CREATE POLICY "person_duplicate_case_events_person_merge_manager_insert"
+  ON "person_duplicate_case_events" AS PERMISSIVE FOR INSERT
+  TO "openschool_person_merge_manager" WITH CHECK (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND event_type = 'merge_executed'
+    AND actor_account_id = nullif(current_setting('app.account_id', true), '')::uuid
+    AND public.openschool_school_scope_allows(tenant_id, review_school_id)
+  );
+--> statement-breakpoint
+CREATE POLICY "accounts_person_merge_manager_update" ON "accounts"
+  AS PERMISSIVE FOR UPDATE TO "openschool_person_merge_manager" USING (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND nullif(current_setting('app.policy_capability', true), '')
+      = 'tenant.people_merges.execute'
+    AND EXISTS (
+      SELECT 1 FROM public.account_links AS link
+      WHERE link.account_id = accounts.id
+        AND link.tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+        AND link.person_id = nullif(
+          current_setting('app.merge_source_person_id', true), ''
+        )::uuid
+    )
+  ) WITH CHECK (true);
+--> statement-breakpoint
+CREATE POLICY "account_sessions_person_merge_manager_update" ON "account_sessions"
+  AS PERMISSIVE FOR UPDATE TO "openschool_person_merge_manager" USING (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND nullif(current_setting('app.policy_capability', true), '')
+      = 'tenant.people_merges.execute'
+    AND EXISTS (
+      SELECT 1 FROM public.account_links AS link
+      WHERE link.account_id = account_sessions.account_id
+        AND link.tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+        AND link.person_id = nullif(
+          current_setting('app.merge_source_person_id', true), ''
+        )::uuid
+    )
+  ) WITH CHECK (true);
+--> statement-breakpoint
+CREATE POLICY "audit_events_person_merge_manager_insert" ON "audit_events"
+  AS PERMISSIVE FOR INSERT TO "openschool_person_merge_manager" WITH CHECK (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND actor_type = 'account'
+    AND actor_account_id = nullif(current_setting('app.account_id', true), '')::uuid
+    AND actor_person_id = nullif(current_setting('app.person_id', true), '')::uuid
+    AND request_id = nullif(current_setting('app.request_id', true), '')
+    AND correlation_id = nullif(current_setting('app.correlation_id', true), '')
+    AND capability = 'tenant.people_merges.execute'
+    AND event_type = 'person.merge.execute'
+    AND target_type = 'person_merge_operation'
+    AND source = 'web'
+  );
+--> statement-breakpoint
+CREATE POLICY "audit_outbox_person_merge_manager_insert" ON "audit_outbox"
+  AS PERMISSIVE FOR INSERT TO "openschool_person_merge_manager" WITH CHECK (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND context ->> 'actorAccountId' = nullif(current_setting('app.account_id', true), '')
+    AND context ->> 'actorPersonId' = nullif(current_setting('app.person_id', true), '')
+    AND context ->> 'requestId' = nullif(current_setting('app.request_id', true), '')
+    AND correlation_id = nullif(current_setting('app.correlation_id', true), '')
+    AND topic = 'audit.event.committed'
+    AND payload ->> 'eventType' = 'person.merge.execute'
+  );
+--> statement-breakpoint
+DO $policies$
+DECLARE
+  v_relation record;
+  v_select_policy text;
+  v_update_policy text;
+BEGIN
+  FOR v_relation IN
+    SELECT DISTINCT child.oid, child.relname
+    FROM pg_constraint AS constraint_row
+    INNER JOIN pg_class AS child ON child.oid = constraint_row.conrelid
+    INNER JOIN pg_namespace AS child_namespace ON child_namespace.oid = child.relnamespace
+    WHERE constraint_row.contype = 'f'
+      AND constraint_row.confrelid = 'public.people'::regclass
+      AND child_namespace.nspname = 'public'
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_inherits AS inheritance
+        WHERE inheritance.inhrelid = child.oid
+      )
+      AND child.relname NOT IN (
+        'person_merge_operations', 'person_merge_preview_items', 'person_merge_events',
+        'person_merge_aliases', 'person_merge_moves'
+      )
+    ORDER BY child.relname
+  LOOP
+    v_select_policy := left(v_relation.relname || '_person_merge_manager_select', 63);
+    v_update_policy := left(v_relation.relname || '_person_merge_manager_update', 63);
+    IF EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = v_relation.relname
+        AND policyname = v_select_policy
+    ) THEN
+      EXECUTE format(
+        'ALTER POLICY %I ON public.%I USING (session_user = ''openschool_runtime'' AND current_user = ''openschool_person_merge_manager'' AND tenant_id = nullif(current_setting(''app.tenant_id'', true), '''')::uuid AND nullif(current_setting(''app.policy_capability'', true), '''') IN (''tenant.people_merges.preview'', ''tenant.people_merges.approve'', ''tenant.people_merges.execute''))',
+        v_select_policy, v_relation.relname
+      );
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = v_relation.relname
+        AND policyname = v_update_policy
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY %I ON public.%I AS PERMISSIVE FOR UPDATE TO openschool_person_merge_manager USING (session_user = ''openschool_runtime'' AND current_user = ''openschool_person_merge_manager'' AND tenant_id = nullif(current_setting(''app.tenant_id'', true), '''')::uuid AND nullif(current_setting(''app.policy_capability'', true), '''') = ''tenant.people_merges.execute'') WITH CHECK (session_user = ''openschool_runtime'' AND current_user = ''openschool_person_merge_manager'' AND tenant_id = nullif(current_setting(''app.tenant_id'', true), '''')::uuid AND nullif(current_setting(''app.policy_capability'', true), '''') = ''tenant.people_merges.execute'')',
+        v_update_policy, v_relation.relname
+      );
+    END IF;
+    EXECUTE format(
+      'GRANT UPDATE ON TABLE public.%I TO openschool_person_merge_manager',
+      v_relation.relname
+    );
+  END LOOP;
+END
+$policies$;
+--> statement-breakpoint
+-- Every new operational Person reference locks the Person row. A merge holds the source row
+-- until commit, so a concurrent writer wakes against the archived version and fails closed.
+CREATE FUNCTION "openschool_private"."guard_operational_person_reference"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+  v_person_id uuid;
+  v_status text;
+BEGIN
+  IF TG_NARGS <> 1 OR TG_ARGV[0] !~ '^[a-z][a-z0-9_]{0,62}$' THEN
+    RAISE EXCEPTION 'PERSON_REFERENCE_GUARD_INVALID' USING ERRCODE = '22023';
+  END IF;
+  v_person_id := nullif(to_jsonb(NEW) ->> TG_ARGV[0], '')::uuid;
+  IF v_person_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+  SELECT person.status INTO v_status
+  FROM public.people AS person
+  WHERE person.tenant_id = NEW.tenant_id AND person.id = v_person_id
+  FOR SHARE;
+  IF NOT FOUND OR v_status NOT IN ('active', 'suspended') THEN
+    RAISE EXCEPTION 'PERSON_REFERENCE_NOT_OPERATIONAL' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."guard_operational_person_reference"()
+  FROM PUBLIC;
+--> statement-breakpoint
+DO $triggers$
+DECLARE
+  v_guard record;
+  v_trigger_name text;
+BEGIN
+  FOR v_guard IN
+    SELECT * FROM (VALUES
+      ('account_links', 'person_id'),
+      ('contact_profiles', 'person_id'),
+      ('student_profiles', 'person_id'),
+      ('guardian_profiles', 'person_id'),
+      ('employee_profiles', 'person_id'),
+      ('teacher_profiles', 'person_id'),
+      ('affiliations', 'person_id'),
+      ('person_relationships', 'subject_person_id'),
+      ('person_relationships', 'related_person_id'),
+      ('household_memberships', 'person_id'),
+      ('school_enrollments', 'person_id'),
+      ('section_staff_assignments', 'person_id'),
+      ('section_roster_memberships', 'person_id'),
+      ('account_invitations', 'person_id')
+    ) AS guard(relation_name, column_name)
+  LOOP
+    v_trigger_name := left(
+      v_guard.relation_name || '_' || v_guard.column_name || '_operational_guard', 63
+    );
+    EXECUTE format(
+      'CREATE TRIGGER %I BEFORE INSERT OR UPDATE OF %I ON public.%I FOR EACH ROW EXECUTE FUNCTION openschool_private.guard_operational_person_reference(%L)',
+      v_trigger_name, v_guard.column_name, v_guard.relation_name, v_guard.column_name
+    );
+  END LOOP;
+END
+$triggers$;
+--> statement-breakpoint
+CREATE FUNCTION "openschool_private"."execute_person_merge"(
+  p_operation_id uuid,
+  p_expected_operation_version integer,
+  p_expected_preview_digest text,
+  p_reason text
+)
+RETURNS TABLE (
+  operation_id uuid,
+  status text,
+  version integer,
+  execution_digest text,
+  invalidation_count integer,
+  executed_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, extensions, public
+SET timezone = 'UTC'
+AS $function$
+DECLARE
+  v_tenant_id uuid := nullif(current_setting('app.tenant_id', true), '')::uuid;
+  v_account_id uuid := nullif(current_setting('app.account_id', true), '')::uuid;
+  v_person_id uuid := nullif(current_setting('app.person_id', true), '')::uuid;
+  v_request_id text := nullif(current_setting('app.request_id', true), '');
+  v_correlation_id text := nullif(current_setting('app.correlation_id', true), '');
+  v_policy_version text := nullif(current_setting('app.policy_version', true), '');
+  v_reauthenticated_at timestamptz :=
+    nullif(current_setting('app.reauthenticated_at', true), '')::timestamptz;
+  v_operation public.person_merge_operations%ROWTYPE;
+  v_case public.person_duplicate_cases%ROWTYPE;
+  v_item record;
+  v_account_record record;
+  v_session_record record;
+  v_changed_count integer;
+  v_sequence integer := 0;
+  v_invalidation_count integer := 0;
+  v_next_version integer;
+  v_case_next_version integer;
+  v_before_fingerprint text;
+  v_after_fingerprint text;
+  v_execution_digest text;
+  v_audit_event_id uuid := gen_random_uuid();
+  v_audit_outbox_id uuid := gen_random_uuid();
+  v_now timestamptz := clock_timestamp();
+BEGIN
+  IF session_user <> 'openschool_runtime'
+    OR current_user <> 'openschool_person_merge_manager'
+    OR nullif(current_setting('app.policy_capability', true), '')
+      <> 'tenant.people_merges.execute'
+    OR nullif(current_setting('app.assurance_level', true), '') <> 'aal2'
+    OR v_tenant_id IS NULL OR v_account_id IS NULL OR v_person_id IS NULL
+    OR v_request_id IS NULL OR v_correlation_id IS NULL OR v_policy_version IS NULL
+    OR v_reauthenticated_at IS NULL
+    OR v_reauthenticated_at < statement_timestamp() - interval '15 minutes'
+    OR v_reauthenticated_at > statement_timestamp() + interval '1 minute'
+    OR p_operation_id IS NULL OR p_expected_operation_version IS NULL
+    OR p_expected_operation_version < 1
+    OR p_expected_preview_digest IS NULL
+    OR p_expected_preview_digest !~ '^[0-9a-f]{64}$'
+    OR p_reason IS NULL OR char_length(btrim(p_reason)) NOT BETWEEN 3 AND 512
+  THEN
+    RAISE EXCEPTION 'PERSON_MERGE_EXECUTION_CONTEXT_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT operation.* INTO v_operation
+  FROM public.person_merge_operations AS operation
+  WHERE operation.tenant_id = v_tenant_id AND operation.id = p_operation_id
+    AND public.openschool_school_scope_allows(
+      operation.tenant_id, operation.review_school_id
+    );
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PERSON_MERGE_OPERATION_NOT_FOUND' USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(
+      v_tenant_id::text || ':' || least(
+        v_operation.source_person_id, v_operation.target_person_id
+      )::text || ':' || greatest(
+        v_operation.source_person_id, v_operation.target_person_id
+      )::text,
+      0
+    )
+  );
+
+  -- Merges are rare and identity-sensitive. A brief fixed-order table lock prevents phantom
+  -- target conflicts and makes the approved fingerprint set stable through commit.
+  LOCK TABLE public.accounts, public.account_sessions, public.account_links,
+    public.contact_profiles, public.student_profiles, public.guardian_profiles,
+    public.employee_profiles, public.teacher_profiles, public.affiliations,
+    public.person_relationships, public.household_memberships, public.school_enrollments,
+    public.section_staff_assignments, public.section_roster_memberships,
+    public.account_invitations IN SHARE ROW EXCLUSIVE MODE;
+
+  SELECT operation.* INTO v_operation
+  FROM public.person_merge_operations AS operation
+  WHERE operation.tenant_id = v_tenant_id AND operation.id = p_operation_id
+    AND public.openschool_school_scope_allows(
+      operation.tenant_id, operation.review_school_id
+    )
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PERSON_MERGE_OPERATION_NOT_FOUND' USING ERRCODE = '42501';
+  END IF;
+  IF v_operation.status <> 'approved'
+    OR v_operation.plan_version <> 2
+    OR v_operation.current_version <> p_expected_operation_version
+    OR v_operation.preview_digest <> p_expected_preview_digest
+    OR v_operation.conflict_count <> 0
+    OR v_operation.executed_at IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'PERSON_MERGE_APPROVAL_CHANGED' USING ERRCODE = '40001';
+  END IF;
+
+  SELECT duplicate_case.* INTO v_case
+  FROM public.person_duplicate_cases AS duplicate_case
+  WHERE duplicate_case.tenant_id = v_tenant_id
+    AND duplicate_case.id = v_operation.duplicate_case_id
+  FOR UPDATE;
+  IF NOT FOUND
+    OR v_case.status <> 'merge_approval_requested'
+    OR v_case.current_version <> v_operation.duplicate_case_version
+    OR v_case.current_evidence_hash <> v_operation.duplicate_evidence_hash
+  THEN
+    RAISE EXCEPTION 'PERSON_MERGE_CASE_CHANGED' USING ERRCODE = '40001';
+  END IF;
+
+  PERFORM 1
+  FROM public.people AS person
+  WHERE person.tenant_id = v_tenant_id
+    AND person.id IN (v_operation.source_person_id, v_operation.target_person_id)
+    AND person.status IN ('active', 'suspended')
+  ORDER BY person.id
+  FOR UPDATE;
+  IF NOT FOUND OR (
+    SELECT count(*) FROM public.people AS person
+    WHERE person.tenant_id = v_tenant_id
+      AND person.id IN (v_operation.source_person_id, v_operation.target_person_id)
+      AND person.status IN ('active', 'suspended')
+  ) <> 2 THEN
+    RAISE EXCEPTION 'PERSON_MERGE_PERSON_CHANGED' USING ERRCODE = '40001';
+  END IF;
+
+  PERFORM set_config(
+    'app.merge_source_person_id', v_operation.source_person_id::text, true
+  );
+  PERFORM openschool_private.assert_person_merge_plan_v2_current(p_operation_id);
+
+  -- Invalidate identity caches and active sessions before moving Account links.
+  FOR v_item IN
+    SELECT item.*
+    FROM public.person_merge_preview_items AS item
+    WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+      AND item.relation_name = 'accounts'
+      AND item.metadata->>'kind' = 'derived_dependency'
+    ORDER BY item.record_key
+  LOOP
+    SELECT account_row.* INTO v_account_record
+    FROM (
+      SELECT account.id, account.status, account.membership_version,
+        account.security_version, account.updated_at
+      FROM public.accounts AS account
+      WHERE EXISTS (
+        SELECT 1 FROM public.account_links AS link
+        WHERE link.account_id = account.id AND link.tenant_id = v_tenant_id
+          AND link.person_id = v_operation.source_person_id
+      )
+    ) AS account_row
+    WHERE encode(
+      digest(convert_to(to_jsonb(account_row)::text, 'UTF8'), 'sha256'), 'hex'
+    ) = v_item.row_fingerprint;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'PERSON_MERGE_ACCOUNT_CHANGED' USING ERRCODE = '40001';
+    END IF;
+    PERFORM 1 FROM public.accounts WHERE id = v_account_record.id FOR UPDATE;
+    UPDATE public.accounts AS account
+    SET membership_version = account.membership_version + 1,
+      security_version = account.security_version + 1, updated_at = v_now
+    WHERE account.id = v_account_record.id;
+    SELECT encode(
+      digest(convert_to(to_jsonb(account_row)::text, 'UTF8'), 'sha256'), 'hex'
+    ) INTO v_after_fingerprint
+    FROM (
+      SELECT account.id, account.status, account.membership_version,
+        account.security_version, account.updated_at
+      FROM public.accounts AS account WHERE account.id = v_account_record.id
+    ) AS account_row;
+    v_sequence := v_sequence + 1;
+    INSERT INTO public.person_merge_moves (
+      tenant_id, review_school_id, operation_id, sequence, relation_name,
+      source_record_key, replacement_record_key, action, before_fingerprint,
+      after_fingerprint, created_at
+    ) VALUES (
+      v_tenant_id, v_operation.review_school_id, p_operation_id, v_sequence,
+      'accounts', v_item.record_key, NULL, 'invalidate', v_item.row_fingerprint,
+      v_after_fingerprint, v_now
+    );
+  END LOOP;
+
+  FOR v_item IN
+    SELECT item.*
+    FROM public.person_merge_preview_items AS item
+    WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+      AND item.relation_name = 'account_sessions'
+      AND item.metadata->>'kind' = 'derived_dependency'
+    ORDER BY item.record_key
+  LOOP
+    SELECT session_row.* INTO v_session_record
+    FROM (
+      SELECT session.id, session.account_id, session.status,
+        session.security_version, session.expires_at, session.updated_at
+      FROM public.account_sessions AS session
+      WHERE EXISTS (
+        SELECT 1 FROM public.account_links AS link
+        WHERE link.account_id = session.account_id AND link.tenant_id = v_tenant_id
+          AND link.person_id = v_operation.source_person_id
+      )
+    ) AS session_row
+    WHERE encode(
+      digest(convert_to(to_jsonb(session_row)::text, 'UTF8'), 'sha256'), 'hex'
+    ) = v_item.row_fingerprint;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'PERSON_MERGE_SESSION_CHANGED' USING ERRCODE = '40001';
+    END IF;
+    PERFORM 1 FROM public.account_sessions
+    WHERE id = v_session_record.id FOR UPDATE;
+    IF v_session_record.status = 'active' THEN
+      UPDATE public.account_sessions AS session
+      SET status = 'revoked', revoked_at = v_now,
+        revoked_by_account_id = v_account_id,
+        revocation_reason = 'Person merge execution', updated_at = v_now
+      WHERE session.id = v_session_record.id;
+      v_invalidation_count := v_invalidation_count + 1;
+    END IF;
+    SELECT encode(
+      digest(convert_to(to_jsonb(session_row)::text, 'UTF8'), 'sha256'), 'hex'
+    ) INTO v_after_fingerprint
+    FROM (
+      SELECT session.id, session.account_id, session.status,
+        session.security_version, session.expires_at, session.updated_at
+      FROM public.account_sessions AS session WHERE session.id = v_session_record.id
+    ) AS session_row;
+    v_sequence := v_sequence + 1;
+    INSERT INTO public.person_merge_moves (
+      tenant_id, review_school_id, operation_id, sequence, relation_name,
+      source_record_key, replacement_record_key, action, before_fingerprint,
+      after_fingerprint, created_at
+    ) VALUES (
+      v_tenant_id, v_operation.review_school_id, p_operation_id, v_sequence,
+      'account_sessions', v_item.record_key, NULL,
+      CASE WHEN v_session_record.status = 'active' THEN 'invalidate' ELSE 'preserve_history' END,
+      v_item.row_fingerprint, v_after_fingerprint, v_now
+    );
+  END LOOP;
+
+  -- Repoint only reviewed operational dependencies. Dynamic identifiers come exclusively from
+  -- immutable preview metadata that was generated from PostgreSQL's FK catalog and revalidated.
+  FOR v_item IN
+    SELECT item.*
+    FROM public.person_merge_preview_items AS item
+    WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+      AND item.metadata ? 'column' AND item.disposition = 'end_and_recreate'
+    ORDER BY item.relation_name, item.record_key, item.direction
+  LOOP
+    IF v_item.relation_name !~ '^[a-z][a-z0-9_]{0,62}$'
+      OR v_item.metadata->>'column' !~ '^[a-z][a-z0-9_]{0,62}$'
+    THEN
+      RAISE EXCEPTION 'PERSON_MERGE_PREVIEW_METADATA_INVALID' USING ERRCODE = '22023';
+    END IF;
+    EXECUTE format(
+      'WITH before_row AS (SELECT source_row.ctid AS row_pointer, to_jsonb(source_row) AS before_json FROM public.%I AS source_row WHERE source_row.tenant_id = $1 AND source_row.%I = $2 AND encode(digest(convert_to(to_jsonb(source_row)::text, ''UTF8''), ''sha256''), ''hex'') = $3 FOR UPDATE), changed AS (UPDATE public.%I AS target_row SET %I = $4 FROM before_row WHERE target_row.ctid = before_row.row_pointer RETURNING before_row.before_json, to_jsonb(target_row) AS after_json) SELECT count(*)::integer, min(encode(digest(convert_to(before_json::text, ''UTF8''), ''sha256''), ''hex'')), min(encode(digest(convert_to(after_json::text, ''UTF8''), ''sha256''), ''hex'')) FROM changed',
+      v_item.relation_name, v_item.metadata->>'column',
+      v_item.relation_name, v_item.metadata->>'column'
+    ) INTO v_changed_count, v_before_fingerprint, v_after_fingerprint
+      USING v_tenant_id, v_operation.source_person_id,
+        v_item.row_fingerprint, v_operation.target_person_id;
+    IF v_changed_count <> 1 OR v_before_fingerprint <> v_item.row_fingerprint THEN
+      RAISE EXCEPTION 'PERSON_MERGE_DEPENDENCY_CHANGED' USING ERRCODE = '40001';
+    END IF;
+    v_sequence := v_sequence + 1;
+    INSERT INTO public.person_merge_moves (
+      tenant_id, review_school_id, operation_id, sequence, relation_name,
+      source_record_key, replacement_record_key, action, before_fingerprint,
+      after_fingerprint, created_at
+    ) VALUES (
+      v_tenant_id, v_operation.review_school_id, p_operation_id, v_sequence,
+      v_item.relation_name, v_item.record_key, v_after_fingerprint, 'repoint',
+      v_before_fingerprint, v_after_fingerprint, v_now
+    );
+  END LOOP;
+
+  -- Historical dependencies and the target anchor remain where they were; ledger entries prove
+  -- that preservation was an explicit reviewed action, not an omitted mutation.
+  FOR v_item IN
+    SELECT item.*
+    FROM public.person_merge_preview_items AS item
+    WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+      AND item.disposition <> 'block'
+      AND NOT (item.metadata ? 'column' AND item.disposition = 'end_and_recreate')
+      AND item.relation_name NOT IN (
+        'accounts', 'account_sessions', 'person_duplicate_cases'
+      )
+      AND NOT (
+        item.metadata->>'kind' = 'person_anchor'
+        AND item.metadata->>'personRole' = 'source'
+      )
+    ORDER BY item.relation_name, item.record_key, item.direction
+  LOOP
+    v_sequence := v_sequence + 1;
+    INSERT INTO public.person_merge_moves (
+      tenant_id, review_school_id, operation_id, sequence, relation_name,
+      source_record_key, replacement_record_key, action, before_fingerprint,
+      after_fingerprint, created_at
+    ) VALUES (
+      v_tenant_id, v_operation.review_school_id, p_operation_id, v_sequence,
+      v_item.relation_name, v_item.record_key, NULL, 'preserve_history',
+      v_item.row_fingerprint, v_item.row_fingerprint, v_now
+    );
+  END LOOP;
+
+  -- No reviewed operational reference may remain on the source. Table locks keep this assertion
+  -- stable through commit and the installed guards reject future references to the archived alias.
+  IF EXISTS (SELECT 1 FROM public.account_links WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.contact_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.student_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.guardian_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.employee_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.teacher_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.affiliations WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.person_relationships WHERE tenant_id = v_tenant_id AND (subject_person_id = v_operation.source_person_id OR related_person_id = v_operation.source_person_id))
+    OR EXISTS (SELECT 1 FROM public.household_memberships WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.school_enrollments WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.section_staff_assignments WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.section_roster_memberships WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.account_invitations WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+  THEN
+    RAISE EXCEPTION 'PERSON_MERGE_OPERATIONAL_REFERENCE_REMAINS' USING ERRCODE = '40001';
+  END IF;
+
+  SELECT item.row_fingerprint INTO v_before_fingerprint
+  FROM public.person_merge_preview_items AS item
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.metadata->>'kind' = 'person_anchor'
+    AND item.metadata->>'personRole' = 'source';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PERSON_MERGE_SOURCE_ANCHOR_MISSING' USING ERRCODE = '40001';
+  END IF;
+  UPDATE public.people AS person
+  SET status = 'archived', updated_at = v_now
+  WHERE person.tenant_id = v_tenant_id AND person.id = v_operation.source_person_id;
+  SELECT encode(
+    digest(convert_to(to_jsonb(person)::text, 'UTF8'), 'sha256'), 'hex'
+  ) INTO v_after_fingerprint
+  FROM public.people AS person
+  WHERE person.tenant_id = v_tenant_id AND person.id = v_operation.source_person_id;
+  v_sequence := v_sequence + 1;
+  INSERT INTO public.person_merge_moves (
+    tenant_id, review_school_id, operation_id, sequence, relation_name,
+    source_record_key, replacement_record_key, action, before_fingerprint,
+    after_fingerprint, created_at
+  )
+  SELECT v_tenant_id, v_operation.review_school_id, p_operation_id, v_sequence,
+    'people', item.record_key, NULL, 'archive_source', v_before_fingerprint,
+    v_after_fingerprint, v_now
+  FROM public.person_merge_preview_items AS item
+  WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+    AND item.metadata->>'kind' = 'person_anchor'
+    AND item.metadata->>'personRole' = 'source';
+
+  INSERT INTO public.person_merge_aliases (
+    tenant_id, review_school_id, operation_id, source_person_id, target_person_id,
+    status, version, merged_at, created_at
+  ) VALUES (
+    v_tenant_id, v_operation.review_school_id, p_operation_id,
+    v_operation.source_person_id, v_operation.target_person_id,
+    'active', 1, v_now, v_now
+  );
+
+  v_case_next_version := v_case.current_version + 1;
+  UPDATE public.person_duplicate_cases AS duplicate_case
+  SET status = 'superseded', current_version = v_case_next_version, updated_at = v_now
+  WHERE duplicate_case.tenant_id = v_tenant_id AND duplicate_case.id = v_case.id
+    AND duplicate_case.current_version = v_case.current_version;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PERSON_MERGE_CASE_CHANGED' USING ERRCODE = '40001';
+  END IF;
+  SELECT encode(
+    digest(convert_to(to_jsonb(duplicate_case)::text, 'UTF8'), 'sha256'), 'hex'
+  ) INTO v_after_fingerprint
+  FROM public.person_duplicate_cases AS duplicate_case
+  WHERE duplicate_case.tenant_id = v_tenant_id AND duplicate_case.id = v_case.id;
+  FOR v_item IN
+    SELECT item.*
+    FROM public.person_merge_preview_items AS item
+    WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+      AND item.relation_name = 'person_duplicate_cases'
+      AND item.metadata ? 'column'
+    ORDER BY item.record_key, item.direction
+  LOOP
+    v_sequence := v_sequence + 1;
+    INSERT INTO public.person_merge_moves (
+      tenant_id, review_school_id, operation_id, sequence, relation_name,
+      source_record_key, replacement_record_key, action, before_fingerprint,
+      after_fingerprint, created_at
+    ) VALUES (
+      v_tenant_id, v_operation.review_school_id, p_operation_id, v_sequence,
+      'person_duplicate_cases', v_item.record_key, NULL, 'preserve_history',
+      v_item.row_fingerprint, v_after_fingerprint, v_now
+    );
+  END LOOP;
+  INSERT INTO public.person_duplicate_case_events (
+    tenant_id, review_school_id, case_id, version, event_type, score, signals,
+    evidence_hash, reason, actor_account_id, created_at
+  ) VALUES (
+    v_tenant_id, v_case.review_school_id, v_case.id, v_case_next_version,
+    'merge_executed', v_case.current_score, v_case.current_signals,
+    v_case.current_evidence_hash, btrim(p_reason), v_account_id, v_now
+  );
+
+  SELECT encode(
+    digest(
+      convert_to(
+        v_operation.preview_digest || ':' || coalesce(string_agg(
+          move.sequence::text || ':' || move.relation_name || ':' ||
+          move.source_record_key || ':' || move.action || ':' ||
+          move.before_fingerprint || ':' || move.after_fingerprint,
+          '|' ORDER BY move.sequence
+        ), ''),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  ) INTO v_execution_digest
+  FROM public.person_merge_moves AS move
+  WHERE move.tenant_id = v_tenant_id AND move.operation_id = p_operation_id;
+
+  v_next_version := v_operation.current_version + 1;
+  UPDATE public.person_merge_operations AS operation
+  SET status = 'executed', current_version = v_next_version,
+    execution_digest = v_execution_digest,
+    invalidation_count = v_invalidation_count,
+    executed_by_account_id = v_account_id, executed_at = v_now, updated_at = v_now
+  WHERE operation.tenant_id = v_tenant_id AND operation.id = p_operation_id
+    AND operation.current_version = p_expected_operation_version;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PERSON_MERGE_APPROVAL_CHANGED' USING ERRCODE = '40001';
+  END IF;
+  INSERT INTO public.person_merge_events (
+    tenant_id, review_school_id, operation_id, version, event_type, operation_status,
+    preview_digest, reason, actor_account_id, created_at
+  ) VALUES (
+    v_tenant_id, v_operation.review_school_id, p_operation_id, v_next_version,
+    'executed', 'executed', v_operation.preview_digest, btrim(p_reason),
+    v_account_id, v_now
+  );
+
+  INSERT INTO public.audit_events (
+    id, occurred_at, event_version, event_type, outcome, tenant_id, school_id,
+    actor_type, actor_account_id, actor_person_id, capability, policy_version,
+    policy_decision, request_id, correlation_id, target_type, target_id,
+    data_classes, change_summary, purpose, source, retention_class,
+    content_hash, created_at
+  ) VALUES (
+    v_audit_event_id, v_now, 1, 'person.merge.execute', 'succeeded', v_tenant_id,
+    v_operation.review_school_id, 'account', v_account_id, v_person_id,
+    'tenant.people_merges.execute', v_policy_version,
+    jsonb_build_object(
+      'effect', 'allow', 'queryConstraints', coalesce(
+        nullif(current_setting('app.policy_constraints', true), '')::jsonb,
+        '[]'::jsonb
+      )
+    ),
+    v_request_id, v_correlation_id, 'person_merge_operation', p_operation_id::text,
+    '["internal", "student_personal", "credential"]'::jsonb,
+    jsonb_build_object('changedFields', jsonb_build_array(
+      'status', 'sourcePersonId', 'targetPersonId', 'membershipVersion',
+      'securityVersion'
+    )),
+    'person_identity_reconciliation', 'web', 'security', 'pending', v_now
+  );
+  INSERT INTO public.audit_outbox (
+    id, tenant_id, audit_event_id, audit_event_occurred_at, topic,
+    deduplication_key, correlation_id, context, payload, payload_hash,
+    status, attempt_count, available_at, created_at, updated_at
+  ) VALUES (
+    v_audit_outbox_id, v_tenant_id, v_audit_event_id, v_now,
+    'audit.event.committed', 'person.merge.execute:' || p_operation_id::text,
+    v_correlation_id,
+    jsonb_build_object(
+      'tenantId', v_tenant_id, 'requestId', v_request_id,
+      'correlationId', v_correlation_id, 'actorAccountId', v_account_id,
+      'actorPersonId', v_person_id
+    ),
+    jsonb_build_object(
+      'auditEventId', v_audit_event_id, 'eventVersion', 1,
+      'eventType', 'person.merge.execute', 'outcome', 'succeeded',
+      'targetType', 'person_merge_operation', 'targetId', p_operation_id
+    ),
+    'pending', 'pending', 0, v_now, v_now, v_now
+  );
+
+  RETURN QUERY SELECT p_operation_id, 'executed'::text, v_next_version,
+    v_execution_digest, v_invalidation_count, v_now;
+END
+$function$;
+--> statement-breakpoint
+ALTER FUNCTION "openschool_private"."execute_person_merge"(uuid, integer, text, text)
+  OWNER TO "openschool_person_merge_manager";
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "openschool_private"."execute_person_merge"(
+  uuid, integer, text, text
+) FROM PUBLIC;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION "openschool_private"."execute_person_merge"(
+  uuid, integer, text, text
+) TO "openschool_runtime";
+--> statement-breakpoint
+DO $verification$
+BEGIN
+  IF NOT has_function_privilege(
+    'openschool_runtime',
+    'openschool_private.execute_person_merge(uuid,integer,text,text)', 'EXECUTE'
+  ) OR has_table_privilege(
+    'openschool_runtime', 'public.person_merge_aliases', 'INSERT'
+  ) OR has_table_privilege(
+    'openschool_runtime', 'public.person_merge_moves', 'INSERT'
+  ) OR pg_has_role(
+    'openschool_runtime', 'openschool_person_merge_manager', 'member'
+  ) THEN
+    RAISE EXCEPTION 'Person merge execution authority is misconfigured';
+  END IF;
+END
+$verification$;

--- a/packages/db/migrations/0044_person_merge_execution.sql
+++ b/packages/db/migrations/0044_person_merge_execution.sql
@@ -108,7 +108,7 @@ CREATE POLICY "audit_events_person_merge_manager_insert" ON "audit_events"
     AND request_id = nullif(current_setting('app.request_id', true), '')
     AND correlation_id = nullif(current_setting('app.correlation_id', true), '')
     AND capability = 'tenant.people_merges.execute'
-    AND event_type = 'person.merge.execute'
+    AND event_type = 'person_merge.execute'
     AND target_type = 'person_merge_operation'
     AND source = 'web'
   );
@@ -123,7 +123,7 @@ CREATE POLICY "audit_outbox_person_merge_manager_insert" ON "audit_outbox"
     AND context ->> 'requestId' = nullif(current_setting('app.request_id', true), '')
     AND correlation_id = nullif(current_setting('app.correlation_id', true), '')
     AND topic = 'audit.event.committed'
-    AND payload ->> 'eventType' = 'person.merge.execute'
+    AND payload ->> 'eventType' = 'person_merge.execute'
   );
 --> statement-breakpoint
 DO $policies$
@@ -711,7 +711,7 @@ BEGIN
     data_classes, change_summary, purpose, source, retention_class,
     content_hash, created_at
   ) VALUES (
-    v_audit_event_id, v_now, 1, 'person.merge.execute', 'succeeded', v_tenant_id,
+    v_audit_event_id, v_now, 1, 'person_merge.execute', 'succeeded', v_tenant_id,
     v_operation.review_school_id, 'account', v_account_id, v_person_id,
     'tenant.people_merges.execute', v_policy_version,
     jsonb_build_object(
@@ -734,7 +734,7 @@ BEGIN
     status, attempt_count, available_at, created_at, updated_at
   ) VALUES (
     v_audit_outbox_id, v_tenant_id, v_audit_event_id, v_now,
-    'audit.event.committed', 'person.merge.execute:' || p_operation_id::text,
+    'audit.event.committed', 'person_merge.execute:' || p_operation_id::text,
     v_correlation_id,
     jsonb_build_object(
       'tenantId', v_tenant_id, 'requestId', v_request_id,
@@ -743,7 +743,7 @@ BEGIN
     ),
     jsonb_build_object(
       'auditEventId', v_audit_event_id, 'eventVersion', 1,
-      'eventType', 'person.merge.execute', 'outcome', 'succeeded',
+      'eventType', 'person_merge.execute', 'outcome', 'succeeded',
       'targetType', 'person_merge_operation', 'targetId', p_operation_id
     ),
     'pending', 'pending', 0, v_now, v_now, v_now

--- a/packages/db/migrations/0044_person_merge_execution.sql
+++ b/packages/db/migrations/0044_person_merge_execution.sql
@@ -203,7 +203,7 @@ BEGIN
   FROM public.people AS person
   WHERE person.tenant_id = NEW.tenant_id AND person.id = v_person_id
   FOR SHARE;
-  IF NOT FOUND OR v_status NOT IN ('active', 'suspended') THEN
+  IF FOUND AND v_status NOT IN ('active', 'suspended') THEN
     RAISE EXCEPTION 'PERSON_REFERENCE_NOT_OPERATIONAL' USING ERRCODE = '23514';
   END IF;
   RETURN NEW;

--- a/packages/db/migrations/0044_person_merge_execution.sql
+++ b/packages/db/migrations/0044_person_merge_execution.sql
@@ -6,6 +6,9 @@ ALTER TABLE "person_duplicate_case_events" ADD CONSTRAINT "person_duplicate_case
 GRANT UPDATE ON TABLE "accounts", "account_sessions"
   TO "openschool_person_merge_manager";
 --> statement-breakpoint
+GRANT INSERT ON TABLE "account_links"
+  TO "openschool_person_merge_manager";
+--> statement-breakpoint
 GRANT INSERT ON TABLE "person_duplicate_case_events", "audit_events", "audit_outbox"
   TO "openschool_person_merge_manager";
 --> statement-breakpoint
@@ -96,6 +99,16 @@ CREATE POLICY "account_sessions_person_merge_manager_update" ON "account_session
         )::uuid
     )
   ) WITH CHECK (true);
+--> statement-breakpoint
+CREATE POLICY "account_links_person_merge_manager_insert" ON "account_links"
+  AS PERMISSIVE FOR INSERT TO "openschool_person_merge_manager" WITH CHECK (
+    session_user = 'openschool_runtime'
+    AND current_user = 'openschool_person_merge_manager'
+    AND tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
+    AND person_id = nullif(current_setting('app.merge_target_person_id', true), '')::uuid
+    AND nullif(current_setting('app.policy_capability', true), '')
+      = 'tenant.people_merges.execute'
+  );
 --> statement-breakpoint
 CREATE POLICY "audit_events_person_merge_manager_insert" ON "audit_events"
   AS PERMISSIVE FOR INSERT TO "openschool_person_merge_manager" WITH CHECK (
@@ -280,6 +293,8 @@ DECLARE
   v_item record;
   v_account_record record;
   v_session_record record;
+  v_link_record public.account_links%ROWTYPE;
+  v_replacement_id uuid;
   v_changed_count integer;
   v_sequence integer := 0;
   v_invalidation_count integer := 0;
@@ -393,6 +408,9 @@ BEGIN
   PERFORM set_config(
     'app.merge_source_person_id', v_operation.source_person_id::text, true
   );
+  PERFORM set_config(
+    'app.merge_target_person_id', v_operation.target_person_id::text, true
+  );
   PERFORM openschool_private.assert_person_merge_plan_v2_current(p_operation_id);
 
   -- Invalidate identity caches and active sessions before moving Account links.
@@ -502,13 +520,85 @@ BEGIN
     );
   END LOOP;
 
-  -- Repoint only reviewed operational dependencies. Dynamic identifiers come exclusively from
+  -- Account links are identity evidence, so their Person anchor is never rewritten. End the
+  -- reviewed source fact and create a replacement for the canonical Person instead.
+  FOR v_item IN
+    SELECT item.*
+    FROM public.person_merge_preview_items AS item
+    WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
+      AND item.relation_name = 'account_links'
+      AND item.metadata->>'column' = 'person_id'
+      AND item.disposition = 'end_and_recreate'
+    ORDER BY item.record_key
+  LOOP
+    SELECT link.* INTO v_link_record
+    FROM public.account_links AS link
+    WHERE link.tenant_id = v_tenant_id
+      AND link.person_id = v_operation.source_person_id
+      AND link.status IN ('pending', 'active', 'suspended')
+      AND encode(
+        digest(convert_to(to_jsonb(link)::text, 'UTF8'), 'sha256'), 'hex'
+      ) = v_item.row_fingerprint
+    FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'PERSON_MERGE_DEPENDENCY_CHANGED' USING ERRCODE = '40001';
+    END IF;
+
+    UPDATE public.account_links AS link
+    SET status = 'revoked',
+      valid_until = CASE
+        WHEN link.valid_from IS NULL OR link.valid_from < v_now THEN v_now
+        ELSE link.valid_from + interval '1 microsecond'
+      END,
+      revoked_at = v_now,
+      revoked_by_account_id = v_account_id,
+      revocation_reason = 'Person merge execution: ' || btrim(p_reason),
+      updated_at = v_now
+    WHERE link.tenant_id = v_tenant_id AND link.id = v_link_record.id;
+
+    v_replacement_id := gen_random_uuid();
+    INSERT INTO public.account_links (
+      id, tenant_id, account_id, person_id, status, valid_from, valid_until,
+      issued_by_account_id, issuance_reason, activated_at, created_at, updated_at
+    ) VALUES (
+      v_replacement_id, v_tenant_id, v_link_record.account_id,
+      v_operation.target_person_id, v_link_record.status,
+      CASE WHEN v_link_record.status = 'pending' THEN v_link_record.valid_from ELSE v_now END,
+      CASE
+        WHEN v_link_record.status = 'pending' THEN v_link_record.valid_until
+        WHEN v_link_record.valid_until > v_now THEN v_link_record.valid_until
+        ELSE NULL
+      END,
+      v_account_id, 'Person merge execution: ' || btrim(p_reason),
+      CASE WHEN v_link_record.status = 'active' THEN v_now ELSE NULL END,
+      v_now, v_now
+    );
+    SELECT encode(
+      digest(convert_to(to_jsonb(link)::text, 'UTF8'), 'sha256'), 'hex'
+    ) INTO v_after_fingerprint
+    FROM public.account_links AS link
+    WHERE link.tenant_id = v_tenant_id AND link.id = v_replacement_id;
+    v_sequence := v_sequence + 1;
+    INSERT INTO public.person_merge_moves (
+      tenant_id, review_school_id, operation_id, sequence, relation_name,
+      source_record_key, replacement_record_key, action, before_fingerprint,
+      after_fingerprint, created_at
+    ) VALUES (
+      v_tenant_id, v_operation.review_school_id, p_operation_id, v_sequence,
+      'account_links', v_link_record.id::text, v_replacement_id::text,
+      'end_and_recreate', v_item.row_fingerprint, v_after_fingerprint, v_now
+    );
+  END LOOP;
+
+  -- Repoint only reviewed operational dependencies that are not versioned identity evidence.
+  -- Dynamic identifiers come exclusively from
   -- immutable preview metadata that was generated from PostgreSQL's FK catalog and revalidated.
   FOR v_item IN
     SELECT item.*
     FROM public.person_merge_preview_items AS item
     WHERE item.tenant_id = v_tenant_id AND item.operation_id = p_operation_id
       AND item.metadata ? 'column' AND item.disposition = 'end_and_recreate'
+      AND item.relation_name <> 'account_links'
     ORDER BY item.relation_name, item.record_key, item.direction
   LOOP
     IF v_item.relation_name !~ '^[a-z][a-z0-9_]{0,62}$'
@@ -569,7 +659,7 @@ BEGIN
 
   -- No reviewed operational reference may remain on the source. Table locks keep this assertion
   -- stable through commit and the installed guards reject future references to the archived alias.
-  IF EXISTS (SELECT 1 FROM public.account_links WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+  IF EXISTS (SELECT 1 FROM public.account_links WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id AND status IN ('pending', 'active', 'suspended'))
     OR EXISTS (SELECT 1 FROM public.contact_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
     OR EXISTS (SELECT 1 FROM public.student_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
     OR EXISTS (SELECT 1 FROM public.guardian_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)

--- a/packages/db/migrations/0044_person_merge_execution.sql
+++ b/packages/db/migrations/0044_person_merge_execution.sql
@@ -659,19 +659,19 @@ BEGIN
 
   -- No reviewed operational reference may remain on the source. Table locks keep this assertion
   -- stable through commit and the installed guards reject future references to the archived alias.
-  IF EXISTS (SELECT 1 FROM public.account_links WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id AND status IN ('pending', 'active', 'suspended'))
-    OR EXISTS (SELECT 1 FROM public.contact_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.student_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.guardian_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.employee_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.teacher_profiles WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.affiliations WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.person_relationships WHERE tenant_id = v_tenant_id AND (subject_person_id = v_operation.source_person_id OR related_person_id = v_operation.source_person_id))
-    OR EXISTS (SELECT 1 FROM public.household_memberships WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.school_enrollments WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.section_staff_assignments WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.section_roster_memberships WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
-    OR EXISTS (SELECT 1 FROM public.account_invitations WHERE tenant_id = v_tenant_id AND person_id = v_operation.source_person_id)
+  IF EXISTS (SELECT 1 FROM public.account_links AS source_link WHERE source_link.tenant_id = v_tenant_id AND source_link.person_id = v_operation.source_person_id AND source_link.status IN ('pending', 'active', 'suspended'))
+    OR EXISTS (SELECT 1 FROM public.contact_profiles AS source_contact WHERE source_contact.tenant_id = v_tenant_id AND source_contact.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.student_profiles AS source_student WHERE source_student.tenant_id = v_tenant_id AND source_student.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.guardian_profiles AS source_guardian WHERE source_guardian.tenant_id = v_tenant_id AND source_guardian.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.employee_profiles AS source_employee WHERE source_employee.tenant_id = v_tenant_id AND source_employee.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.teacher_profiles AS source_teacher WHERE source_teacher.tenant_id = v_tenant_id AND source_teacher.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.affiliations AS source_affiliation WHERE source_affiliation.tenant_id = v_tenant_id AND source_affiliation.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.person_relationships AS source_relationship WHERE source_relationship.tenant_id = v_tenant_id AND (source_relationship.subject_person_id = v_operation.source_person_id OR source_relationship.related_person_id = v_operation.source_person_id))
+    OR EXISTS (SELECT 1 FROM public.household_memberships AS source_household WHERE source_household.tenant_id = v_tenant_id AND source_household.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.school_enrollments AS source_enrollment WHERE source_enrollment.tenant_id = v_tenant_id AND source_enrollment.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.section_staff_assignments AS source_staff WHERE source_staff.tenant_id = v_tenant_id AND source_staff.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.section_roster_memberships AS source_roster WHERE source_roster.tenant_id = v_tenant_id AND source_roster.person_id = v_operation.source_person_id)
+    OR EXISTS (SELECT 1 FROM public.account_invitations AS source_invitation WHERE source_invitation.tenant_id = v_tenant_id AND source_invitation.person_id = v_operation.source_person_id)
   THEN
     RAISE EXCEPTION 'PERSON_MERGE_OPERATIONAL_REFERENCE_REMAINS' USING ERRCODE = '40001';
   END IF;

--- a/packages/db/migrations/meta/0042_snapshot.json
+++ b/packages/db/migrations/meta/0042_snapshot.json
@@ -1,0 +1,14360 @@
+{
+  "id": "2562a929-3d2e-490a-a7e4-9afbd8301819",
+  "prevId": "58e8e7c5-61bf-4478-bb09-0fb962d299ae",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tenant_placements_adapter_check": {
+          "name": "tenant_placements_adapter_check",
+          "value": "\"tenant_placements\".\"adapter\" = 'pooled'"
+        },
+        "tenant_placements_status_check": {
+          "name": "tenant_placements_status_check",
+          "value": "\"tenant_placements\".\"status\" IN ('active', 'migrating', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tenants_status_check": {
+          "name": "tenants_status_check",
+          "value": "\"tenants\".\"status\" IN ('active', 'suspended', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schools_tenant_organization_idx": {
+          "name": "schools_tenant_organization_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "schools_tenant_organization_fk": {
+          "name": "schools_tenant_organization_fk",
+          "tableFrom": "schools",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        }
+      },
+      "policies": {
+        "schools_runtime_select": {
+          "name": "schools_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND (\n          \"schools\".\"id\" = nullif(current_setting('app.school_id', true), '')::uuid\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              IN (\n                'tenant.schools.read',\n                'tenant.students.create', 'tenant.students.read',\n                'tenant.students.update', 'tenant.students.delete',\n                'support.schools.read', 'support.students.read',\n                'tenant.accounts.invite', 'tenant.accounts.manage',\n                'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n                'tenant.student_enrollments.read', 'tenant.student_enrollments.manage',\n                'tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage',\n                'tenant.sections.read', 'tenant.sections.manage',\n                'identity.context.resolve'\n              )\n            AND public.openschool_school_scope_allows(\n              \"schools\".\"tenant_id\", \"schools\".\"id\"\n            )\n          )\n        )\n      "
+        },
+        "schools_identity_revoker_select": {
+          "name": "schools_identity_revoker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_identity_revoker"],
+          "using": "\n        \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND nullif(current_setting('app.assurance_level', true), '') = 'aal2'\n      "
+        },
+        "schools_worker_select": {
+          "name": "schools_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "schools_student_admitter_select": {
+          "name": "schools_student_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_school_scope_allows(\"schools\".\"tenant_id\", \"schools\".\"id\")\n      "
+        },
+        "schools_academic_configurator_select": {
+          "name": "schools_academic_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_academic_configurator'\n        AND \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.academic_structure.manage'\n        AND public.openschool_school_scope_allows(\"schools\".\"tenant_id\", \"schools\".\"id\")\n      "
+        },
+        "schools_runtime_insert_deny": {
+          "name": "schools_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "schools_runtime_update_deny": {
+          "name": "schools_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "schools_runtime_delete_deny": {
+          "name": "schools_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "schools_worker_insert_deny": {
+          "name": "schools_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "schools_worker_update_deny": {
+          "name": "schools_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "schools_worker_delete_deny": {
+          "name": "schools_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "schools_profile_check": {
+          "name": "schools_profile_check",
+          "value": "\"schools\".\"profile\" IN ('primary', 'secondary', 'all_through', 'special', 'other')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "education_organizations_legacy_organization_fk": {
+          "name": "education_organizations_legacy_organization_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "legacy_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "education_organizations_type_check": {
+          "name": "education_organizations_type_check",
+          "value": "\"education_organizations\".\"type\" IN ('ministry', 'school_board', 'district', 'network', 'region', 'other')"
+        },
+        "education_organizations_status_check": {
+          "name": "education_organizations_status_check",
+          "value": "\"education_organizations\".\"status\" IN ('active', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "version"]
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_links": {
+      "name": "account_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_links_account_status_idx": {
+          "name": "account_links_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_links_tenant_person_status_idx": {
+          "name": "account_links_tenant_person_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_links_tenant_id_tenants_id_fk": {
+          "name": "account_links_tenant_id_tenants_id_fk",
+          "tableFrom": "account_links",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_links_account_id_accounts_id_fk": {
+          "name": "account_links_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_links_issued_by_account_id_accounts_id_fk": {
+          "name": "account_links_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_links_revoked_by_account_id_accounts_id_fk": {
+          "name": "account_links_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_links_tenant_person_fk": {
+          "name": "account_links_tenant_person_fk",
+          "tableFrom": "account_links",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_links_tenant_id_id_unique": {
+          "name": "account_links_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_links_status_check": {
+          "name": "account_links_status_check",
+          "value": "\"account_links\".\"status\" IN ('pending', 'active', 'suspended', 'revoked', 'expired')"
+        },
+        "account_links_valid_period_check": {
+          "name": "account_links_valid_period_check",
+          "value": "\"account_links\".\"valid_from\" IS NULL OR \"account_links\".\"valid_until\" IS NULL OR \"account_links\".\"valid_until\" > \"account_links\".\"valid_from\""
+        },
+        "account_links_activation_evidence_check": {
+          "name": "account_links_activation_evidence_check",
+          "value": "\"account_links\".\"status\" <> 'active' OR (\"account_links\".\"valid_from\" IS NOT NULL AND \"account_links\".\"activated_at\" IS NOT NULL)"
+        },
+        "account_links_revocation_evidence_check": {
+          "name": "account_links_revocation_evidence_check",
+          "value": "\"account_links\".\"status\" <> 'revoked' OR (\"account_links\".\"revoked_at\" IS NOT NULL AND \"account_links\".\"revocation_reason\" IS NOT NULL AND \"account_links\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_sessions": {
+      "name": "account_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assurance_level": {
+          "name": "assurance_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_version": {
+          "name": "security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authenticated_at": {
+          "name": "authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reauthenticated_at": {
+          "name": "reauthenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_sessions_account_status_idx": {
+          "name": "account_sessions_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_sessions_account_id_accounts_id_fk": {
+          "name": "account_sessions_account_id_accounts_id_fk",
+          "tableFrom": "account_sessions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_sessions_revoked_by_account_id_accounts_id_fk": {
+          "name": "account_sessions_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "account_sessions",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_sessions_provider_session_id_unique": {
+          "name": "account_sessions_provider_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider_session_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_sessions_status_check": {
+          "name": "account_sessions_status_check",
+          "value": "\"account_sessions\".\"status\" IN ('active', 'revoked', 'expired')"
+        },
+        "account_sessions_assurance_level_check": {
+          "name": "account_sessions_assurance_level_check",
+          "value": "\"account_sessions\".\"assurance_level\" IN ('aal1', 'aal2')"
+        },
+        "account_sessions_security_version_positive": {
+          "name": "account_sessions_security_version_positive",
+          "value": "\"account_sessions\".\"security_version\" > 0"
+        },
+        "account_sessions_time_order_check": {
+          "name": "account_sessions_time_order_check",
+          "value": "\"account_sessions\".\"expires_at\" > \"account_sessions\".\"authenticated_at\""
+        },
+        "account_sessions_reauthentication_time_check": {
+          "name": "account_sessions_reauthentication_time_check",
+          "value": "\"account_sessions\".\"reauthenticated_at\" IS NULL OR \"account_sessions\".\"reauthenticated_at\" < \"account_sessions\".\"expires_at\""
+        },
+        "account_sessions_revocation_evidence_check": {
+          "name": "account_sessions_revocation_evidence_check",
+          "value": "\"account_sessions\".\"status\" <> 'revoked' OR (\"account_sessions\".\"revoked_at\" IS NOT NULL AND \"account_sessions\".\"revocation_reason\" IS NOT NULL AND btrim(\"account_sessions\".\"revocation_reason\") <> '')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "legacy_user_id": {
+          "name": "legacy_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_provider": {
+          "name": "identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'supabase'"
+        },
+        "provider_subject": {
+          "name": "provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "membership_version": {
+          "name": "membership_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "security_version": {
+          "name": "security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_legacy_user_id_users_id_fk": {
+          "name": "accounts_legacy_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["legacy_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_legacy_user_id_unique": {
+          "name": "accounts_legacy_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_user_id"]
+        },
+        "accounts_provider_subject_unique": {
+          "name": "accounts_provider_subject_unique",
+          "nullsNotDistinct": false,
+          "columns": ["identity_provider", "provider_subject"]
+        },
+        "accounts_primary_email_unique": {
+          "name": "accounts_primary_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["primary_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "accounts_status_check": {
+          "name": "accounts_status_check",
+          "value": "\"accounts\".\"status\" IN ('active', 'disabled', 'deleted')"
+        },
+        "accounts_versions_positive": {
+          "name": "accounts_versions_positive",
+          "value": "\"accounts\".\"membership_version\" > 0 AND \"accounts\".\"security_version\" > 0"
+        },
+        "accounts_disabled_evidence_check": {
+          "name": "accounts_disabled_evidence_check",
+          "value": "\"accounts\".\"status\" = 'active' OR (\"accounts\".\"disabled_at\" IS NOT NULL AND \"accounts\".\"disabled_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_tenant_person_effective_idx": {
+          "name": "affiliations_tenant_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "affiliations_tenant_school_effective_idx": {
+          "name": "affiliations_tenant_school_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "affiliations_tenant_id_tenants_id_fk": {
+          "name": "affiliations_tenant_id_tenants_id_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_issued_by_account_id_accounts_id_fk": {
+          "name": "affiliations_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_revoked_by_account_id_accounts_id_fk": {
+          "name": "affiliations_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_tenant_person_fk": {
+          "name": "affiliations_tenant_person_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_tenant_education_organization_fk": {
+          "name": "affiliations_tenant_education_organization_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_tenant_school_fk": {
+          "name": "affiliations_tenant_school_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_tenant_class_fk": {
+          "name": "affiliations_tenant_class_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "affiliations_tenant_id_id_unique": {
+          "name": "affiliations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "affiliations_kind_check": {
+          "name": "affiliations_kind_check",
+          "value": "\"affiliations\".\"kind\" IN ('student', 'guardian', 'employee', 'teacher', 'administrator', 'member')"
+        },
+        "affiliations_status_check": {
+          "name": "affiliations_status_check",
+          "value": "\"affiliations\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "affiliations_scope_check": {
+          "name": "affiliations_scope_check",
+          "value": "(\"affiliations\".\"scope_type\" = 'tenant' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'education_organization' AND \"affiliations\".\"education_organization_id\" IS NOT NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'school' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NOT NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'class' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NOT NULL)"
+        },
+        "affiliations_valid_period_check": {
+          "name": "affiliations_valid_period_check",
+          "value": "\"affiliations\".\"valid_until\" IS NULL OR \"affiliations\".\"valid_until\" > \"affiliations\".\"valid_from\""
+        },
+        "affiliations_revocation_evidence_check": {
+          "name": "affiliations_revocation_evidence_check",
+          "value": "\"affiliations\".\"status\" <> 'revoked' OR (\"affiliations\".\"revoked_at\" IS NOT NULL AND \"affiliations\".\"revocation_reason\" IS NOT NULL AND \"affiliations\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.contact_profiles": {
+      "name": "contact_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_phone": {
+          "name": "normalized_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_profiles_tenant_phone_idx": {
+          "name": "contact_profiles_tenant_phone_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_profiles_tenant_id_tenants_id_fk": {
+          "name": "contact_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "contact_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "contact_profiles_tenant_person_fk": {
+          "name": "contact_profiles_tenant_person_fk",
+          "tableFrom": "contact_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contact_profiles_pk": {
+          "name": "contact_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "contact_profiles_runtime_select": {
+          "name": "contact_profiles_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage')\n        AND public.openschool_contact_person_read_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_runtime_insert_deny": {
+          "name": "contact_profiles_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "contact_profiles_runtime_update_deny": {
+          "name": "contact_profiles_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "contact_profiles_runtime_delete_deny": {
+          "name": "contact_profiles_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "contact_profiles_contact_manager_select": {
+          "name": "contact_profiles_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_insert": {
+          "name": "contact_profiles_contact_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_guardian_contact_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_update": {
+          "name": "contact_profiles_contact_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_delete_deny": {
+          "name": "contact_profiles_contact_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "contact_profiles_phone_check": {
+          "name": "contact_profiles_phone_check",
+          "value": "\"contact_profiles\".\"phone\" IS NULL OR char_length(btrim(\"contact_profiles\".\"phone\")) BETWEEN 5 AND 32"
+        },
+        "contact_profiles_normalized_phone_check": {
+          "name": "contact_profiles_normalized_phone_check",
+          "value": "\"contact_profiles\".\"normalized_phone\" IS NULL OR char_length(\"contact_profiles\".\"normalized_phone\") BETWEEN 5 AND 20"
+        },
+        "contact_profiles_preferred_method_check": {
+          "name": "contact_profiles_preferred_method_check",
+          "value": "\"contact_profiles\".\"preferred_contact_method\" IN ('email', 'phone', 'sms', 'none')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.employee_profiles": {
+      "name": "employee_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_number": {
+          "name": "employee_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "employee_profiles_tenant_id_tenants_id_fk": {
+          "name": "employee_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "employee_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "employee_profiles_tenant_person_fk": {
+          "name": "employee_profiles_tenant_person_fk",
+          "tableFrom": "employee_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "employee_profiles_pk": {
+          "name": "employee_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "employee_profiles_tenant_employee_number_unique": {
+          "name": "employee_profiles_tenant_employee_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "employee_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "employee_profiles_status_check": {
+          "name": "employee_profiles_status_check",
+          "value": "\"employee_profiles\".\"status\" IN ('active', 'leave', 'terminated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.guardian_profiles": {
+      "name": "guardian_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardian_profiles_tenant_id_tenants_id_fk": {
+          "name": "guardian_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "guardian_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "guardian_profiles_tenant_person_fk": {
+          "name": "guardian_profiles_tenant_person_fk",
+          "tableFrom": "guardian_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "guardian_profiles_pk": {
+          "name": "guardian_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "guardian_profiles_status_check": {
+          "name": "guardian_profiles_status_check",
+          "value": "\"guardian_profiles\".\"status\" IN ('active', 'inactive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.identity_migration_events": {
+      "name": "identity_migration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_link_id": {
+          "name": "account_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_version": {
+          "name": "membership_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identity_migration_events_account_version_idx": {
+          "name": "identity_migration_events_account_version_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "membership_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_migration_events_tenant_person_idx": {
+          "name": "identity_migration_events_tenant_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_migration_events_tenant_id_tenants_id_fk": {
+          "name": "identity_migration_events_tenant_id_tenants_id_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "identity_migration_events_account_id_accounts_id_fk": {
+          "name": "identity_migration_events_account_id_accounts_id_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "identity_migration_events_actor_account_id_accounts_id_fk": {
+          "name": "identity_migration_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "identity_migration_events_tenant_person_fk": {
+          "name": "identity_migration_events_tenant_person_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "identity_migration_events_tenant_account_link_fk": {
+          "name": "identity_migration_events_tenant_account_link_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "account_links",
+          "columnsFrom": ["tenant_id", "account_link_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "identity_migration_events_tenant_id_id_unique": {
+          "name": "identity_migration_events_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "identity_migration_events_type_check": {
+          "name": "identity_migration_events_type_check",
+          "value": "\"identity_migration_events\".\"event_type\" IN ('account_link_backfilled', 'account_link_activated', 'account_link_revoked')"
+        },
+        "identity_migration_events_version_positive": {
+          "name": "identity_migration_events_version_positive",
+          "value": "\"identity_migration_events\".\"membership_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.people": {
+      "name": "people",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_user_id": {
+          "name": "legacy_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_display_name": {
+          "name": "normalized_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "people_tenant_name_idx": {
+          "name": "people_tenant_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "people_tenant_email_idx": {
+          "name": "people_tenant_email_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "people_tenant_id_tenants_id_fk": {
+          "name": "people_tenant_id_tenants_id_fk",
+          "tableFrom": "people",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "people_legacy_user_id_users_id_fk": {
+          "name": "people_legacy_user_id_users_id_fk",
+          "tableFrom": "people",
+          "tableTo": "users",
+          "columnsFrom": ["legacy_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "people_tenant_legacy_student_fk": {
+          "name": "people_tenant_legacy_student_fk",
+          "tableFrom": "people",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "people_tenant_id_id_unique": {
+          "name": "people_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "people_tenant_legacy_user_unique": {
+          "name": "people_tenant_legacy_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_user_id"]
+        },
+        "people_tenant_legacy_student_unique": {
+          "name": "people_tenant_legacy_student_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_student_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "people_status_check": {
+          "name": "people_status_check",
+          "value": "\"people\".\"status\" IN ('active', 'suspended', 'archived', 'deceased')"
+        },
+        "people_source_check": {
+          "name": "people_source_check",
+          "value": "\"people\".\"source\" IN ('legacy_user', 'legacy_student', 'native')"
+        },
+        "people_legacy_source_check": {
+          "name": "people_legacy_source_check",
+          "value": "(\"people\".\"source\" <> 'legacy_user' OR \"people\".\"legacy_user_id\" IS NOT NULL)\n          AND (\"people\".\"source\" <> 'legacy_student' OR \"people\".\"legacy_student_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.person_merge_evidence": {
+      "name": "person_merge_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "recorded_by_account_id": {
+          "name": "recorded_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_evidence_tenant_people_idx": {
+          "name": "person_merge_evidence_tenant_people_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_evidence_tenant_id_tenants_id_fk": {
+          "name": "person_merge_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_evidence_recorded_by_account_id_accounts_id_fk": {
+          "name": "person_merge_evidence_recorded_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_evidence",
+          "tableTo": "accounts",
+          "columnsFrom": ["recorded_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_evidence_tenant_source_fk": {
+          "name": "person_merge_evidence_tenant_source_fk",
+          "tableFrom": "person_merge_evidence",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_evidence_tenant_target_fk": {
+          "name": "person_merge_evidence_tenant_target_fk",
+          "tableFrom": "person_merge_evidence",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_evidence_tenant_id_id_unique": {
+          "name": "person_merge_evidence_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "person_merge_evidence_status_check": {
+          "name": "person_merge_evidence_status_check",
+          "value": "\"person_merge_evidence\".\"status\" IN ('proposed', 'approved', 'completed', 'rejected', 'reverted')"
+        },
+        "person_merge_evidence_distinct_people_check": {
+          "name": "person_merge_evidence_distinct_people_check",
+          "value": "\"person_merge_evidence\".\"source_person_id\" <> \"person_merge_evidence\".\"target_person_id\""
+        },
+        "person_merge_evidence_completion_check": {
+          "name": "person_merge_evidence_completion_check",
+          "value": "\"person_merge_evidence\".\"status\" <> 'completed' OR \"person_merge_evidence\".\"completed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.person_relationships": {
+      "name": "person_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_person_id": {
+          "name": "subject_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_person_id": {
+          "name": "related_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_authority": {
+          "name": "legal_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decision_authority": {
+          "name": "decision_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "emergency_priority": {
+          "name": "emergency_priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_authority": {
+          "name": "pickup_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "portal_eligible": {
+          "name": "portal_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_relationships_one_active_contact_per_learner_idx": {
+          "name": "person_relationships_one_active_contact_per_learner_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"person_relationships\".\"status\" = 'active' AND \"person_relationships\".\"type\" IN ('parent_of', 'guardian_of', 'emergency_contact_of')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_relationships_subject_effective_idx": {
+          "name": "person_relationships_subject_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_relationships_related_effective_idx": {
+          "name": "person_relationships_related_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_relationships_tenant_id_tenants_id_fk": {
+          "name": "person_relationships_tenant_id_tenants_id_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_relationships_issued_by_account_id_accounts_id_fk": {
+          "name": "person_relationships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_relationships_revoked_by_account_id_accounts_id_fk": {
+          "name": "person_relationships_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_relationships_tenant_subject_fk": {
+          "name": "person_relationships_tenant_subject_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "subject_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_relationships_tenant_related_fk": {
+          "name": "person_relationships_tenant_related_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "related_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_relationships_tenant_id_id_unique": {
+          "name": "person_relationships_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {
+        "person_relationships_runtime_select": {
+          "name": "person_relationships_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND (\n          (\n            nullif(current_setting('app.policy_capability', true), '')\n              = 'tenant.guardian_contacts.read'\n            AND public.openschool_guardian_contact_read_scope_allows(\n              \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n            )\n          )\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              = 'tenant.guardian_contacts.manage'\n            AND public.openschool_guardian_contact_manage_scope_allows(\n              \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n            )\n          )\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              IN ('identity.context.resolve', 'tenant.students.read')\n            AND \"person_relationships\".\"subject_person_id\"::text\n              = nullif(current_setting('app.person_id', true), '')\n            AND \"person_relationships\".\"type\" IN ('guardian_of', 'parent_of')\n            AND \"person_relationships\".\"portal_eligible\"\n            AND \"person_relationships\".\"status\" = 'active'\n            AND \"person_relationships\".\"valid_from\" <= now()\n            AND (\"person_relationships\".\"valid_until\" IS NULL OR \"person_relationships\".\"valid_until\" > now())\n            AND EXISTS (\n              SELECT 1\n              FROM jsonb_array_elements(public.openschool_policy_constraints()) AS constraint_row\n              WHERE constraint_row ->> 'kind' = 'linked_student'\n                AND constraint_row ->> 'tenantId' = \"person_relationships\".\"tenant_id\"::text\n                AND constraint_row ->> 'guardianPersonId' = \"person_relationships\".\"subject_person_id\"::text\n                AND (\n                  constraint_row ->> 'studentId' IS NULL\n                  OR constraint_row ->> 'studentId' = \"person_relationships\".\"related_person_id\"::text\n                )\n            )\n          )\n        )\n      "
+        },
+        "person_relationships_runtime_insert_deny": {
+          "name": "person_relationships_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "person_relationships_runtime_update_deny": {
+          "name": "person_relationships_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_relationships_runtime_delete_deny": {
+          "name": "person_relationships_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "person_relationships_contact_manager_select": {
+          "name": "person_relationships_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_insert": {
+          "name": "person_relationships_contact_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_guardian_contact_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_update": {
+          "name": "person_relationships_contact_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_delete_deny": {
+          "name": "person_relationships_contact_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "person_relationships_type_check": {
+          "name": "person_relationships_type_check",
+          "value": "\"person_relationships\".\"type\" IN ('guardian_of', 'parent_of', 'emergency_contact_of', 'spouse_of', 'sibling_of', 'other')"
+        },
+        "person_relationships_status_check": {
+          "name": "person_relationships_status_check",
+          "value": "\"person_relationships\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "person_relationships_distinct_people_check": {
+          "name": "person_relationships_distinct_people_check",
+          "value": "\"person_relationships\".\"subject_person_id\" <> \"person_relationships\".\"related_person_id\""
+        },
+        "person_relationships_valid_period_check": {
+          "name": "person_relationships_valid_period_check",
+          "value": "\"person_relationships\".\"valid_until\" IS NULL OR \"person_relationships\".\"valid_until\" > \"person_relationships\".\"valid_from\""
+        },
+        "person_relationships_revocation_evidence_check": {
+          "name": "person_relationships_revocation_evidence_check",
+          "value": "\"person_relationships\".\"status\" <> 'revoked' OR (\"person_relationships\".\"revoked_at\" IS NOT NULL AND \"person_relationships\".\"revocation_reason\" IS NOT NULL AND \"person_relationships\".\"valid_until\" IS NOT NULL)"
+        },
+        "person_relationships_decision_authority_check": {
+          "name": "person_relationships_decision_authority_check",
+          "value": "\"person_relationships\".\"decision_authority\" IN ('none', 'shared', 'sole', 'limited')"
+        },
+        "person_relationships_emergency_priority_check": {
+          "name": "person_relationships_emergency_priority_check",
+          "value": "\"person_relationships\".\"emergency_priority\" IS NULL OR \"person_relationships\".\"emergency_priority\" BETWEEN 1 AND 99"
+        },
+        "person_relationships_portal_eligibility_check": {
+          "name": "person_relationships_portal_eligibility_check",
+          "value": "NOT \"person_relationships\".\"portal_eligible\" OR \"person_relationships\".\"type\" IN ('guardian_of', 'parent_of')"
+        },
+        "person_relationships_version_positive": {
+          "name": "person_relationships_version_positive",
+          "value": "\"person_relationships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.role_template_assignments": {
+      "name": "role_template_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliation_id": {
+          "name": "affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_template_key": {
+          "name": "role_template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_template_assignments_affiliation_effective_idx": {
+          "name": "role_template_assignments_affiliation_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affiliation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_template_assignments_tenant_id_tenants_id_fk": {
+          "name": "role_template_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "role_template_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "role_template_assignments_issued_by_account_id_accounts_id_fk": {
+          "name": "role_template_assignments_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "role_template_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "role_template_assignments_revoked_by_account_id_accounts_id_fk": {
+          "name": "role_template_assignments_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "role_template_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "role_template_assignments_tenant_affiliation_fk": {
+          "name": "role_template_assignments_tenant_affiliation_fk",
+          "tableFrom": "role_template_assignments",
+          "tableTo": "affiliations",
+          "columnsFrom": ["tenant_id", "affiliation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_template_assignments_tenant_id_id_unique": {
+          "name": "role_template_assignments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "role_template_assignments_status_check": {
+          "name": "role_template_assignments_status_check",
+          "value": "\"role_template_assignments\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "role_template_assignments_valid_period_check": {
+          "name": "role_template_assignments_valid_period_check",
+          "value": "\"role_template_assignments\".\"valid_until\" IS NULL OR \"role_template_assignments\".\"valid_until\" > \"role_template_assignments\".\"valid_from\""
+        },
+        "role_template_assignments_revocation_evidence_check": {
+          "name": "role_template_assignments_revocation_evidence_check",
+          "value": "\"role_template_assignments\".\"status\" <> 'revoked' OR (\"role_template_assignments\".\"revoked_at\" IS NOT NULL AND \"role_template_assignments\".\"revocation_reason\" IS NOT NULL AND \"role_template_assignments\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.student_profiles": {
+      "name": "student_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_profiles_tenant_id_tenants_id_fk": {
+          "name": "student_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "student_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_profiles_tenant_person_fk": {
+          "name": "student_profiles_tenant_person_fk",
+          "tableFrom": "student_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_profiles_tenant_legacy_student_fk": {
+          "name": "student_profiles_tenant_legacy_student_fk",
+          "tableFrom": "student_profiles",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_profiles_pk": {
+          "name": "student_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "student_profiles_tenant_student_number_unique": {
+          "name": "student_profiles_tenant_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "student_number"]
+        },
+        "student_profiles_tenant_legacy_student_unique": {
+          "name": "student_profiles_tenant_legacy_student_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_student_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "student_profiles_status_check": {
+          "name": "student_profiles_status_check",
+          "value": "\"student_profiles\".\"status\" IN ('active', 'inactive', 'graduated', 'withdrawn')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teacher_profiles": {
+      "name": "teacher_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teacher_profiles_tenant_id_tenants_id_fk": {
+          "name": "teacher_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "teacher_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "teacher_profiles_tenant_person_fk": {
+          "name": "teacher_profiles_tenant_person_fk",
+          "tableFrom": "teacher_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_profiles_pk": {
+          "name": "teacher_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "teacher_profiles_tenant_registration_number_unique": {
+          "name": "teacher_profiles_tenant_registration_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "registration_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "teacher_profiles_status_check": {
+          "name": "teacher_profiles_status_check",
+          "value": "\"teacher_profiles\".\"status\" IN ('active', 'inactive', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classes_tenant_school_idx": {
+          "name": "classes_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "classes_tenant_school_fk": {
+          "name": "classes_tenant_school_fk",
+          "tableFrom": "classes",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_tenant_school_idx": {
+          "name": "students_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "students_tenant_school_fk": {
+          "name": "students_tenant_school_fk",
+          "tableFrom": "students",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "student_number"]
+        }
+      },
+      "policies": {
+        "students_runtime_select": {
+          "name": "students_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          'tenant.students.create', 'tenant.students.read',\n          'tenant.students.update', 'tenant.students.delete',\n          'support.students.read',\n          'identity.context.resolve'\n        )\n        AND public.openschool_student_scope_allows(\n          \"students\".\"tenant_id\", \"students\".\"school_id\", \"students\".\"id\"\n        )\n      "
+        },
+        "students_runtime_insert": {
+          "name": "students_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "students_runtime_update": {
+          "name": "students_runtime_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "students_runtime_delete": {
+          "name": "students_runtime_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "students_admitter_select": {
+          "name": "students_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_insert": {
+          "name": "students_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.students.create'\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_update": {
+          "name": "students_admitter_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.update', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.update', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_delete_deny": {
+          "name": "students_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        },
+        "students_worker_select": {
+          "name": "students_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "students_worker_insert_deny": {
+          "name": "students_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "students_worker_update_deny": {
+          "name": "students_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "students_worker_delete_deny": {
+          "name": "students_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.school_enrollment_transition_events": {
+      "name": "school_enrollment_transition_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_id": {
+          "name": "transition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_enrollment_id": {
+          "name": "from_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_enrollment_id": {
+          "name": "to_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_school_id": {
+          "name": "source_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_school_id": {
+          "name": "destination_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_type": {
+          "name": "transition_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_reference": {
+          "name": "evidence_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_enrollment_version": {
+          "name": "expected_enrollment_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_tree_version_id": {
+          "name": "organization_tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_version_evidence": {
+          "name": "authorization_version_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_enrollment_transition_events_timeline_idx": {
+          "name": "school_enrollment_transition_events_timeline_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_enrollment_transition_events_due_idx": {
+          "name": "school_enrollment_transition_events_due_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_enrollment_transition_events_tenant_id_tenants_id_fk": {
+          "name": "school_enrollment_transition_events_tenant_id_tenants_id_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_actor_account_id_accounts_id_fk": {
+          "name": "school_enrollment_transition_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_person_fk": {
+          "name": "school_enrollment_transition_events_tenant_person_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_from_fk": {
+          "name": "school_enrollment_transition_events_tenant_from_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "from_enrollment_id", "person_id", "source_school_id"],
+          "columnsTo": ["tenant_id", "id", "person_id", "school_id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_to_fk": {
+          "name": "school_enrollment_transition_events_tenant_to_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "to_enrollment_id", "person_id", "destination_school_id"],
+          "columnsTo": ["tenant_id", "id", "person_id", "school_id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_source_school_fk": {
+          "name": "school_enrollment_transition_events_tenant_source_school_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "source_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_destination_school_fk": {
+          "name": "school_enrollment_transition_events_tenant_destination_school_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "destination_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_tree_version_fk": {
+          "name": "school_enrollment_transition_events_tenant_tree_version_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "organization_tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_enrollment_transition_events_tenant_id_id_unique": {
+          "name": "school_enrollment_transition_events_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "school_enrollment_transition_events_kind_unique": {
+          "name": "school_enrollment_transition_events_kind_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "transition_id", "event_type"]
+        },
+        "school_enrollment_transition_events_request_unique": {
+          "name": "school_enrollment_transition_events_request_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "request_id", "event_type"]
+        }
+      },
+      "policies": {
+        "school_enrollment_transition_events_runtime_select": {
+          "name": "school_enrollment_transition_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.student_enrollments.read', 'tenant.student_enrollments.manage')\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_runtime_insert_deny": {
+          "name": "school_enrollment_transition_events_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_runtime_update_deny": {
+          "name": "school_enrollment_transition_events_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_runtime_delete_deny": {
+          "name": "school_enrollment_transition_events_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "school_enrollment_transition_events_admitter_select": {
+          "name": "school_enrollment_transition_events_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_admitter_insert": {
+          "name": "school_enrollment_transition_events_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_admitter_update_deny": {
+          "name": "school_enrollment_transition_events_admitter_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_admitter_delete_deny": {
+          "name": "school_enrollment_transition_events_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "school_enrollment_transition_events_event_check": {
+          "name": "school_enrollment_transition_events_event_check",
+          "value": "\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'applied', 'cancelled')"
+        },
+        "school_enrollment_transition_events_transition_check": {
+          "name": "school_enrollment_transition_events_transition_check",
+          "value": "\"school_enrollment_transition_events\".\"transition_type\" IN ('withdraw', 'transfer', 'graduate', 'reenroll', 'add_secondary', 'end_secondary')"
+        },
+        "school_enrollment_transition_events_reason_check": {
+          "name": "school_enrollment_transition_events_reason_check",
+          "value": "char_length(btrim(\"school_enrollment_transition_events\".\"reason\")) BETWEEN 3 AND 512"
+        },
+        "school_enrollment_transition_events_evidence_check": {
+          "name": "school_enrollment_transition_events_evidence_check",
+          "value": "\"school_enrollment_transition_events\".\"evidence_reference\" IS NULL OR char_length(btrim(\"school_enrollment_transition_events\".\"evidence_reference\")) BETWEEN 3 AND 512"
+        },
+        "school_enrollment_transition_events_expected_version_check": {
+          "name": "school_enrollment_transition_events_expected_version_check",
+          "value": "\"school_enrollment_transition_events\".\"expected_enrollment_version\" IS NULL OR \"school_enrollment_transition_events\".\"expected_enrollment_version\" > 0"
+        },
+        "school_enrollment_transition_events_shape_check": {
+          "name": "school_enrollment_transition_events_shape_check",
+          "value": "(\n          \"school_enrollment_transition_events\".\"transition_type\" IN ('withdraw', 'graduate', 'end_secondary')\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL\n        ) OR (\n          \"school_enrollment_transition_events\".\"transition_type\" = 'transfer'\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NOT NULL\n          AND (\n            (\"school_enrollment_transition_events\".\"event_type\" = 'applied' AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NOT NULL)\n            OR (\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'cancelled') AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL)\n          )\n        ) OR (\n          \"school_enrollment_transition_events\".\"transition_type\" IN ('reenroll', 'add_secondary')\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NOT NULL\n          AND (\n            (\"school_enrollment_transition_events\".\"event_type\" = 'applied' AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NOT NULL)\n            OR (\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'cancelled') AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.school_enrollments": {
+      "name": "school_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_affiliation_id": {
+          "name": "student_affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollment_type": {
+          "name": "enrollment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_reason": {
+          "name": "admission_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_evidence_reference": {
+          "name": "end_evidence_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supersedes_enrollment_id": {
+          "name": "supersedes_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_tree_version_id": {
+          "name": "organization_tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_enrollments_tenant_school_current_idx": {
+          "name": "school_enrollments_tenant_school_current_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_enrollments_tenant_person_history_idx": {
+          "name": "school_enrollments_tenant_person_history_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_enrollments_tenant_id_tenants_id_fk": {
+          "name": "school_enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_ended_by_account_id_accounts_id_fk": {
+          "name": "school_enrollments_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_created_by_account_id_accounts_id_fk": {
+          "name": "school_enrollments_created_by_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_person_fk": {
+          "name": "school_enrollments_tenant_person_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_school_fk": {
+          "name": "school_enrollments_tenant_school_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_affiliation_fk": {
+          "name": "school_enrollments_tenant_affiliation_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "affiliations",
+          "columnsFrom": ["tenant_id", "student_affiliation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_legacy_student_fk": {
+          "name": "school_enrollments_tenant_legacy_student_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_supersedes_fk": {
+          "name": "school_enrollments_tenant_supersedes_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "supersedes_enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_tree_version_fk": {
+          "name": "school_enrollments_tenant_tree_version_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "organization_tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_enrollments_tenant_id_id_unique": {
+          "name": "school_enrollments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "school_enrollments_transition_reference_unique": {
+          "name": "school_enrollments_transition_reference_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id", "person_id", "school_id"]
+        }
+      },
+      "policies": {
+        "school_enrollments_runtime_select": {
+          "name": "school_enrollments_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          \n  'tenant.students.read', 'tenant.students.update',\n  'tenant.students.delete', 'support.students.read',\n  'tenant.student_enrollments.read', 'tenant.student_enrollments.manage'\n,\n          'tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage',\n          'tenant.households.read', 'tenant.households.manage',\n          'tenant.sections.read', 'tenant.sections.manage',\n          'identity.context.resolve'\n        )\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_section_manager_select": {
+          "name": "school_enrollments_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_section_manager'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n        AND public.openschool_school_scope_allows(\"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\")\n      "
+        },
+        "school_enrollments_runtime_insert_deny": {
+          "name": "school_enrollments_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "school_enrollments_runtime_update_deny": {
+          "name": "school_enrollments_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollments_runtime_delete_deny": {
+          "name": "school_enrollments_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "school_enrollments_admitter_select": {
+          "name": "school_enrollments_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_admitter_insert": {
+          "name": "school_enrollments_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.create', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\")\n      "
+        },
+        "school_enrollments_admitter_update": {
+          "name": "school_enrollments_admitter_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_admitter_delete_deny": {
+          "name": "school_enrollments_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        },
+        "school_enrollments_contact_manager_select": {
+          "name": "school_enrollments_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "school_enrollments_type_check": {
+          "name": "school_enrollments_type_check",
+          "value": "\"school_enrollments\".\"enrollment_type\" IN ('primary', 'secondary')"
+        },
+        "school_enrollments_status_check": {
+          "name": "school_enrollments_status_check",
+          "value": "\"school_enrollments\".\"status\" IN ('enrolled', 'withdrawn', 'graduated', 'cancelled')"
+        },
+        "school_enrollments_source_check": {
+          "name": "school_enrollments_source_check",
+          "value": "\"school_enrollments\".\"source\" IN ('legacy_backfill', 'native')"
+        },
+        "school_enrollments_valid_period_check": {
+          "name": "school_enrollments_valid_period_check",
+          "value": "\"school_enrollments\".\"valid_until\" IS NULL OR \"school_enrollments\".\"valid_until\" > \"school_enrollments\".\"valid_from\""
+        },
+        "school_enrollments_closed_status_check": {
+          "name": "school_enrollments_closed_status_check",
+          "value": "\"school_enrollments\".\"status\" = 'enrolled' OR \"school_enrollments\".\"valid_until\" IS NOT NULL"
+        },
+        "school_enrollments_legacy_source_check": {
+          "name": "school_enrollments_legacy_source_check",
+          "value": "\"school_enrollments\".\"source\" <> 'legacy_backfill' OR \"school_enrollments\".\"legacy_student_id\" IS NOT NULL"
+        },
+        "school_enrollments_native_tree_version_check": {
+          "name": "school_enrollments_native_tree_version_check",
+          "value": "\"school_enrollments\".\"source\" = 'legacy_backfill' OR \"school_enrollments\".\"organization_tree_version_id\" IS NOT NULL"
+        },
+        "school_enrollments_version_positive": {
+          "name": "school_enrollments_version_positive",
+          "value": "\"school_enrollments\".\"version\" > 0"
+        },
+        "school_enrollments_end_evidence_check": {
+          "name": "school_enrollments_end_evidence_check",
+          "value": "(\"school_enrollments\".\"valid_until\" IS NULL AND \"school_enrollments\".\"end_reason\" IS NULL AND \"school_enrollments\".\"ended_by_account_id\" IS NULL AND \"school_enrollments\".\"ended_at\" IS NULL)\n        OR (\"school_enrollments\".\"valid_until\" IS NOT NULL AND \"school_enrollments\".\"end_reason\" IS NOT NULL AND \"school_enrollments\".\"ended_at\" IS NOT NULL)"
+        },
+        "school_enrollments_end_reason_check": {
+          "name": "school_enrollments_end_reason_check",
+          "value": "\"school_enrollments\".\"end_reason\" IS NULL OR \"school_enrollments\".\"end_reason\" IN ('withdrawal', 'transfer', 'graduation', 'secondary_ended', 'correction')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.student_compatibility_evidence": {
+      "name": "student_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_enrollment_id": {
+          "name": "school_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_affiliation_id": {
+          "name": "student_affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parity_status": {
+          "name": "parity_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_snapshot": {
+          "name": "canonical_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "legacy_snapshot": {
+          "name": "legacy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_account_id": {
+          "name": "recorded_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_compatibility_evidence_tenant_person_idx": {
+          "name": "student_compatibility_evidence_tenant_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "student_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_recorded_by_account_id_accounts_id_fk": {
+          "name": "student_compatibility_evidence_recorded_by_account_id_accounts_id_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "accounts",
+          "columnsFrom": ["recorded_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_person_fk": {
+          "name": "student_compatibility_evidence_tenant_person_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_school_fk": {
+          "name": "student_compatibility_evidence_tenant_school_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_enrollment_fk": {
+          "name": "student_compatibility_evidence_tenant_enrollment_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "school_enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_affiliation_fk": {
+          "name": "student_compatibility_evidence_tenant_affiliation_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "affiliations",
+          "columnsFrom": ["tenant_id", "student_affiliation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_legacy_student_fk": {
+          "name": "student_compatibility_evidence_tenant_legacy_student_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_compatibility_evidence_tenant_id_id_unique": {
+          "name": "student_compatibility_evidence_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "student_compatibility_evidence_request_unique": {
+          "name": "student_compatibility_evidence_request_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "person_id", "request_id", "operation"]
+        }
+      },
+      "policies": {
+        "student_compatibility_evidence_runtime_select": {
+          "name": "student_compatibility_evidence_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          \n  'tenant.students.read', 'tenant.students.update',\n  'tenant.students.delete', 'support.students.read',\n  'tenant.student_enrollments.read', 'tenant.student_enrollments.manage'\n\n        )\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_runtime_insert_deny": {
+          "name": "student_compatibility_evidence_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_runtime_update_deny": {
+          "name": "student_compatibility_evidence_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_runtime_delete_deny": {
+          "name": "student_compatibility_evidence_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "student_compatibility_evidence_admitter_select": {
+          "name": "student_compatibility_evidence_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_admitter_insert": {
+          "name": "student_compatibility_evidence_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_admitter_update_deny": {
+          "name": "student_compatibility_evidence_admitter_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_admitter_delete_deny": {
+          "name": "student_compatibility_evidence_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "student_compatibility_evidence_operation_check": {
+          "name": "student_compatibility_evidence_operation_check",
+          "value": "\"student_compatibility_evidence\".\"operation\" IN ('backfill', 'create', 'update', 'transition')"
+        },
+        "student_compatibility_evidence_parity_check": {
+          "name": "student_compatibility_evidence_parity_check",
+          "value": "\"student_compatibility_evidence\".\"parity_status\" IN ('matched', 'mismatch')"
+        },
+        "student_compatibility_evidence_request_check": {
+          "name": "student_compatibility_evidence_request_check",
+          "value": "btrim(\"student_compatibility_evidence\".\"request_id\") <> ''"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_compatibility_evidence": {
+      "name": "academic_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_value": {
+          "name": "legacy_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_status": {
+          "name": "mapping_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_term_id": {
+          "name": "academic_term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_compatibility_evidence_tenant_school_idx": {
+          "name": "academic_compatibility_evidence_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mapping_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "academic_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "academic_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_school_fk": {
+          "name": "academic_compatibility_evidence_tenant_school_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_year_fk": {
+          "name": "academic_compatibility_evidence_tenant_year_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "tableTo": "academic_years",
+          "columnsFrom": ["tenant_id", "academic_year_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_term_fk": {
+          "name": "academic_compatibility_evidence_tenant_term_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "tableTo": "academic_terms",
+          "columnsFrom": ["tenant_id", "academic_term_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_compatibility_evidence_tenant_id_id_unique": {
+          "name": "academic_compatibility_evidence_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "academic_compatibility_evidence_source_unique": {
+          "name": "academic_compatibility_evidence_source_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "source_type", "source_key"]
+        }
+      },
+      "policies": {
+        "academic_compatibility_evidence_runtime_select": {
+          "name": "academic_compatibility_evidence_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_compatibility_evidence\".\"tenant_id\", \"academic_compatibility_evidence\".\"school_id\")\n"
+        },
+        "academic_compatibility_evidence_runtime_insert_deny": {
+          "name": "academic_compatibility_evidence_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_compatibility_evidence_runtime_update_deny": {
+          "name": "academic_compatibility_evidence_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_compatibility_evidence_runtime_delete_deny": {
+          "name": "academic_compatibility_evidence_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_compatibility_evidence_source_type_check": {
+          "name": "academic_compatibility_evidence_source_type_check",
+          "value": "\"academic_compatibility_evidence\".\"source_type\" IN ('school_academic_year', 'school_term', 'class_academic_year')"
+        },
+        "academic_compatibility_evidence_mapping_status_check": {
+          "name": "academic_compatibility_evidence_mapping_status_check",
+          "value": "\"academic_compatibility_evidence\".\"mapping_status\" IN ('mapped', 'unmapped', 'review_required')"
+        },
+        "academic_compatibility_evidence_source_key_check": {
+          "name": "academic_compatibility_evidence_source_key_check",
+          "value": "char_length(btrim(\"academic_compatibility_evidence\".\"source_key\")) BETWEEN 1 AND 256"
+        },
+        "academic_compatibility_evidence_reason_check": {
+          "name": "academic_compatibility_evidence_reason_check",
+          "value": "char_length(btrim(\"academic_compatibility_evidence\".\"reason\")) BETWEEN 3 AND 512"
+        },
+        "academic_compatibility_evidence_mapping_check": {
+          "name": "academic_compatibility_evidence_mapping_check",
+          "value": "\"academic_compatibility_evidence\".\"mapping_status\" <> 'mapped' OR \"academic_compatibility_evidence\".\"academic_year_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_terms": {
+      "name": "academic_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_terms_year_dates_idx": {
+          "name": "academic_terms_year_dates_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "academic_terms_tenant_id_tenants_id_fk": {
+          "name": "academic_terms_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_terms",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_terms_tenant_school_year_fk": {
+          "name": "academic_terms_tenant_school_year_fk",
+          "tableFrom": "academic_terms",
+          "tableTo": "academic_years",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_terms_tenant_id_id_unique": {
+          "name": "academic_terms_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "academic_terms_tenant_school_id_id_unique": {
+          "name": "academic_terms_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "academic_terms_year_code_unique": {
+          "name": "academic_terms_year_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "code"]
+        },
+        "academic_terms_year_ordinal_unique": {
+          "name": "academic_terms_year_ordinal_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "ordinal"]
+        }
+      },
+      "policies": {
+        "academic_terms_runtime_select": {
+          "name": "academic_terms_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_runtime_insert_deny": {
+          "name": "academic_terms_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_terms_runtime_update_deny": {
+          "name": "academic_terms_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_terms_runtime_delete_deny": {
+          "name": "academic_terms_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "academic_terms_configurator_select": {
+          "name": "academic_terms_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_section_manager_select": {
+          "name": "academic_terms_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_configurator_insert": {
+          "name": "academic_terms_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_configurator_update_deny": {
+          "name": "academic_terms_configurator_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_terms_configurator_delete_deny": {
+          "name": "academic_terms_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_terms_code_check": {
+          "name": "academic_terms_code_check",
+          "value": "char_length(btrim(\"academic_terms\".\"code\")) BETWEEN 1 AND 64 AND \"academic_terms\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "academic_terms_name_check": {
+          "name": "academic_terms_name_check",
+          "value": "char_length(btrim(\"academic_terms\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "academic_terms_ordinal_check": {
+          "name": "academic_terms_ordinal_check",
+          "value": "\"academic_terms\".\"ordinal\" BETWEEN 1 AND 20"
+        },
+        "academic_terms_dates_check": {
+          "name": "academic_terms_dates_check",
+          "value": "\"academic_terms\".\"end_date\" >= \"academic_terms\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_years": {
+      "name": "academic_years",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "migration_review_status": {
+          "name": "migration_review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "legacy_academic_year": {
+          "name": "legacy_academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by_account_id": {
+          "name": "published_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_years_tenant_school_status_dates_idx": {
+          "name": "academic_years_tenant_school_status_dates_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "academic_years_tenant_id_tenants_id_fk": {
+          "name": "academic_years_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_years_created_by_account_id_accounts_id_fk": {
+          "name": "academic_years_created_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_years_published_by_account_id_accounts_id_fk": {
+          "name": "academic_years_published_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "accounts",
+          "columnsFrom": ["published_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_years_closed_by_account_id_accounts_id_fk": {
+          "name": "academic_years_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "accounts",
+          "columnsFrom": ["closed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_years_tenant_school_fk": {
+          "name": "academic_years_tenant_school_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_years_tenant_id_id_unique": {
+          "name": "academic_years_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "academic_years_tenant_school_id_id_unique": {
+          "name": "academic_years_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "academic_years_tenant_school_code_unique": {
+          "name": "academic_years_tenant_school_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "code"]
+        }
+      },
+      "policies": {
+        "academic_years_runtime_select": {
+          "name": "academic_years_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_runtime_insert_deny": {
+          "name": "academic_years_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_years_runtime_update_deny": {
+          "name": "academic_years_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_years_runtime_delete_deny": {
+          "name": "academic_years_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "academic_years_configurator_select": {
+          "name": "academic_years_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_section_manager_select": {
+          "name": "academic_years_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_insert": {
+          "name": "academic_years_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_update": {
+          "name": "academic_years_configurator_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_delete_deny": {
+          "name": "academic_years_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_years_code_check": {
+          "name": "academic_years_code_check",
+          "value": "char_length(btrim(\"academic_years\".\"code\")) BETWEEN 1 AND 64 AND \"academic_years\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "academic_years_name_check": {
+          "name": "academic_years_name_check",
+          "value": "char_length(btrim(\"academic_years\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "academic_years_timezone_check": {
+          "name": "academic_years_timezone_check",
+          "value": "char_length(btrim(\"academic_years\".\"time_zone\")) BETWEEN 1 AND 128"
+        },
+        "academic_years_dates_check": {
+          "name": "academic_years_dates_check",
+          "value": "\"academic_years\".\"end_date\" >= \"academic_years\".\"start_date\""
+        },
+        "academic_years_status_check": {
+          "name": "academic_years_status_check",
+          "value": "\"academic_years\".\"status\" IN ('draft', 'published', 'closed')"
+        },
+        "academic_years_source_check": {
+          "name": "academic_years_source_check",
+          "value": "\"academic_years\".\"source\" IN ('native', 'legacy_backfill')"
+        },
+        "academic_years_review_check": {
+          "name": "academic_years_review_check",
+          "value": "\"academic_years\".\"migration_review_status\" IN ('not_required', 'needs_review', 'approved')"
+        },
+        "academic_years_review_source_check": {
+          "name": "academic_years_review_source_check",
+          "value": "\"academic_years\".\"source\" = 'legacy_backfill' OR \"academic_years\".\"migration_review_status\" = 'not_required'"
+        },
+        "academic_years_publish_evidence_check": {
+          "name": "academic_years_publish_evidence_check",
+          "value": "\"academic_years\".\"status\" = 'draft' OR (\"academic_years\".\"published_at\" IS NOT NULL AND \"academic_years\".\"published_by_account_id\" IS NOT NULL)"
+        },
+        "academic_years_close_evidence_check": {
+          "name": "academic_years_close_evidence_check",
+          "value": "\"academic_years\".\"status\" <> 'closed' OR (\"academic_years\".\"closed_at\" IS NOT NULL AND \"academic_years\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"academic_years\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.learner_levels": {
+      "name": "learner_levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_stage": {
+          "name": "education_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "learner_levels_year_order_idx": {
+          "name": "learner_levels_year_order_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "learner_levels_tenant_id_tenants_id_fk": {
+          "name": "learner_levels_tenant_id_tenants_id_fk",
+          "tableFrom": "learner_levels",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "learner_levels_tenant_school_year_fk": {
+          "name": "learner_levels_tenant_school_year_fk",
+          "tableFrom": "learner_levels",
+          "tableTo": "academic_years",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "learner_levels_tenant_id_id_unique": {
+          "name": "learner_levels_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "learner_levels_tenant_school_id_id_unique": {
+          "name": "learner_levels_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "learner_levels_year_code_unique": {
+          "name": "learner_levels_year_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "code"]
+        },
+        "learner_levels_year_ordinal_unique": {
+          "name": "learner_levels_year_ordinal_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "ordinal"]
+        }
+      },
+      "policies": {
+        "learner_levels_runtime_select": {
+          "name": "learner_levels_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_runtime_insert_deny": {
+          "name": "learner_levels_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "learner_levels_runtime_update_deny": {
+          "name": "learner_levels_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "learner_levels_runtime_delete_deny": {
+          "name": "learner_levels_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "learner_levels_configurator_select": {
+          "name": "learner_levels_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_section_manager_select": {
+          "name": "learner_levels_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_configurator_insert": {
+          "name": "learner_levels_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_configurator_update_deny": {
+          "name": "learner_levels_configurator_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "learner_levels_configurator_delete_deny": {
+          "name": "learner_levels_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "learner_levels_code_check": {
+          "name": "learner_levels_code_check",
+          "value": "char_length(btrim(\"learner_levels\".\"code\")) BETWEEN 1 AND 64 AND \"learner_levels\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "learner_levels_name_check": {
+          "name": "learner_levels_name_check",
+          "value": "char_length(btrim(\"learner_levels\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "learner_levels_ordinal_check": {
+          "name": "learner_levels_ordinal_check",
+          "value": "\"learner_levels\".\"ordinal\" BETWEEN 1 AND 30"
+        },
+        "learner_levels_stage_check": {
+          "name": "learner_levels_stage_check",
+          "value": "\"learner_levels\".\"education_stage\" IS NULL OR char_length(btrim(\"learner_levels\".\"education_stage\")) BETWEEN 1 AND 64"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_type": {
+          "name": "course_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_area": {
+          "name": "subject_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_value": {
+          "name": "credit_value",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by_account_id": {
+          "name": "archived_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "courses_tenant_school_status_name_idx": {
+          "name": "courses_tenant_school_status_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "courses_tenant_id_tenants_id_fk": {
+          "name": "courses_tenant_id_tenants_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "courses_created_by_account_id_accounts_id_fk": {
+          "name": "courses_created_by_account_id_accounts_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "courses_archived_by_account_id_accounts_id_fk": {
+          "name": "courses_archived_by_account_id_accounts_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "accounts",
+          "columnsFrom": ["archived_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "courses_tenant_school_fk": {
+          "name": "courses_tenant_school_fk",
+          "tableFrom": "courses",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "courses_tenant_id_id_unique": {
+          "name": "courses_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "courses_tenant_school_id_id_unique": {
+          "name": "courses_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "courses_tenant_school_code_unique": {
+          "name": "courses_tenant_school_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "code"]
+        }
+      },
+      "policies": {
+        "courses_runtime_select": {
+          "name": "courses_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_course_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\", \"courses\".\"id\")\n      "
+        },
+        "courses_runtime_write_deny": {
+          "name": "courses_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "courses_manager_all": {
+          "name": "courses_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "courses_code_check": {
+          "name": "courses_code_check",
+          "value": "char_length(btrim(\"courses\".\"code\")) BETWEEN 1 AND 64 AND \"courses\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "courses_name_check": {
+          "name": "courses_name_check",
+          "value": "char_length(btrim(\"courses\".\"name\")) BETWEEN 1 AND 160"
+        },
+        "courses_type_check": {
+          "name": "courses_type_check",
+          "value": "\"courses\".\"course_type\" IN ('general', 'subject', 'elective', 'support')"
+        },
+        "courses_status_check": {
+          "name": "courses_status_check",
+          "value": "\"courses\".\"status\" IN ('active', 'archived')"
+        },
+        "courses_credit_check": {
+          "name": "courses_credit_check",
+          "value": "\"courses\".\"credit_value\" IS NULL OR (\"courses\".\"credit_value\" >= 0 AND \"courses\".\"credit_value\" <= 100)"
+        },
+        "courses_creation_reason_check": {
+          "name": "courses_creation_reason_check",
+          "value": "char_length(btrim(\"courses\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "courses_archive_evidence_check": {
+          "name": "courses_archive_evidence_check",
+          "value": "\"courses\".\"status\" <> 'archived' OR (\"courses\".\"archived_at\" IS NOT NULL AND \"courses\".\"archived_by_account_id\" IS NOT NULL AND char_length(btrim(\"courses\".\"archive_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_compatibility_evidence": {
+      "name": "section_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_class_id": {
+          "name": "legacy_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapping_status": {
+          "name": "mapping_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_roster_count": {
+          "name": "legacy_roster_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_roster_count": {
+          "name": "canonical_roster_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_roster_hash": {
+          "name": "legacy_roster_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_roster_hash": {
+          "name": "canonical_roster_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_compatibility_tenant_school_status_idx": {
+          "name": "section_compatibility_tenant_school_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mapping_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "section_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_compatibility_tenant_school_fk": {
+          "name": "section_compatibility_tenant_school_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_compatibility_tenant_legacy_class_fk": {
+          "name": "section_compatibility_tenant_legacy_class_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "legacy_class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_compatibility_tenant_section_fk": {
+          "name": "section_compatibility_tenant_section_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "tableTo": "sections",
+          "columnsFrom": ["tenant_id", "section_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_compatibility_tenant_id_id_unique": {
+          "name": "section_compatibility_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "section_compatibility_legacy_class_unique": {
+          "name": "section_compatibility_legacy_class_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_class_id"]
+        }
+      },
+      "policies": {
+        "section_compatibility_runtime_select": {
+          "name": "section_compatibility_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"section_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_school_scope_allows(\"section_compatibility_evidence\".\"tenant_id\", \"section_compatibility_evidence\".\"school_id\")\n      "
+        },
+        "section_compatibility_runtime_write_deny": {
+          "name": "section_compatibility_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        }
+      },
+      "checkConstraints": {
+        "section_compatibility_status_check": {
+          "name": "section_compatibility_status_check",
+          "value": "\"section_compatibility_evidence\".\"mapping_status\" IN ('mapped', 'unmapped', 'review_required')"
+        },
+        "section_compatibility_counts_check": {
+          "name": "section_compatibility_counts_check",
+          "value": "\"section_compatibility_evidence\".\"legacy_roster_count\" >= 0 AND \"section_compatibility_evidence\".\"canonical_roster_count\" >= 0"
+        },
+        "section_compatibility_mapping_check": {
+          "name": "section_compatibility_mapping_check",
+          "value": "\"section_compatibility_evidence\".\"mapping_status\" <> 'mapped' OR (\"section_compatibility_evidence\".\"section_id\" IS NOT NULL AND \"section_compatibility_evidence\".\"legacy_roster_count\" = \"section_compatibility_evidence\".\"canonical_roster_count\" AND \"section_compatibility_evidence\".\"legacy_roster_hash\" = \"section_compatibility_evidence\".\"canonical_roster_hash\")"
+        },
+        "section_compatibility_reason_check": {
+          "name": "section_compatibility_reason_check",
+          "value": "char_length(btrim(\"section_compatibility_evidence\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_roster_memberships": {
+      "name": "section_roster_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_enrollment_id": {
+          "name": "school_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_key": {
+          "name": "roster_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_enrollment_id": {
+          "name": "legacy_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_rosters_tenant_section_effective_idx": {
+          "name": "section_rosters_tenant_section_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_rosters_tenant_person_effective_idx": {
+          "name": "section_rosters_tenant_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_roster_memberships_tenant_id_tenants_id_fk": {
+          "name": "section_roster_memberships_tenant_id_tenants_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_roster_memberships_issued_by_account_id_accounts_id_fk": {
+          "name": "section_roster_memberships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_roster_memberships_ended_by_account_id_accounts_id_fk": {
+          "name": "section_roster_memberships_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_rosters_tenant_section_fk": {
+          "name": "section_rosters_tenant_section_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "sections",
+          "columnsFrom": ["tenant_id", "school_id", "section_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_rosters_tenant_person_fk": {
+          "name": "section_rosters_tenant_person_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_rosters_tenant_school_enrollment_fk": {
+          "name": "section_rosters_tenant_school_enrollment_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "school_enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_rosters_tenant_legacy_enrollment_fk": {
+          "name": "section_rosters_tenant_legacy_enrollment_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "enrollments",
+          "columnsFrom": ["tenant_id", "legacy_enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_rosters_tenant_id_id_unique": {
+          "name": "section_rosters_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "section_rosters_key_version_unique": {
+          "name": "section_rosters_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "roster_key", "version"]
+        },
+        "section_rosters_legacy_enrollment_unique": {
+          "name": "section_rosters_legacy_enrollment_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_enrollment_id"]
+        }
+      },
+      "policies": {
+        "section_rosters_runtime_select": {
+          "name": "section_rosters_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_section_roster_scope_allows(\n          \"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\", \"section_roster_memberships\".\"section_id\", \"section_roster_memberships\".\"person_id\"\n        )\n      "
+        },
+        "section_rosters_runtime_write_deny": {
+          "name": "section_rosters_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "section_rosters_manager_all": {
+          "name": "section_rosters_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "section_rosters_period_check": {
+          "name": "section_rosters_period_check",
+          "value": "\"section_roster_memberships\".\"valid_until\" IS NULL OR \"section_roster_memberships\".\"valid_until\" > \"section_roster_memberships\".\"valid_from\""
+        },
+        "section_rosters_status_check": {
+          "name": "section_rosters_status_check",
+          "value": "\"section_roster_memberships\".\"status\" IN ('active', 'ended')"
+        },
+        "section_rosters_end_evidence_check": {
+          "name": "section_rosters_end_evidence_check",
+          "value": "\"section_roster_memberships\".\"status\" <> 'ended' OR (\"section_roster_memberships\".\"valid_until\" IS NOT NULL AND \"section_roster_memberships\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"section_roster_memberships\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "section_rosters_version_positive": {
+          "name": "section_rosters_version_positive",
+          "value": "\"section_roster_memberships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_staff_assignments": {
+      "name": "section_staff_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_key": {
+          "name": "assignment_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_teacher_class_id": {
+          "name": "legacy_teacher_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_staff_tenant_section_effective_idx": {
+          "name": "section_staff_tenant_section_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_staff_assignments_tenant_id_tenants_id_fk": {
+          "name": "section_staff_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_assignments_issued_by_account_id_accounts_id_fk": {
+          "name": "section_staff_assignments_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_assignments_ended_by_account_id_accounts_id_fk": {
+          "name": "section_staff_assignments_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_tenant_section_fk": {
+          "name": "section_staff_tenant_section_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "sections",
+          "columnsFrom": ["tenant_id", "school_id", "section_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_tenant_person_fk": {
+          "name": "section_staff_tenant_person_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_tenant_legacy_assignment_fk": {
+          "name": "section_staff_tenant_legacy_assignment_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "teachers_on_class",
+          "columnsFrom": ["tenant_id", "legacy_teacher_class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_staff_tenant_id_id_unique": {
+          "name": "section_staff_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "section_staff_key_version_unique": {
+          "name": "section_staff_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "assignment_key", "version"]
+        },
+        "section_staff_legacy_assignment_unique": {
+          "name": "section_staff_legacy_assignment_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_teacher_class_id"]
+        }
+      },
+      "policies": {
+        "section_staff_runtime_select": {
+          "name": "section_staff_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.sections.read', 'tenant.sections.manage')\n  AND public.openschool_section_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\", \"section_staff_assignments\".\"section_id\")\n"
+        },
+        "section_staff_runtime_write_deny": {
+          "name": "section_staff_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "section_staff_manager_all": {
+          "name": "section_staff_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "section_staff_role_check": {
+          "name": "section_staff_role_check",
+          "value": "\"section_staff_assignments\".\"role\" IN ('lead_teacher', 'teacher', 'assistant', 'counselor')"
+        },
+        "section_staff_status_check": {
+          "name": "section_staff_status_check",
+          "value": "\"section_staff_assignments\".\"status\" IN ('active', 'ended')"
+        },
+        "section_staff_period_check": {
+          "name": "section_staff_period_check",
+          "value": "\"section_staff_assignments\".\"valid_until\" IS NULL OR \"section_staff_assignments\".\"valid_until\" > \"section_staff_assignments\".\"valid_from\""
+        },
+        "section_staff_end_evidence_check": {
+          "name": "section_staff_end_evidence_check",
+          "value": "\"section_staff_assignments\".\"status\" <> 'ended' OR (\"section_staff_assignments\".\"valid_until\" IS NOT NULL AND \"section_staff_assignments\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"section_staff_assignments\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "section_staff_version_positive": {
+          "name": "section_staff_version_positive",
+          "value": "\"section_staff_assignments\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_term_id": {
+          "name": "academic_term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learner_level_id": {
+          "name": "learner_level_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "legacy_class_id": {
+          "name": "legacy_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_by_account_id": {
+          "name": "activated_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sections_tenant_school_year_status_idx": {
+          "name": "sections_tenant_school_year_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sections_tenant_id_tenants_id_fk": {
+          "name": "sections_tenant_id_tenants_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_created_by_account_id_accounts_id_fk": {
+          "name": "sections_created_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_activated_by_account_id_accounts_id_fk": {
+          "name": "sections_activated_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "accounts",
+          "columnsFrom": ["activated_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_closed_by_account_id_accounts_id_fk": {
+          "name": "sections_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "accounts",
+          "columnsFrom": ["closed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_fk": {
+          "name": "sections_tenant_school_fk",
+          "tableFrom": "sections",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_year_fk": {
+          "name": "sections_tenant_school_year_fk",
+          "tableFrom": "sections",
+          "tableTo": "academic_years",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_term_fk": {
+          "name": "sections_tenant_school_term_fk",
+          "tableFrom": "sections",
+          "tableTo": "academic_terms",
+          "columnsFrom": ["tenant_id", "school_id", "academic_term_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_level_fk": {
+          "name": "sections_tenant_school_level_fk",
+          "tableFrom": "sections",
+          "tableTo": "learner_levels",
+          "columnsFrom": ["tenant_id", "school_id", "learner_level_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_course_fk": {
+          "name": "sections_tenant_school_course_fk",
+          "tableFrom": "sections",
+          "tableTo": "courses",
+          "columnsFrom": ["tenant_id", "school_id", "course_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_legacy_class_fk": {
+          "name": "sections_tenant_legacy_class_fk",
+          "tableFrom": "sections",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "legacy_class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sections_tenant_id_id_unique": {
+          "name": "sections_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "sections_tenant_school_id_id_unique": {
+          "name": "sections_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "sections_year_code_unique": {
+          "name": "sections_year_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "code"]
+        },
+        "sections_legacy_class_unique": {
+          "name": "sections_legacy_class_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_class_id"]
+        }
+      },
+      "policies": {
+        "sections_runtime_select": {
+          "name": "sections_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.sections.read', 'tenant.sections.manage')\n  AND public.openschool_section_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\", \"sections\".\"id\")\n"
+        },
+        "sections_runtime_write_deny": {
+          "name": "sections_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "sections_manager_all": {
+          "name": "sections_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "sections_code_check": {
+          "name": "sections_code_check",
+          "value": "char_length(btrim(\"sections\".\"code\")) BETWEEN 1 AND 64 AND \"sections\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "sections_name_check": {
+          "name": "sections_name_check",
+          "value": "char_length(btrim(\"sections\".\"name\")) BETWEEN 1 AND 160"
+        },
+        "sections_type_check": {
+          "name": "sections_type_check",
+          "value": "\"sections\".\"section_type\" IN ('homeroom', 'course')"
+        },
+        "sections_course_requirement_check": {
+          "name": "sections_course_requirement_check",
+          "value": "\"sections\".\"section_type\" <> 'course' OR \"sections\".\"course_id\" IS NOT NULL"
+        },
+        "sections_dates_check": {
+          "name": "sections_dates_check",
+          "value": "\"sections\".\"end_date\" >= \"sections\".\"start_date\""
+        },
+        "sections_status_check": {
+          "name": "sections_status_check",
+          "value": "\"sections\".\"status\" IN ('draft', 'active', 'closed')"
+        },
+        "sections_capacity_check": {
+          "name": "sections_capacity_check",
+          "value": "\"sections\".\"capacity\" IS NULL OR \"sections\".\"capacity\" > 0"
+        },
+        "sections_version_positive": {
+          "name": "sections_version_positive",
+          "value": "\"sections\".\"version\" > 0"
+        },
+        "sections_source_check": {
+          "name": "sections_source_check",
+          "value": "\"sections\".\"source\" IN ('native', 'legacy_backfill') AND (\"sections\".\"source\" <> 'legacy_backfill' OR \"sections\".\"legacy_class_id\" IS NOT NULL)"
+        },
+        "sections_creation_reason_check": {
+          "name": "sections_creation_reason_check",
+          "value": "char_length(btrim(\"sections\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "sections_activation_evidence_check": {
+          "name": "sections_activation_evidence_check",
+          "value": "\"sections\".\"status\" = 'draft' OR (\"sections\".\"activated_at\" IS NOT NULL AND \"sections\".\"activated_by_account_id\" IS NOT NULL)"
+        },
+        "sections_closure_evidence_check": {
+          "name": "sections_closure_evidence_check",
+          "value": "\"sections\".\"status\" <> 'closed' OR (\"sections\".\"closed_at\" IS NOT NULL AND \"sections\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"sections\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_duplicate_case_events": {
+      "name": "person_duplicate_case_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signals": {
+          "name": "signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_hash": {
+          "name": "evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_duplicate_case_events_history_idx": {
+          "name": "person_duplicate_case_events_history_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_duplicate_case_events_tenant_id_tenants_id_fk": {
+          "name": "person_duplicate_case_events_tenant_id_tenants_id_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_case_events_actor_account_id_accounts_id_fk": {
+          "name": "person_duplicate_case_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_case_events_tenant_case_fk": {
+          "name": "person_duplicate_case_events_tenant_case_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "tableTo": "person_duplicate_cases",
+          "columnsFrom": ["tenant_id", "case_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_case_events_tenant_school_fk": {
+          "name": "person_duplicate_case_events_tenant_school_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_duplicate_case_events_tenant_id_id_unique": {
+          "name": "person_duplicate_case_events_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_duplicate_case_events_case_version_unique": {
+          "name": "person_duplicate_case_events_case_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "case_id", "version"]
+        }
+      },
+      "policies": {
+        "person_duplicate_case_events_runtime_select": {
+          "name": "person_duplicate_case_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_duplicates.read',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        },
+        "person_duplicate_case_events_runtime_write_deny": {
+          "name": "person_duplicate_case_events_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_duplicate_case_events_manager_select": {
+          "name": "person_duplicate_case_events_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_duplicate_review_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        },
+        "person_duplicate_case_events_manager_insert": {
+          "name": "person_duplicate_case_events_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_duplicate_review_manager"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_duplicate_case_events_version_check": {
+          "name": "person_duplicate_case_events_version_check",
+          "value": "\"person_duplicate_case_events\".\"version\" > 0"
+        },
+        "person_duplicate_case_events_type_check": {
+          "name": "person_duplicate_case_events_type_check",
+          "value": "\"person_duplicate_case_events\".\"event_type\" IN ('candidate_detected', 'evidence_refreshed', 'evidence_no_longer_matches', 'marked_distinct', 'merge_approval_requested')"
+        },
+        "person_duplicate_case_events_score_check": {
+          "name": "person_duplicate_case_events_score_check",
+          "value": "\"person_duplicate_case_events\".\"score\" BETWEEN 0 AND 100"
+        },
+        "person_duplicate_case_events_signals_check": {
+          "name": "person_duplicate_case_events_signals_check",
+          "value": "jsonb_typeof(\"person_duplicate_case_events\".\"signals\") = 'array' AND jsonb_array_length(\"person_duplicate_case_events\".\"signals\") <= 4"
+        },
+        "person_duplicate_case_events_hash_check": {
+          "name": "person_duplicate_case_events_hash_check",
+          "value": "\"person_duplicate_case_events\".\"evidence_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_duplicate_case_events_reason_check": {
+          "name": "person_duplicate_case_events_reason_check",
+          "value": "char_length(btrim(\"person_duplicate_case_events\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_duplicate_cases": {
+      "name": "person_duplicate_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_person_id": {
+          "name": "first_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_person_id": {
+          "name": "second_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_score": {
+          "name": "current_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_signals": {
+          "name": "current_signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_evidence_hash": {
+          "name": "current_evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_duplicate_cases_queue_idx": {
+          "name": "person_duplicate_cases_queue_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_duplicate_cases_first_person_idx": {
+          "name": "person_duplicate_cases_first_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_duplicate_cases_second_person_idx": {
+          "name": "person_duplicate_cases_second_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "second_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_duplicate_cases_tenant_id_tenants_id_fk": {
+          "name": "person_duplicate_cases_tenant_id_tenants_id_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_cases_created_by_account_id_accounts_id_fk": {
+          "name": "person_duplicate_cases_created_by_account_id_accounts_id_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_cases_tenant_school_fk": {
+          "name": "person_duplicate_cases_tenant_school_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_cases_tenant_first_person_fk": {
+          "name": "person_duplicate_cases_tenant_first_person_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "first_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_cases_tenant_second_person_fk": {
+          "name": "person_duplicate_cases_tenant_second_person_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "second_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_duplicate_cases_tenant_id_id_unique": {
+          "name": "person_duplicate_cases_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_duplicate_cases_school_pair_unique": {
+          "name": "person_duplicate_cases_school_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "review_school_id", "first_person_id", "second_person_id"]
+        }
+      },
+      "policies": {
+        "person_duplicate_cases_runtime_select": {
+          "name": "person_duplicate_cases_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_duplicates.read',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n"
+        },
+        "person_duplicate_cases_runtime_write_deny": {
+          "name": "person_duplicate_cases_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_duplicate_cases_manager_all": {
+          "name": "person_duplicate_cases_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_duplicate_review_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_duplicate_cases_pair_order_check": {
+          "name": "person_duplicate_cases_pair_order_check",
+          "value": "\"person_duplicate_cases\".\"first_person_id\"::text < \"person_duplicate_cases\".\"second_person_id\"::text"
+        },
+        "person_duplicate_cases_status_check": {
+          "name": "person_duplicate_cases_status_check",
+          "value": "\"person_duplicate_cases\".\"status\" IN ('open', 'distinct', 'merge_approval_requested', 'superseded')"
+        },
+        "person_duplicate_cases_version_check": {
+          "name": "person_duplicate_cases_version_check",
+          "value": "\"person_duplicate_cases\".\"current_version\" > 0"
+        },
+        "person_duplicate_cases_score_check": {
+          "name": "person_duplicate_cases_score_check",
+          "value": "\"person_duplicate_cases\".\"current_score\" BETWEEN 0 AND 100"
+        },
+        "person_duplicate_cases_signals_check": {
+          "name": "person_duplicate_cases_signals_check",
+          "value": "jsonb_typeof(\"person_duplicate_cases\".\"current_signals\") = 'array' AND jsonb_array_length(\"person_duplicate_cases\".\"current_signals\") <= 4"
+        },
+        "person_duplicate_cases_hash_check": {
+          "name": "person_duplicate_cases_hash_check",
+          "value": "\"person_duplicate_cases\".\"current_evidence_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_aliases": {
+      "name": "person_merge_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_by_account_id": {
+          "name": "reversed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_aliases_target_idx": {
+          "name": "person_merge_aliases_target_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_aliases_tenant_id_tenants_id_fk": {
+          "name": "person_merge_aliases_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_reversed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_aliases_reversed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "accounts",
+          "columnsFrom": ["reversed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_tenant_operation_fk": {
+          "name": "person_merge_aliases_tenant_operation_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_tenant_school_fk": {
+          "name": "person_merge_aliases_tenant_school_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_tenant_source_fk": {
+          "name": "person_merge_aliases_tenant_source_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_tenant_target_fk": {
+          "name": "person_merge_aliases_tenant_target_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_aliases_tenant_id_id_unique": {
+          "name": "person_merge_aliases_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_merge_aliases_tenant_source_unique": {
+          "name": "person_merge_aliases_tenant_source_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "source_person_id"]
+        },
+        "person_merge_aliases_tenant_operation_unique": {
+          "name": "person_merge_aliases_tenant_operation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id"]
+        }
+      },
+      "policies": {
+        "person_merge_aliases_runtime_select": {
+          "name": "person_merge_aliases_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n"
+        },
+        "person_merge_aliases_runtime_write_deny": {
+          "name": "person_merge_aliases_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_aliases_manager_all": {
+          "name": "person_merge_aliases_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_aliases_people_check": {
+          "name": "person_merge_aliases_people_check",
+          "value": "\"person_merge_aliases\".\"source_person_id\" <> \"person_merge_aliases\".\"target_person_id\""
+        },
+        "person_merge_aliases_status_check": {
+          "name": "person_merge_aliases_status_check",
+          "value": "\"person_merge_aliases\".\"status\" IN ('active', 'reversed')"
+        },
+        "person_merge_aliases_version_check": {
+          "name": "person_merge_aliases_version_check",
+          "value": "\"person_merge_aliases\".\"version\" > 0"
+        },
+        "person_merge_aliases_reversal_check": {
+          "name": "person_merge_aliases_reversal_check",
+          "value": "\"person_merge_aliases\".\"status\" <> 'reversed'\n        OR (\"person_merge_aliases\".\"reversed_at\" IS NOT NULL AND \"person_merge_aliases\".\"reversed_by_account_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_events": {
+      "name": "person_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_status": {
+          "name": "operation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_digest": {
+          "name": "preview_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_events_operation_idx": {
+          "name": "person_merge_events_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_events_tenant_id_tenants_id_fk": {
+          "name": "person_merge_events_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_events_actor_account_id_accounts_id_fk": {
+          "name": "person_merge_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_events_tenant_operation_fk": {
+          "name": "person_merge_events_tenant_operation_fk",
+          "tableFrom": "person_merge_events",
+          "tableTo": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_events_tenant_school_fk": {
+          "name": "person_merge_events_tenant_school_fk",
+          "tableFrom": "person_merge_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_events_tenant_id_id_unique": {
+          "name": "person_merge_events_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_merge_events_operation_version_unique": {
+          "name": "person_merge_events_operation_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id", "version"]
+        }
+      },
+      "policies": {
+        "person_merge_events_runtime_select": {
+          "name": "person_merge_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n"
+        },
+        "person_merge_events_runtime_write_deny": {
+          "name": "person_merge_events_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_events_manager_all": {
+          "name": "person_merge_events_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_events_version_check": {
+          "name": "person_merge_events_version_check",
+          "value": "\"person_merge_events\".\"version\" > 0"
+        },
+        "person_merge_events_type_check": {
+          "name": "person_merge_events_type_check",
+          "value": "\"person_merge_events\".\"event_type\" IN ('preview_created', 'approval_granted', 'executed', 'reversal_requested', 'reversed', 'manual_recovery_required')"
+        },
+        "person_merge_events_status_check": {
+          "name": "person_merge_events_status_check",
+          "value": "\"person_merge_events\".\"operation_status\" IN ('blocked', 'pending_approval', 'approved', 'executed', 'reversed', 'manual_recovery')"
+        },
+        "person_merge_events_hash_check": {
+          "name": "person_merge_events_hash_check",
+          "value": "\"person_merge_events\".\"preview_digest\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_merge_events_reason_check": {
+          "name": "person_merge_events_reason_check",
+          "value": "char_length(btrim(\"person_merge_events\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_moves": {
+      "name": "person_merge_moves",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_name": {
+          "name": "relation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_key": {
+          "name": "source_record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_record_key": {
+          "name": "replacement_record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_fingerprint": {
+          "name": "before_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after_fingerprint": {
+          "name": "after_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_moves_operation_idx": {
+          "name": "person_merge_moves_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_moves_tenant_id_tenants_id_fk": {
+          "name": "person_merge_moves_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_moves",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_moves_tenant_operation_fk": {
+          "name": "person_merge_moves_tenant_operation_fk",
+          "tableFrom": "person_merge_moves",
+          "tableTo": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_moves_tenant_school_fk": {
+          "name": "person_merge_moves_tenant_school_fk",
+          "tableFrom": "person_merge_moves",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_moves_tenant_id_id_unique": {
+          "name": "person_merge_moves_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_merge_moves_operation_sequence_unique": {
+          "name": "person_merge_moves_operation_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id", "sequence"]
+        },
+        "person_merge_moves_operation_record_unique": {
+          "name": "person_merge_moves_operation_record_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id", "relation_name", "source_record_key"]
+        }
+      },
+      "policies": {
+        "person_merge_moves_runtime_select": {
+          "name": "person_merge_moves_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n"
+        },
+        "person_merge_moves_runtime_write_deny": {
+          "name": "person_merge_moves_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_moves_manager_all": {
+          "name": "person_merge_moves_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_moves_sequence_check": {
+          "name": "person_merge_moves_sequence_check",
+          "value": "\"person_merge_moves\".\"sequence\" > 0"
+        },
+        "person_merge_moves_action_check": {
+          "name": "person_merge_moves_action_check",
+          "value": "\"person_merge_moves\".\"action\" IN ('repoint', 'end_and_recreate', 'preserve_history', 'invalidate', 'archive_source')"
+        },
+        "person_merge_moves_text_check": {
+          "name": "person_merge_moves_text_check",
+          "value": "char_length(\"person_merge_moves\".\"relation_name\") BETWEEN 3 AND 128\n        AND char_length(\"person_merge_moves\".\"source_record_key\") BETWEEN 1 AND 512\n        AND (\"person_merge_moves\".\"replacement_record_key\" IS NULL\n          OR char_length(\"person_merge_moves\".\"replacement_record_key\") BETWEEN 1 AND 512)"
+        },
+        "person_merge_moves_hash_check": {
+          "name": "person_merge_moves_hash_check",
+          "value": "\"person_merge_moves\".\"before_fingerprint\" ~ '^[0-9a-f]{64}$'\n        AND \"person_merge_moves\".\"after_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_operations": {
+      "name": "person_merge_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_case_id": {
+          "name": "duplicate_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_case_version": {
+          "name": "duplicate_case_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_evidence_hash": {
+          "name": "duplicate_evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plan_version": {
+          "name": "plan_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "preview_digest": {
+          "name": "preview_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_digest": {
+          "name": "execution_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_count": {
+          "name": "dependency_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "invalidation_count": {
+          "name": "invalidation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "initiated_by_account_id": {
+          "name": "initiated_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiation_reason": {
+          "name": "initiation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by_account_id": {
+          "name": "approved_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_reason": {
+          "name": "approval_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_by_account_id": {
+          "name": "executed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_by_account_id": {
+          "name": "reversed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_operations_active_source_unique": {
+          "name": "person_merge_operations_active_source_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"person_merge_operations\".\"status\" IN ('pending_approval', 'approved', 'executed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_merge_operations_school_status_idx": {
+          "name": "person_merge_operations_school_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_merge_operations_case_idx": {
+          "name": "person_merge_operations_case_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "duplicate_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_operations_tenant_id_tenants_id_fk": {
+          "name": "person_merge_operations_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_initiated_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_initiated_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "accounts",
+          "columnsFrom": ["initiated_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_approved_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_approved_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "accounts",
+          "columnsFrom": ["approved_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_executed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_executed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "accounts",
+          "columnsFrom": ["executed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_reversed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_reversed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "accounts",
+          "columnsFrom": ["reversed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_tenant_school_fk": {
+          "name": "person_merge_operations_tenant_school_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_tenant_case_fk": {
+          "name": "person_merge_operations_tenant_case_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "person_duplicate_cases",
+          "columnsFrom": ["tenant_id", "duplicate_case_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_tenant_source_fk": {
+          "name": "person_merge_operations_tenant_source_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_tenant_target_fk": {
+          "name": "person_merge_operations_tenant_target_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_operations_tenant_id_id_unique": {
+          "name": "person_merge_operations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {
+        "person_merge_operations_runtime_select": {
+          "name": "person_merge_operations_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n"
+        },
+        "person_merge_operations_runtime_write_deny": {
+          "name": "person_merge_operations_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_operations_manager_all": {
+          "name": "person_merge_operations_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_operations_status_check": {
+          "name": "person_merge_operations_status_check",
+          "value": "\"person_merge_operations\".\"status\" IN ('blocked', 'pending_approval', 'approved', 'executed', 'reversed', 'manual_recovery')"
+        },
+        "person_merge_operations_people_check": {
+          "name": "person_merge_operations_people_check",
+          "value": "\"person_merge_operations\".\"source_person_id\" <> \"person_merge_operations\".\"target_person_id\""
+        },
+        "person_merge_operations_version_check": {
+          "name": "person_merge_operations_version_check",
+          "value": "\"person_merge_operations\".\"current_version\" > 0 AND \"person_merge_operations\".\"plan_version\" > 0"
+        },
+        "person_merge_operations_hash_check": {
+          "name": "person_merge_operations_hash_check",
+          "value": "\"person_merge_operations\".\"duplicate_evidence_hash\" ~ '^[0-9a-f]{64}$'\n        AND \"person_merge_operations\".\"preview_digest\" ~ '^[0-9a-f]{64}$'\n        AND (\"person_merge_operations\".\"execution_digest\" IS NULL OR \"person_merge_operations\".\"execution_digest\" ~ '^[0-9a-f]{64}$')"
+        },
+        "person_merge_operations_count_check": {
+          "name": "person_merge_operations_count_check",
+          "value": "\"person_merge_operations\".\"dependency_count\" >= 0 AND \"person_merge_operations\".\"conflict_count\" >= 0\n        AND \"person_merge_operations\".\"conflict_count\" <= \"person_merge_operations\".\"dependency_count\"\n        AND \"person_merge_operations\".\"invalidation_count\" >= 0"
+        },
+        "person_merge_operations_reason_check": {
+          "name": "person_merge_operations_reason_check",
+          "value": "char_length(btrim(\"person_merge_operations\".\"initiation_reason\")) BETWEEN 3 AND 512\n        AND (\"person_merge_operations\".\"approval_reason\" IS NULL OR char_length(btrim(\"person_merge_operations\".\"approval_reason\")) BETWEEN 3 AND 512)"
+        },
+        "person_merge_operations_approval_check": {
+          "name": "person_merge_operations_approval_check",
+          "value": "(\"person_merge_operations\".\"status\" NOT IN ('approved', 'executed', 'reversed', 'manual_recovery'))\n        OR (\"person_merge_operations\".\"approved_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"approval_reason\" IS NOT NULL\n          AND \"person_merge_operations\".\"approved_at\" IS NOT NULL AND \"person_merge_operations\".\"approved_by_account_id\" <> \"person_merge_operations\".\"initiated_by_account_id\")"
+        },
+        "person_merge_operations_execution_check": {
+          "name": "person_merge_operations_execution_check",
+          "value": "\"person_merge_operations\".\"status\" NOT IN ('executed', 'reversed', 'manual_recovery')\n        OR (\"person_merge_operations\".\"executed_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"executed_at\" IS NOT NULL\n          AND \"person_merge_operations\".\"execution_digest\" IS NOT NULL)"
+        },
+        "person_merge_operations_reversal_check": {
+          "name": "person_merge_operations_reversal_check",
+          "value": "\"person_merge_operations\".\"status\" <> 'reversed'\n        OR (\"person_merge_operations\".\"reversed_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"reversed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_preview_items": {
+      "name": "person_merge_preview_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_name": {
+          "name": "relation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflict_code": {
+          "name": "conflict_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_fingerprint": {
+          "name": "row_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_preview_items_operation_idx": {
+          "name": "person_merge_preview_items_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_preview_items_tenant_id_tenants_id_fk": {
+          "name": "person_merge_preview_items_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_preview_items",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_preview_items_tenant_operation_fk": {
+          "name": "person_merge_preview_items_tenant_operation_fk",
+          "tableFrom": "person_merge_preview_items",
+          "tableTo": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_preview_items_tenant_school_fk": {
+          "name": "person_merge_preview_items_tenant_school_fk",
+          "tableFrom": "person_merge_preview_items",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_preview_items_tenant_id_id_unique": {
+          "name": "person_merge_preview_items_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_merge_preview_items_operation_record_unique": {
+          "name": "person_merge_preview_items_operation_record_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id", "relation_name", "record_key", "direction"]
+        }
+      },
+      "policies": {
+        "person_merge_preview_items_runtime_select": {
+          "name": "person_merge_preview_items_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n"
+        },
+        "person_merge_preview_items_runtime_write_deny": {
+          "name": "person_merge_preview_items_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_preview_items_manager_all": {
+          "name": "person_merge_preview_items_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_preview_items_category_check": {
+          "name": "person_merge_preview_items_category_check",
+          "value": "\"person_merge_preview_items\".\"category\" IN ('account_link', 'profile', 'affiliation', 'relationship', 'household_membership', 'school_enrollment', 'section_staff', 'section_roster', 'invitation', 'authorization_history', 'academic_history', 'duplicate_case', 'audit_history', 'compatibility_evidence')"
+        },
+        "person_merge_preview_items_direction_check": {
+          "name": "person_merge_preview_items_direction_check",
+          "value": "\"person_merge_preview_items\".\"direction\" IN ('source', 'subject', 'related', 'actor', 'none')"
+        },
+        "person_merge_preview_items_disposition_check": {
+          "name": "person_merge_preview_items_disposition_check",
+          "value": "\"person_merge_preview_items\".\"disposition\" IN ('move', 'end_and_recreate', 'preserve_history', 'block')"
+        },
+        "person_merge_preview_items_text_check": {
+          "name": "person_merge_preview_items_text_check",
+          "value": "char_length(\"person_merge_preview_items\".\"relation_name\") BETWEEN 3 AND 128\n        AND char_length(\"person_merge_preview_items\".\"record_key\") BETWEEN 1 AND 512\n        AND (\"person_merge_preview_items\".\"conflict_code\" IS NULL OR \"person_merge_preview_items\".\"conflict_code\" ~ '^[A-Z][A-Z0-9_]{2,127}$')"
+        },
+        "person_merge_preview_items_hash_check": {
+          "name": "person_merge_preview_items_hash_check",
+          "value": "\"person_merge_preview_items\".\"row_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_merge_preview_items_conflict_check": {
+          "name": "person_merge_preview_items_conflict_check",
+          "value": "(\"person_merge_preview_items\".\"disposition\" = 'block') = (\"person_merge_preview_items\".\"conflict_code\" IS NOT NULL)"
+        },
+        "person_merge_preview_items_metadata_check": {
+          "name": "person_merge_preview_items_metadata_check",
+          "value": "jsonb_typeof(\"person_merge_preview_items\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.household_addresses": {
+      "name": "household_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_key": {
+          "name": "address_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "address_type": {
+          "name": "address_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line1": {
+          "name": "line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line2": {
+          "name": "line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administrative_area": {
+          "name": "administrative_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_address": {
+          "name": "normalized_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_addresses_household_effective_idx": {
+          "name": "household_addresses_household_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_addresses_issued_by_account_id_accounts_id_fk": {
+          "name": "household_addresses_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "household_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_addresses_ended_by_account_id_accounts_id_fk": {
+          "name": "household_addresses_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "household_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_addresses_tenant_household_fk": {
+          "name": "household_addresses_tenant_household_fk",
+          "tableFrom": "household_addresses",
+          "tableTo": "households",
+          "columnsFrom": ["tenant_id", "household_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_addresses_tenant_id_id_unique": {
+          "name": "household_addresses_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "household_addresses_tenant_key_version_unique": {
+          "name": "household_addresses_tenant_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "address_key", "version"]
+        }
+      },
+      "policies": {
+        "household_addresses_runtime_select": {
+          "name": "household_addresses_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.households.read', 'tenant.households.manage')\n  AND public.openschool_household_read_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_runtime_insert_deny": {
+          "name": "household_addresses_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "household_addresses_runtime_update_deny": {
+          "name": "household_addresses_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "household_addresses_runtime_delete_deny": {
+          "name": "household_addresses_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "household_addresses_manager_select": {
+          "name": "household_addresses_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_insert": {
+          "name": "household_addresses_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_update": {
+          "name": "household_addresses_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_delete_deny": {
+          "name": "household_addresses_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "household_addresses_type_check": {
+          "name": "household_addresses_type_check",
+          "value": "\"household_addresses\".\"address_type\" IN ('residential', 'mailing', 'temporary', 'other')"
+        },
+        "household_addresses_country_code_check": {
+          "name": "household_addresses_country_code_check",
+          "value": "\"household_addresses\".\"country_code\" ~ '^[A-Z]{2}$'"
+        },
+        "household_addresses_required_text_check": {
+          "name": "household_addresses_required_text_check",
+          "value": "char_length(btrim(\"household_addresses\".\"line1\")) BETWEEN 1 AND 200 AND char_length(btrim(\"household_addresses\".\"locality\")) BETWEEN 1 AND 120 AND char_length(btrim(\"household_addresses\".\"normalized_address\")) BETWEEN 3 AND 600"
+        },
+        "household_addresses_valid_period_check": {
+          "name": "household_addresses_valid_period_check",
+          "value": "\"household_addresses\".\"valid_until\" IS NULL OR \"household_addresses\".\"valid_until\" > \"household_addresses\".\"valid_from\""
+        },
+        "household_addresses_end_evidence_check": {
+          "name": "household_addresses_end_evidence_check",
+          "value": "\"household_addresses\".\"status\" <> 'ended' OR (\"household_addresses\".\"valid_until\" IS NOT NULL AND \"household_addresses\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"household_addresses\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "household_addresses_version_positive": {
+          "name": "household_addresses_version_positive",
+          "value": "\"household_addresses\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.household_memberships": {
+      "name": "household_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "membership_kind": {
+          "name": "membership_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary_residence": {
+          "name": "is_primary_residence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary_mailing": {
+          "name": "is_primary_mailing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_memberships_household_effective_idx": {
+          "name": "household_memberships_household_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "household_memberships_person_effective_idx": {
+          "name": "household_memberships_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_memberships_issued_by_account_id_accounts_id_fk": {
+          "name": "household_memberships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "household_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_memberships_ended_by_account_id_accounts_id_fk": {
+          "name": "household_memberships_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "household_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_memberships_tenant_household_fk": {
+          "name": "household_memberships_tenant_household_fk",
+          "tableFrom": "household_memberships",
+          "tableTo": "households",
+          "columnsFrom": ["tenant_id", "household_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_memberships_tenant_person_fk": {
+          "name": "household_memberships_tenant_person_fk",
+          "tableFrom": "household_memberships",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_memberships_tenant_id_id_unique": {
+          "name": "household_memberships_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "household_memberships_tenant_key_version_unique": {
+          "name": "household_memberships_tenant_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "membership_key", "version"]
+        }
+      },
+      "policies": {
+        "household_memberships_runtime_select": {
+          "name": "household_memberships_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.households.read', 'tenant.households.manage')\n        AND public.openschool_household_member_read_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"household_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_runtime_insert_deny": {
+          "name": "household_memberships_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "household_memberships_runtime_update_deny": {
+          "name": "household_memberships_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "household_memberships_runtime_delete_deny": {
+          "name": "household_memberships_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "household_memberships_manager_select": {
+          "name": "household_memberships_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n        \n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_memberships\".\"tenant_id\", \"household_memberships\".\"household_id\")\n\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_insert": {
+          "name": "household_memberships_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_update": {
+          "name": "household_memberships_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_delete_deny": {
+          "name": "household_memberships_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "household_memberships_kind_check": {
+          "name": "household_memberships_kind_check",
+          "value": "\"household_memberships\".\"membership_kind\" IN ('resident', 'associated')"
+        },
+        "household_memberships_primary_requires_resident": {
+          "name": "household_memberships_primary_requires_resident",
+          "value": "(NOT \"household_memberships\".\"is_primary_residence\" AND NOT \"household_memberships\".\"is_primary_mailing\") OR \"household_memberships\".\"membership_kind\" = 'resident'"
+        },
+        "household_memberships_valid_period_check": {
+          "name": "household_memberships_valid_period_check",
+          "value": "\"household_memberships\".\"valid_until\" IS NULL OR \"household_memberships\".\"valid_until\" > \"household_memberships\".\"valid_from\""
+        },
+        "household_memberships_end_evidence_check": {
+          "name": "household_memberships_end_evidence_check",
+          "value": "\"household_memberships\".\"status\" <> 'ended' OR (\"household_memberships\".\"valid_until\" IS NOT NULL AND \"household_memberships\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"household_memberships\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "household_memberships_version_positive": {
+          "name": "household_memberships_version_positive",
+          "value": "\"household_memberships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.households": {
+      "name": "households",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_display_name": {
+          "name": "normalized_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "households_tenant_status_name_idx": {
+          "name": "households_tenant_status_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "households_tenant_id_tenants_id_fk": {
+          "name": "households_tenant_id_tenants_id_fk",
+          "tableFrom": "households",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "households_created_by_account_id_accounts_id_fk": {
+          "name": "households_created_by_account_id_accounts_id_fk",
+          "tableFrom": "households",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "households_closed_by_account_id_accounts_id_fk": {
+          "name": "households_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "households",
+          "tableTo": "accounts",
+          "columnsFrom": ["closed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "households_tenant_id_id_unique": {
+          "name": "households_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {
+        "households_runtime_select": {
+          "name": "households_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.households.read', 'tenant.households.manage')\n  AND public.openschool_household_read_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_runtime_insert_deny": {
+          "name": "households_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "households_runtime_update_deny": {
+          "name": "households_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "households_runtime_delete_deny": {
+          "name": "households_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "households_manager_select": {
+          "name": "households_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_manager_insert": {
+          "name": "households_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n      "
+        },
+        "households_manager_update": {
+          "name": "households_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_manager_delete_deny": {
+          "name": "households_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "households_name_check": {
+          "name": "households_name_check",
+          "value": "char_length(btrim(\"households\".\"display_name\")) BETWEEN 1 AND 160 AND char_length(btrim(\"households\".\"normalized_display_name\")) BETWEEN 1 AND 160"
+        },
+        "households_status_check": {
+          "name": "households_status_check",
+          "value": "\"households\".\"status\" IN ('active', 'closed')"
+        },
+        "households_version_positive": {
+          "name": "households_version_positive",
+          "value": "\"households\".\"version\" > 0"
+        },
+        "households_creation_reason_check": {
+          "name": "households_creation_reason_check",
+          "value": "char_length(btrim(\"households\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "households_closure_evidence_check": {
+          "name": "households_closure_evidence_check",
+          "value": "\"households\".\"status\" <> 'closed' OR (\"households\".\"closed_at\" IS NOT NULL AND \"households\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"households\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_student_tenant_parent_idx": {
+          "name": "parent_student_tenant_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "users",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "parent_student_tenant_student_fk": {
+          "name": "parent_student_tenant_student_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_student_tenant_id_id_unique": {
+          "name": "parent_student_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teachers_on_class_tenant_user_idx": {
+          "name": "teachers_on_class_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teachers_on_class_tenant_class_fk": {
+          "name": "teachers_on_class_tenant_class_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teachers_on_class_tenant_id_id_unique": {
+          "name": "teachers_on_class_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_org_tenant_user_idx": {
+          "name": "users_on_org_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_org_tenant_organization_fk": {
+          "name": "users_on_org_tenant_organization_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_org_tenant_id_id_unique": {
+          "name": "users_on_org_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_school_tenant_user_idx": {
+          "name": "users_on_school_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_school_tenant_school_fk": {
+          "name": "users_on_school_tenant_school_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_school_tenant_id_id_unique": {
+          "name": "users_on_school_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "enrollments_tenant_student_idx": {
+          "name": "enrollments_tenant_student_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollments_tenant_class_idx": {
+          "name": "enrollments_tenant_class_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_student_fk": {
+          "name": "enrollments_tenant_student_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_class_fk": {
+          "name": "enrollments_tenant_class_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grades_tenant_enrollment_idx": {
+          "name": "grades_tenant_enrollment_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrollment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "users",
+          "columnsFrom": ["graded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grades_tenant_enrollment_fk": {
+          "name": "grades_tenant_enrollment_fk",
+          "tableFrom": "grades",
+          "tableTo": "enrollments",
+          "columnsFrom": ["tenant_id", "enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grades_tenant_id_id_unique": {
+          "name": "grades_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_archive_manifests": {
+      "name": "audit_archive_manifests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_class": {
+          "name": "retention_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_event_hash": {
+          "name": "first_event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_hash": {
+          "name": "last_event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_hash": {
+          "name": "root_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_manifest_hash": {
+          "name": "previous_manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_location_hash": {
+          "name": "archive_location_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "includes_legal_hold": {
+          "name": "includes_legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_archive_manifest_chain_idx": {
+          "name": "audit_archive_manifest_chain_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retention_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_archive_manifests_tenant_id_tenants_id_fk": {
+          "name": "audit_archive_manifests_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_archive_manifests",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audit_archive_manifest_period_unique": {
+          "name": "audit_archive_manifest_period_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "period_start", "retention_class"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "audit_archive_manifest_period_check": {
+          "name": "audit_archive_manifest_period_check",
+          "value": "\"audit_archive_manifests\".\"period_end\" > \"audit_archive_manifests\".\"period_start\""
+        },
+        "audit_archive_manifest_count_check": {
+          "name": "audit_archive_manifest_count_check",
+          "value": "\"audit_archive_manifests\".\"event_count\" >= 0"
+        },
+        "audit_archive_manifest_hashes_check": {
+          "name": "audit_archive_manifest_hashes_check",
+          "value": "\"audit_archive_manifests\".\"first_event_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"last_event_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"root_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"manifest_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"archive_location_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_version": {
+          "name": "event_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_person_id": {
+          "name": "actor_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "causation_id": {
+          "name": "causation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_operation_receipt_id": {
+          "name": "pre_operation_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_grant_id": {
+          "name": "support_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_classes": {
+          "name": "data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_class": {
+          "name": "retention_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'security'"
+        },
+        "legal_hold": {
+          "name": "legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_tenant_time_idx": {
+          "name": "audit_events_tenant_time_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_tenant_target_idx": {
+          "name": "audit_events_tenant_target_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_correlation_idx": {
+          "name": "audit_events_correlation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_tenant_id_tenants_id_fk": {
+          "name": "audit_events_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_events_actor_account_id_accounts_id_fk": {
+          "name": "audit_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_events_tenant_actor_person_fk": {
+          "name": "audit_events_tenant_actor_person_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "actor_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_events_tenant_organization_fk": {
+          "name": "audit_events_tenant_organization_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_events_tenant_school_fk": {
+          "name": "audit_events_tenant_school_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audit_events_pk": {
+          "name": "audit_events_pk",
+          "columns": ["occurred_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "audit_events_runtime_select": {
+          "name": "audit_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.audit.read'\n        AND public.openschool_audit_scope_allows(\n          \"audit_events\".\"tenant_id\", \"audit_events\".\"education_organization_id\", \"audit_events\".\"school_id\"\n        )\n      "
+        },
+        "audit_events_runtime_insert": {
+          "name": "audit_events_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" IN ('account', 'support')\n        AND \"audit_events\".\"actor_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND \"audit_events\".\"actor_person_id\" IS NOT DISTINCT FROM nullif(current_setting('app.person_id', true), '')::uuid\n        AND \"audit_events\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_events\".\"education_organization_id\" IS NOT DISTINCT FROM nullif(current_setting('app.education_organization_id', true), '')::uuid\n        AND \"audit_events\".\"school_id\" IS NOT DISTINCT FROM nullif(current_setting('app.school_id', true), '')::uuid\n        AND (\n          (\"audit_events\".\"actor_type\" = 'account' AND \"audit_events\".\"source\" = 'web' AND \"audit_events\".\"support_grant_id\" IS NULL)\n          OR (\"audit_events\".\"actor_type\" = 'support' AND \"audit_events\".\"source\" = 'support' AND \"audit_events\".\"support_grant_id\" IS NOT NULL AND \"audit_events\".\"purpose\" IS NOT NULL)\n        )\n      "
+        },
+        "audit_events_invitation_denial_insert": {
+          "name": "audit_events_invitation_denial_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" = 'system'\n        AND \"audit_events\".\"actor_account_id\" IS NULL\n        AND \"audit_events\".\"actor_person_id\" IS NULL\n        AND \"audit_events\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_events\".\"education_organization_id\" IS NOT DISTINCT FROM nullif(current_setting('app.education_organization_id', true), '')::uuid\n        AND \"audit_events\".\"school_id\" IS NOT DISTINCT FROM nullif(current_setting('app.school_id', true), '')::uuid\n        AND \"audit_events\".\"event_type\" = 'account.invitation.accept'\n        AND \"audit_events\".\"outcome\" = 'denied'\n        AND \"audit_events\".\"capability\" = 'identity.invitation.accept'\n        AND \"audit_events\".\"policy_version\" = 'identity-invitation.v1'\n        AND \"audit_events\".\"policy_decision\" ->> 'effect' = 'deny'\n        AND \"audit_events\".\"policy_decision\" ->> 'reason' IN (\n          'INVITATION_UNAVAILABLE', 'INVITATION_IDENTITY_MISMATCH', 'INVITATION_ACCOUNT_CONFLICT'\n        )\n        AND \"audit_events\".\"target_type\" = 'account.invitation'\n        AND \"audit_events\".\"target_id\" IS NOT NULL\n        AND \"audit_events\".\"data_classes\" = '[\"credential\"]'::jsonb\n        AND \"audit_events\".\"purpose\" = 'account_onboarding'\n        AND \"audit_events\".\"source\" = 'web'\n        AND \"audit_events\".\"retention_class\" = 'security'\n      "
+        },
+        "audit_events_runtime_update_deny": {
+          "name": "audit_events_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_events_runtime_delete_deny": {
+          "name": "audit_events_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "audit_events_worker_select": {
+          "name": "audit_events_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_events_worker_insert": {
+          "name": "audit_events_worker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" = 'worker'\n        AND \"audit_events\".\"actor_account_id\" IS NULL\n        AND \"audit_events\".\"actor_person_id\" IS NULL\n        AND \"audit_events\".\"source\" = 'worker'\n      "
+        },
+        "audit_events_worker_update_deny": {
+          "name": "audit_events_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_events_worker_delete_deny": {
+          "name": "audit_events_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "audit_events_version_positive": {
+          "name": "audit_events_version_positive",
+          "value": "\"audit_events\".\"event_version\" > 0"
+        },
+        "audit_events_type_format": {
+          "name": "audit_events_type_format",
+          "value": "\"audit_events\".\"event_type\" ~ '^[a-z][a-z0-9_.]{2,127}$'"
+        },
+        "audit_events_reference_format": {
+          "name": "audit_events_reference_format",
+          "value": "\"audit_events\".\"target_type\" ~ '^[a-z][a-z0-9_.]{2,127}$' AND char_length(\"audit_events\".\"request_id\") BETWEEN 1 AND 512 AND char_length(\"audit_events\".\"correlation_id\") BETWEEN 1 AND 512 AND (\"audit_events\".\"target_id\" IS NULL OR char_length(\"audit_events\".\"target_id\") BETWEEN 1 AND 512) AND (\"audit_events\".\"purpose\" IS NULL OR \"audit_events\".\"purpose\" ~ '^[a-z][a-z0-9_.-]{2,63}$')"
+        },
+        "audit_events_outcome_check": {
+          "name": "audit_events_outcome_check",
+          "value": "\"audit_events\".\"outcome\" IN ('attempted', 'succeeded', 'denied', 'failed')"
+        },
+        "audit_events_actor_type_check": {
+          "name": "audit_events_actor_type_check",
+          "value": "\"audit_events\".\"actor_type\" IN ('account', 'worker', 'system', 'support', 'platform')"
+        },
+        "audit_events_source_check": {
+          "name": "audit_events_source_check",
+          "value": "\"audit_events\".\"source\" IN ('web', 'worker', 'migration', 'support', 'system', 'platform')"
+        },
+        "audit_events_retention_check": {
+          "name": "audit_events_retention_check",
+          "value": "\"audit_events\".\"retention_class\" IN ('operational', 'security', 'financial', 'safeguarding', 'legal_hold')"
+        },
+        "audit_events_data_classes_check": {
+          "name": "audit_events_data_classes_check",
+          "value": "jsonb_typeof(\"audit_events\".\"data_classes\") = 'array' AND jsonb_array_length(\"audit_events\".\"data_classes\") BETWEEN 1 AND 8 AND \"audit_events\".\"data_classes\" <@ '[\"internal\", \"student_personal\", \"financial\", \"health\", \"safeguarding\", \"credential\"]'::jsonb"
+        },
+        "audit_events_json_shape_check": {
+          "name": "audit_events_json_shape_check",
+          "value": "jsonb_typeof(\"audit_events\".\"change_summary\") = 'object' AND (\"audit_events\".\"policy_decision\" IS NULL OR jsonb_typeof(\"audit_events\".\"policy_decision\") = 'object')"
+        },
+        "audit_events_account_actor_check": {
+          "name": "audit_events_account_actor_check",
+          "value": "(\"audit_events\".\"actor_type\" NOT IN ('account', 'support', 'platform')) OR (\"audit_events\".\"actor_account_id\" IS NOT NULL AND (\"audit_events\".\"actor_type\" IN ('support', 'platform') OR \"audit_events\".\"actor_person_id\" IS NOT NULL))"
+        },
+        "audit_events_support_context_check": {
+          "name": "audit_events_support_context_check",
+          "value": "(\"audit_events\".\"actor_type\" = 'support' AND \"audit_events\".\"support_grant_id\" IS NOT NULL AND \"audit_events\".\"purpose\" IS NOT NULL AND \"audit_events\".\"source\" = 'support') OR (\"audit_events\".\"actor_type\" <> 'support' AND \"audit_events\".\"support_grant_id\" IS NULL AND (\"audit_events\".\"actor_type\" <> 'platform' OR (\"audit_events\".\"actor_person_id\" IS NULL AND \"audit_events\".\"source\" = 'platform')))"
+        },
+        "audit_events_content_hash_check": {
+          "name": "audit_events_content_hash_check",
+          "value": "\"audit_events\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_outbox": {
+      "name": "audit_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_event_occurred_at": {
+          "name": "audit_event_occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deduplication_key": {
+          "name": "deduplication_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_outbox_claim_idx": {
+          "name": "audit_outbox_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_outbox_event_idx": {
+          "name": "audit_outbox_event_idx",
+          "columns": [
+            {
+              "expression": "audit_event_occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audit_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_outbox_tenant_id_tenants_id_fk": {
+          "name": "audit_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_outbox",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_outbox_event_fk": {
+          "name": "audit_outbox_event_fk",
+          "tableFrom": "audit_outbox",
+          "tableTo": "audit_events",
+          "columnsFrom": ["audit_event_occurred_at", "audit_event_id"],
+          "columnsTo": ["occurred_at", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audit_outbox_tenant_dedup_unique": {
+          "name": "audit_outbox_tenant_dedup_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "deduplication_key"]
+        }
+      },
+      "policies": {
+        "audit_outbox_runtime_select": {
+          "name": "audit_outbox_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' = nullif(current_setting('app.account_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' = nullif(current_setting('app.person_id', true), '')\n      "
+        },
+        "audit_outbox_runtime_insert": {
+          "name": "audit_outbox_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' = nullif(current_setting('app.account_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' = nullif(current_setting('app.person_id', true), '')\n      "
+        },
+        "audit_outbox_invitation_denial_select": {
+          "name": "audit_outbox_invitation_denial_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' IS NULL\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' IS NULL\n        AND \"audit_outbox\".\"topic\" = 'audit.event.committed'\n        AND \"audit_outbox\".\"payload\" ->> 'eventType' = 'account.invitation.accept'\n        AND \"audit_outbox\".\"payload\" ->> 'outcome' = 'denied'\n        AND \"audit_outbox\".\"payload\" ->> 'targetType' = 'account.invitation'\n        AND nullif(\"audit_outbox\".\"payload\" ->> 'targetId', '') IS NOT NULL\n        AND \"audit_outbox\".\"deduplication_key\" =\n          'account.invitation.accept.denied:' || (\"audit_outbox\".\"payload\" ->> 'targetId') || ':' ||\n          nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "audit_outbox_invitation_denial_insert": {
+          "name": "audit_outbox_invitation_denial_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' IS NULL\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' IS NULL\n        AND \"audit_outbox\".\"topic\" = 'audit.event.committed'\n        AND \"audit_outbox\".\"payload\" ->> 'eventType' = 'account.invitation.accept'\n        AND \"audit_outbox\".\"payload\" ->> 'outcome' = 'denied'\n        AND \"audit_outbox\".\"payload\" ->> 'targetType' = 'account.invitation'\n        AND nullif(\"audit_outbox\".\"payload\" ->> 'targetId', '') IS NOT NULL\n        AND \"audit_outbox\".\"deduplication_key\" =\n          'account.invitation.accept.denied:' || (\"audit_outbox\".\"payload\" ->> 'targetId') || ':' ||\n          nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "audit_outbox_runtime_update_deny": {
+          "name": "audit_outbox_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_outbox_runtime_delete_deny": {
+          "name": "audit_outbox_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "audit_outbox_worker_select": {
+          "name": "audit_outbox_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_outbox_worker_update": {
+          "name": "audit_outbox_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_outbox_worker_insert_deny": {
+          "name": "audit_outbox_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "audit_outbox_worker_delete_deny": {
+          "name": "audit_outbox_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "audit_outbox_attempt_nonnegative": {
+          "name": "audit_outbox_attempt_nonnegative",
+          "value": "\"audit_outbox\".\"attempt_count\" >= 0"
+        },
+        "audit_outbox_topic_format": {
+          "name": "audit_outbox_topic_format",
+          "value": "\"audit_outbox\".\"topic\" ~ '^[a-z][a-z0-9_.]{2,127}$'"
+        },
+        "audit_outbox_reference_format": {
+          "name": "audit_outbox_reference_format",
+          "value": "char_length(\"audit_outbox\".\"deduplication_key\") BETWEEN 1 AND 512 AND char_length(\"audit_outbox\".\"correlation_id\") BETWEEN 1 AND 512"
+        },
+        "audit_outbox_context_binding_check": {
+          "name": "audit_outbox_context_binding_check",
+          "value": "jsonb_typeof(\"audit_outbox\".\"context\") = 'object' AND jsonb_typeof(\"audit_outbox\".\"payload\") = 'object' AND \"audit_outbox\".\"context\" ->> 'tenantId' = \"audit_outbox\".\"tenant_id\"::text AND \"audit_outbox\".\"context\" ->> 'correlationId' = \"audit_outbox\".\"correlation_id\" AND nullif(\"audit_outbox\".\"context\" ->> 'requestId', '') IS NOT NULL AND \"audit_outbox\".\"payload\" ->> 'auditEventId' = \"audit_outbox\".\"audit_event_id\"::text"
+        },
+        "audit_outbox_status_check": {
+          "name": "audit_outbox_status_check",
+          "value": "\"audit_outbox\".\"status\" IN ('pending', 'processing', 'published', 'failed', 'dead_letter')"
+        },
+        "audit_outbox_payload_hash_check": {
+          "name": "audit_outbox_payload_hash_check",
+          "value": "\"audit_outbox\".\"payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.account_invitations": {
+      "name": "account_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intended_email": {
+          "name": "intended_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_provider": {
+          "name": "identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'supabase'"
+        },
+        "intended_provider_subject": {
+          "name": "intended_provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "affiliation_kind": {
+          "name": "affiliation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_template_keys": {
+          "name": "role_template_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliation_valid_until": {
+          "name": "affiliation_valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_account_id": {
+          "name": "accepted_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_provider_subject": {
+          "name": "accepted_provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_account_id": {
+          "name": "cancelled_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_invitations_tenant_status_expiry_idx": {
+          "name": "account_invitations_tenant_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_tenant_person_status_idx": {
+          "name": "account_invitations_tenant_person_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_tenant_id_tenants_id_fk": {
+          "name": "account_invitations_tenant_id_tenants_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_issued_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_accepted_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_accepted_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["accepted_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_cancelled_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_cancelled_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["cancelled_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_tenant_person_fk": {
+          "name": "account_invitations_tenant_person_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_tenant_organization_fk": {
+          "name": "account_invitations_tenant_organization_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_tenant_school_fk": {
+          "name": "account_invitations_tenant_school_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_tenant_class_fk": {
+          "name": "account_invitations_tenant_class_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_invitations_tenant_id_id_unique": {
+          "name": "account_invitations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "account_invitations_token_hash_unique": {
+          "name": "account_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {
+        "account_invitations_runtime_select": {
+          "name": "account_invitations_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          'tenant.accounts.invite', 'tenant.accounts.manage'\n        )\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_insert": {
+          "name": "account_invitations_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"issued_by_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.invite'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_update": {
+          "name": "account_invitations_runtime_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      ",
+          "withCheck": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"cancelled_by_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_delete_deny": {
+          "name": "account_invitations_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "account_invitations_worker_select": {
+          "name": "account_invitations_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "account_invitations_acceptance_select": {
+          "name": "account_invitations_acceptance_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n      "
+        },
+        "account_invitations_acceptance_update": {
+          "name": "account_invitations_acceptance_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["public"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n        AND \"account_invitations\".\"status\" = 'pending'\n        AND \"account_invitations\".\"expires_at\" > now()\n        AND \"account_invitations\".\"identity_provider\" = nullif(current_setting('app.identity_provider', true), '')\n        AND \"account_invitations\".\"intended_email\" = lower(btrim(nullif(current_setting('app.identity_email', true), '')))\n        AND (\n          \"account_invitations\".\"intended_provider_subject\" IS NULL\n          OR \"account_invitations\".\"intended_provider_subject\" = nullif(current_setting('app.provider_subject', true), '')\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n        AND \"account_invitations\".\"status\" = 'accepted'\n        AND \"account_invitations\".\"accepted_provider_subject\" = nullif(current_setting('app.provider_subject', true), '')\n        AND EXISTS (\n          SELECT 1 FROM public.accounts AS accepted_account\n          WHERE accepted_account.id = \"account_invitations\".\"accepted_by_account_id\"\n            AND accepted_account.identity_provider = nullif(current_setting('app.identity_provider', true), '')\n            AND accepted_account.provider_subject = nullif(current_setting('app.provider_subject', true), '')\n            AND lower(btrim(accepted_account.primary_email)) = lower(btrim(nullif(current_setting('app.identity_email', true), '')))\n            AND accepted_account.status = 'active'\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "account_invitations_email_normalized_check": {
+          "name": "account_invitations_email_normalized_check",
+          "value": "\"account_invitations\".\"intended_email\" = lower(btrim(\"account_invitations\".\"intended_email\")) AND char_length(\"account_invitations\".\"intended_email\") BETWEEN 3 AND 320 AND \"account_invitations\".\"intended_email\" ~ '^[^[:space:]@]+@[^[:space:]@]+$'"
+        },
+        "account_invitations_identity_check": {
+          "name": "account_invitations_identity_check",
+          "value": "char_length(\"account_invitations\".\"identity_provider\") BETWEEN 1 AND 128 AND (\"account_invitations\".\"intended_provider_subject\" IS NULL OR char_length(\"account_invitations\".\"intended_provider_subject\") BETWEEN 1 AND 512)"
+        },
+        "account_invitations_token_check": {
+          "name": "account_invitations_token_check",
+          "value": "\"account_invitations\".\"token_version\" = 1 AND \"account_invitations\".\"token_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "account_invitations_scope_check": {
+          "name": "account_invitations_scope_check",
+          "value": "(\"account_invitations\".\"scope_type\" = 'tenant' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"education_organization_id\" IS NOT NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NOT NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'class' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NOT NULL)"
+        },
+        "account_invitations_roles_check": {
+          "name": "account_invitations_roles_check",
+          "value": "jsonb_typeof(\"account_invitations\".\"role_template_keys\") = 'array'\n          AND jsonb_array_length(\"account_invitations\".\"role_template_keys\") = 1\n          AND NOT jsonb_path_exists(\"account_invitations\".\"role_template_keys\", '$[*] ? (@.type() != \"string\")')\n          AND (\n            (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"affiliation_kind\" = 'administrator' AND \"account_invitations\".\"role_template_keys\" = '[\"org_admin\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"affiliation_kind\" = 'member' AND \"account_invitations\".\"role_template_keys\" = '[\"org_viewer\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'administrator' AND \"account_invitations\".\"role_template_keys\" = '[\"school_admin\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'employee' AND \"account_invitations\".\"role_template_keys\" = '[\"staff\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'guardian' AND \"account_invitations\".\"role_template_keys\" = '[\"parent\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'student' AND \"account_invitations\".\"role_template_keys\" = '[\"student\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'class' AND \"account_invitations\".\"affiliation_kind\" = 'teacher' AND \"account_invitations\".\"role_template_keys\" = '[\"teacher\"]'::jsonb)\n          )"
+        },
+        "account_invitations_affiliation_kind_check": {
+          "name": "account_invitations_affiliation_kind_check",
+          "value": "\"account_invitations\".\"affiliation_kind\" IN ('student', 'guardian', 'employee', 'teacher', 'administrator', 'member')"
+        },
+        "account_invitations_period_check": {
+          "name": "account_invitations_period_check",
+          "value": "\"account_invitations\".\"expires_at\" > \"account_invitations\".\"created_at\" AND (\"account_invitations\".\"affiliation_valid_until\" IS NULL OR \"account_invitations\".\"affiliation_valid_until\" > \"account_invitations\".\"created_at\")"
+        },
+        "account_invitations_status_evidence_check": {
+          "name": "account_invitations_status_evidence_check",
+          "value": "(\"account_invitations\".\"status\" = 'pending' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)\n          OR (\"account_invitations\".\"status\" = 'accepted' AND \"account_invitations\".\"accepted_at\" IS NOT NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NOT NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NOT NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)\n          OR (\"account_invitations\".\"status\" = 'cancelled' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NOT NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NOT NULL AND nullif(btrim(\"account_invitations\".\"cancellation_reason\"), '') IS NOT NULL)\n          OR (\"account_invitations\".\"status\" = 'expired' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.invitation_acceptance_rate_limits": {
+      "name": "invitation_acceptance_rate_limits",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_acceptance_rate_limits_pkey": {
+          "name": "invitation_acceptance_rate_limits_pkey",
+          "columns": ["key_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "invitation_acceptance_rate_limits_acceptor_select": {
+          "name": "invitation_acceptance_rate_limits_acceptor_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        },
+        "invitation_acceptance_rate_limits_acceptor_insert": {
+          "name": "invitation_acceptance_rate_limits_acceptor_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["public"],
+          "withCheck": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        },
+        "invitation_acceptance_rate_limits_acceptor_update": {
+          "name": "invitation_acceptance_rate_limits_acceptor_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["public"],
+          "using": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'",
+          "withCheck": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        }
+      },
+      "checkConstraints": {
+        "invitation_acceptance_rate_limits_key_check": {
+          "name": "invitation_acceptance_rate_limits_key_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"key_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "invitation_acceptance_rate_limits_count_check": {
+          "name": "invitation_acceptance_rate_limits_count_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"attempt_count\" BETWEEN 1 AND 1000000"
+        },
+        "invitation_acceptance_rate_limits_time_check": {
+          "name": "invitation_acceptance_rate_limits_time_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"updated_at\" >= \"invitation_acceptance_rate_limits\".\"window_started_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.invitation_delivery_outbox": {
+      "name": "invitation_delivery_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_key_id": {
+          "name": "encryption_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_auth_tag": {
+          "name": "token_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_delivery_claim_idx": {
+          "name": "invitation_delivery_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_delivery_outbox_tenant_id_tenants_id_fk": {
+          "name": "invitation_delivery_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "invitation_delivery_outbox",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "invitation_delivery_invitation_fk": {
+          "name": "invitation_delivery_invitation_fk",
+          "tableFrom": "invitation_delivery_outbox",
+          "tableTo": "account_invitations",
+          "columnsFrom": ["tenant_id", "invitation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_delivery_invitation_unique": {
+          "name": "invitation_delivery_invitation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "invitation_id"]
+        }
+      },
+      "policies": {
+        "invitation_delivery_runtime_insert": {
+          "name": "invitation_delivery_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.invite'\n        AND EXISTS (\n          SELECT 1 FROM public.account_invitations AS invitation\n          WHERE invitation.tenant_id = \"invitation_delivery_outbox\".\"tenant_id\"\n            AND invitation.id = \"invitation_delivery_outbox\".\"invitation_id\"\n            AND invitation.intended_email = \"invitation_delivery_outbox\".\"recipient_email\"\n            AND invitation.issued_by_account_id = nullif(current_setting('app.account_id', true), '')::uuid\n            AND invitation.status = 'pending'\n        )\n      "
+        },
+        "invitation_delivery_runtime_select_deny": {
+          "name": "invitation_delivery_runtime_select_deny",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "invitation_delivery_runtime_update_deny": {
+          "name": "invitation_delivery_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "invitation_delivery_runtime_delete_deny": {
+          "name": "invitation_delivery_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "invitation_delivery_worker_select": {
+          "name": "invitation_delivery_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "invitation_delivery_worker_update": {
+          "name": "invitation_delivery_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "invitation_delivery_worker_insert_deny": {
+          "name": "invitation_delivery_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "invitation_delivery_worker_delete_deny": {
+          "name": "invitation_delivery_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "invitation_delivery_email_normalized_check": {
+          "name": "invitation_delivery_email_normalized_check",
+          "value": "\"invitation_delivery_outbox\".\"recipient_email\" = lower(btrim(\"invitation_delivery_outbox\".\"recipient_email\")) AND char_length(\"invitation_delivery_outbox\".\"recipient_email\") BETWEEN 3 AND 320"
+        },
+        "invitation_delivery_encryption_check": {
+          "name": "invitation_delivery_encryption_check",
+          "value": "(\n            \"invitation_delivery_outbox\".\"status\" IN ('pending', 'processing', 'failed')\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" ~ '^[A-Za-z0-9_.-]{1,64}$'\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" ~ '^[A-Za-z0-9_-]+$'\n            AND char_length(\"invitation_delivery_outbox\".\"token_ciphertext\") BETWEEN 16 AND 1024\n            AND \"invitation_delivery_outbox\".\"token_iv\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_iv\" ~ '^[A-Za-z0-9_-]{16}$'\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" ~ '^[A-Za-z0-9_-]{22}$'\n          ) OR (\n            \"invitation_delivery_outbox\".\"status\" IN ('delivered', 'dead_letter')\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_iv\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" IS NULL\n          )"
+        },
+        "invitation_delivery_attempt_nonnegative": {
+          "name": "invitation_delivery_attempt_nonnegative",
+          "value": "\"invitation_delivery_outbox\".\"attempt_count\" >= 0"
+        },
+        "invitation_delivery_status_check": {
+          "name": "invitation_delivery_status_check",
+          "value": "\"invitation_delivery_outbox\".\"status\" IN ('pending', 'processing', 'delivered', 'failed', 'dead_letter')"
+        },
+        "invitation_delivery_status_evidence_check": {
+          "name": "invitation_delivery_status_evidence_check",
+          "value": "(\"invitation_delivery_outbox\".\"status\" = 'pending' AND \"invitation_delivery_outbox\".\"attempt_count\" = 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'processing' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NOT NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'delivered' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NOT NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'failed' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')\n          OR (\"invitation_delivery_outbox\".\"status\" = 'dead_letter' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.platform_access_grants": {
+      "name": "platform_access_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_template_key": {
+          "name": "role_template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_source": {
+          "name": "issuance_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_access_grants_account_status_idx": {
+          "name": "platform_access_grants_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_access_grants_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "platform_access_grants_issued_by_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "platform_access_grants_revoked_by_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_access_grants_role_check": {
+          "name": "platform_access_grants_role_check",
+          "value": "\"platform_access_grants\".\"role_template_key\" IN ('super_admin', 'support_agent', 'break_glass_operator')"
+        },
+        "platform_access_grants_status_check": {
+          "name": "platform_access_grants_status_check",
+          "value": "\"platform_access_grants\".\"status\" IN ('active', 'revoked')"
+        },
+        "platform_access_grants_issuance_source_check": {
+          "name": "platform_access_grants_issuance_source_check",
+          "value": "\"platform_access_grants\".\"issuance_source\" IN ('bootstrap', 'platform')"
+        },
+        "platform_access_grants_period_check": {
+          "name": "platform_access_grants_period_check",
+          "value": "\"platform_access_grants\".\"valid_until\" > \"platform_access_grants\".\"valid_from\" AND \"platform_access_grants\".\"valid_until\" <= \"platform_access_grants\".\"valid_from\" + interval '90 days'"
+        },
+        "platform_access_grants_reason_check": {
+          "name": "platform_access_grants_reason_check",
+          "value": "char_length(btrim(\"platform_access_grants\".\"issuance_reason\")) BETWEEN 3 AND 512 AND (\"platform_access_grants\".\"revocation_reason\" IS NULL OR char_length(btrim(\"platform_access_grants\".\"revocation_reason\")) BETWEEN 3 AND 512)"
+        },
+        "platform_access_grants_issuer_check": {
+          "name": "platform_access_grants_issuer_check",
+          "value": "(\"platform_access_grants\".\"issuance_source\" = 'bootstrap' AND \"platform_access_grants\".\"issued_by_account_id\" IS NULL) OR (\"platform_access_grants\".\"issuance_source\" = 'platform' AND \"platform_access_grants\".\"issued_by_account_id\" IS NOT NULL)"
+        },
+        "platform_access_grants_revocation_check": {
+          "name": "platform_access_grants_revocation_check",
+          "value": "(\"platform_access_grants\".\"status\" = 'active' AND \"platform_access_grants\".\"revoked_at\" IS NULL AND \"platform_access_grants\".\"revoked_by_account_id\" IS NULL AND \"platform_access_grants\".\"revocation_reason\" IS NULL) OR (\"platform_access_grants\".\"status\" = 'revoked' AND \"platform_access_grants\".\"revoked_at\" IS NOT NULL AND \"platform_access_grants\".\"revoked_by_account_id\" IS NOT NULL AND \"platform_access_grants\".\"revocation_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_security_reconciliation_outbox": {
+      "name": "provider_security_reconciliation_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_security_version": {
+          "name": "expected_security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_person_id": {
+          "name": "actor_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_factor_count": {
+          "name": "deleted_factor_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_security_reconciliation_claim_idx": {
+          "name": "provider_security_reconciliation_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_security_reconciliation_outbox_tenant_id_tenants_id_fk": {
+          "name": "provider_security_reconciliation_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "provider_security_reconciliation_outbox_account_id_accounts_id_fk": {
+          "name": "provider_security_reconciliation_outbox_account_id_accounts_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "provider_security_reconciliation_outbox_actor_account_id_accounts_id_fk": {
+          "name": "provider_security_reconciliation_outbox_actor_account_id_accounts_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "provider_security_reconciliation_actor_person_fk": {
+          "name": "provider_security_reconciliation_actor_person_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "actor_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_security_reconciliation_effect_unique": {
+          "name": "provider_security_reconciliation_effect_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "account_id", "action", "expected_security_version"]
+        }
+      },
+      "policies": {
+        "provider_security_reconciliation_revoker_insert": {
+          "name": "provider_security_reconciliation_revoker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_identity_revoker"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_identity_revoker'\n        AND \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"actor_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"actor_person_id\" = nullif(current_setting('app.person_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "provider_security_reconciliation_worker_select": {
+          "name": "provider_security_reconciliation_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_worker_update": {
+          "name": "provider_security_reconciliation_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      ",
+          "withCheck": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_resolver_select": {
+          "name": "provider_security_reconciliation_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_provider_security_resolver"],
+          "using": "\n        session_user = 'openschool_worker'\n        AND current_user = 'openschool_provider_security_resolver'\n        AND \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_identity_resolver_select": {
+          "name": "provider_security_reconciliation_identity_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_provider_security_resolver"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_provider_security_resolver'\n        AND EXISTS (\n          SELECT 1 FROM public.accounts AS verified_account\n          WHERE verified_account.id = \"provider_security_reconciliation_outbox\".\"account_id\"\n            AND verified_account.identity_provider = nullif(current_setting('app.identity_provider', true), '')\n            AND verified_account.provider_subject = nullif(current_setting('app.provider_subject', true), '')\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "provider_security_reconciliation_action_check": {
+          "name": "provider_security_reconciliation_action_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"action\" = 'reset_mfa'"
+        },
+        "provider_security_reconciliation_version_check": {
+          "name": "provider_security_reconciliation_version_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"expected_security_version\" > 0"
+        },
+        "provider_security_reconciliation_request_check": {
+          "name": "provider_security_reconciliation_request_check",
+          "value": "char_length(\"provider_security_reconciliation_outbox\".\"request_id\") BETWEEN 1 AND 512"
+        },
+        "provider_security_reconciliation_attempt_check": {
+          "name": "provider_security_reconciliation_attempt_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"attempt_count\" >= 0"
+        },
+        "provider_security_reconciliation_status_check": {
+          "name": "provider_security_reconciliation_status_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"status\" IN ('pending', 'processing', 'completed', 'failed', 'dead_letter')"
+        },
+        "provider_security_reconciliation_status_evidence_check": {
+          "name": "provider_security_reconciliation_status_evidence_check",
+          "value": "(\"provider_security_reconciliation_outbox\".\"status\" = 'pending' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" = 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'processing' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NOT NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'completed' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NOT NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" >= 0 AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'failed' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'dead_letter' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_access_grants": {
+      "name": "support_access_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_account_id": {
+          "name": "support_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_access_grant_id": {
+          "name": "platform_access_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_capabilities": {
+          "name": "allowed_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_reference": {
+          "name": "ticket_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emergency_rule_reference": {
+          "name": "emergency_rule_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_by_account_id": {
+          "name": "authorized_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_by_person_id": {
+          "name": "authorized_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_reason": {
+          "name": "authorization_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_account_session_id": {
+          "name": "bound_account_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_person_id": {
+          "name": "closed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_person_id": {
+          "name": "revoked_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_due'"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_account_id": {
+          "name": "reviewed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_person_id": {
+          "name": "reviewed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_outcome": {
+          "name": "review_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_notes": {
+          "name": "review_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_access_grants_resolve_idx": {
+          "name": "support_access_grants_resolve_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "support_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_access_grants_review_idx": {
+          "name": "support_access_grants_review_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_access_grants_tenant_id_tenants_id_fk": {
+          "name": "support_access_grants_tenant_id_tenants_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_support_account_id_accounts_id_fk": {
+          "name": "support_access_grants_support_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["support_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_platform_access_grant_id_platform_access_grants_id_fk": {
+          "name": "support_access_grants_platform_access_grant_id_platform_access_grants_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "platform_access_grants",
+          "columnsFrom": ["platform_access_grant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_authorized_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_authorized_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["authorized_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_bound_account_session_id_account_sessions_id_fk": {
+          "name": "support_access_grants_bound_account_session_id_account_sessions_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "account_sessions",
+          "columnsFrom": ["bound_account_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_closed_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["closed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_revoked_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_reviewed_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_reviewed_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["reviewed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_organization_fk": {
+          "name": "support_access_grants_tenant_organization_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_school_fk": {
+          "name": "support_access_grants_tenant_school_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_authorizer_person_fk": {
+          "name": "support_access_grants_tenant_authorizer_person_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "authorized_by_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_closer_person_fk": {
+          "name": "support_access_grants_tenant_closer_person_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "closed_by_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_revoker_person_fk": {
+          "name": "support_access_grants_tenant_revoker_person_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "revoked_by_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_reviewer_person_fk": {
+          "name": "support_access_grants_tenant_reviewer_person_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "reviewed_by_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_access_grants_tenant_id_id_unique": {
+          "name": "support_access_grants_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {
+        "support_access_grants_manager_select": {
+          "name": "support_access_grants_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_support_grant_manager"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_manager_insert": {
+          "name": "support_access_grants_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_manager_update": {
+          "name": "support_access_grants_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_support_grant_manager"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_resolver_select": {
+          "name": "support_access_grants_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_support_access_resolver"],
+          "using": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_grants_resolver_update": {
+          "name": "support_access_grants_resolver_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_support_access_resolver"],
+          "using": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid",
+          "withCheck": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_grants_worker_select": {
+          "name": "support_access_grants_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        },
+        "support_access_grants_worker_update": {
+          "name": "support_access_grants_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'",
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        }
+      },
+      "checkConstraints": {
+        "support_access_grants_kind_check": {
+          "name": "support_access_grants_kind_check",
+          "value": "\"support_access_grants\".\"kind\" IN ('support', 'break_glass')"
+        },
+        "support_access_grants_status_check": {
+          "name": "support_access_grants_status_check",
+          "value": "\"support_access_grants\".\"status\" IN ('approved', 'active', 'closed', 'revoked', 'expired')"
+        },
+        "support_access_grants_scope_check": {
+          "name": "support_access_grants_scope_check",
+          "value": "(\"support_access_grants\".\"scope_type\" = 'tenant' AND \"support_access_grants\".\"education_organization_id\" IS NULL AND \"support_access_grants\".\"school_id\" IS NULL)\n          OR (\"support_access_grants\".\"scope_type\" = 'organization_subtree' AND \"support_access_grants\".\"education_organization_id\" IS NOT NULL AND \"support_access_grants\".\"school_id\" IS NULL)\n          OR (\"support_access_grants\".\"scope_type\" = 'school' AND \"support_access_grants\".\"education_organization_id\" IS NULL AND \"support_access_grants\".\"school_id\" IS NOT NULL)"
+        },
+        "support_access_grants_capabilities_check": {
+          "name": "support_access_grants_capabilities_check",
+          "value": "jsonb_typeof(\"support_access_grants\".\"allowed_capabilities\") = 'array'\n          AND jsonb_array_length(\"support_access_grants\".\"allowed_capabilities\") BETWEEN 1 AND 2\n          AND \"support_access_grants\".\"allowed_capabilities\" <@ '[\"support.schools.read\", \"support.students.read\"]'::jsonb\n          AND (jsonb_array_length(\"support_access_grants\".\"allowed_capabilities\") = 1\n            OR (\"support_access_grants\".\"allowed_capabilities\" ? 'support.schools.read'\n              AND \"support_access_grants\".\"allowed_capabilities\" ? 'support.students.read'))"
+        },
+        "support_access_grants_purpose_check": {
+          "name": "support_access_grants_purpose_check",
+          "value": "\"support_access_grants\".\"purpose\" IN ('customer_support', 'incident_response')\n          AND (\"support_access_grants\".\"kind\" <> 'break_glass' OR \"support_access_grants\".\"purpose\" = 'incident_response')"
+        },
+        "support_access_grants_reference_check": {
+          "name": "support_access_grants_reference_check",
+          "value": "char_length(btrim(\"support_access_grants\".\"ticket_reference\")) BETWEEN 3 AND 128\n          AND char_length(btrim(\"support_access_grants\".\"authorization_reason\")) BETWEEN 3 AND 512\n          AND (\"support_access_grants\".\"emergency_rule_reference\" IS NULL OR char_length(btrim(\"support_access_grants\".\"emergency_rule_reference\")) BETWEEN 3 AND 128)\n          AND (\"support_access_grants\".\"close_reason\" IS NULL OR char_length(btrim(\"support_access_grants\".\"close_reason\")) BETWEEN 3 AND 512)\n          AND (\"support_access_grants\".\"revocation_reason\" IS NULL OR char_length(btrim(\"support_access_grants\".\"revocation_reason\")) BETWEEN 3 AND 512)\n          AND (\"support_access_grants\".\"review_notes\" IS NULL OR char_length(btrim(\"support_access_grants\".\"review_notes\")) BETWEEN 3 AND 2048)"
+        },
+        "support_access_grants_authorizer_check": {
+          "name": "support_access_grants_authorizer_check",
+          "value": "(\"support_access_grants\".\"kind\" = 'support' AND \"support_access_grants\".\"authorized_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"emergency_rule_reference\" IS NULL)\n          OR (\"support_access_grants\".\"kind\" = 'break_glass' AND \"support_access_grants\".\"authorized_by_person_id\" IS NULL AND \"support_access_grants\".\"emergency_rule_reference\" IS NOT NULL)"
+        },
+        "support_access_grants_period_check": {
+          "name": "support_access_grants_period_check",
+          "value": "\"support_access_grants\".\"valid_until\" > \"support_access_grants\".\"valid_from\"\n          AND ((\"support_access_grants\".\"kind\" = 'support' AND \"support_access_grants\".\"valid_until\" <= \"support_access_grants\".\"valid_from\" + interval '8 hours')\n            OR (\"support_access_grants\".\"kind\" = 'break_glass' AND \"support_access_grants\".\"valid_until\" <= \"support_access_grants\".\"valid_from\" + interval '30 minutes'))"
+        },
+        "support_access_grants_state_evidence_check": {
+          "name": "support_access_grants_state_evidence_check",
+          "value": "(\"support_access_grants\".\"status\" = 'approved' AND \"support_access_grants\".\"bound_account_session_id\" IS NULL AND \"support_access_grants\".\"opened_at\" IS NULL AND \"support_access_grants\".\"closed_at\" IS NULL AND \"support_access_grants\".\"closed_by_account_id\" IS NULL AND \"support_access_grants\".\"closed_by_person_id\" IS NULL AND \"support_access_grants\".\"close_reason\" IS NULL AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"review_status\" = 'not_due')\n          OR (\"support_access_grants\".\"status\" = 'active' AND \"support_access_grants\".\"bound_account_session_id\" IS NOT NULL AND \"support_access_grants\".\"opened_at\" IS NOT NULL AND \"support_access_grants\".\"closed_at\" IS NULL AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"review_status\" = 'not_due')\n          OR (\"support_access_grants\".\"status\" IN ('closed', 'expired') AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"closed_at\" IS NOT NULL AND \"support_access_grants\".\"close_reason\" IS NOT NULL AND \"support_access_grants\".\"review_status\" IN ('pending', 'completed'))\n          OR (\"support_access_grants\".\"status\" = 'revoked' AND \"support_access_grants\".\"revoked_at\" IS NOT NULL AND \"support_access_grants\".\"revoked_by_account_id\" IS NOT NULL AND \"support_access_grants\".\"revoked_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"revocation_reason\" IS NOT NULL AND \"support_access_grants\".\"review_status\" IN ('pending', 'completed'))"
+        },
+        "support_access_grants_review_evidence_check": {
+          "name": "support_access_grants_review_evidence_check",
+          "value": "(\"support_access_grants\".\"review_status\" IN ('not_due', 'pending') AND \"support_access_grants\".\"reviewed_at\" IS NULL AND \"support_access_grants\".\"reviewed_by_account_id\" IS NULL AND \"support_access_grants\".\"reviewed_by_person_id\" IS NULL AND \"support_access_grants\".\"review_outcome\" IS NULL AND \"support_access_grants\".\"review_notes\" IS NULL)\n          OR (\"support_access_grants\".\"review_status\" = 'completed' AND \"support_access_grants\".\"reviewed_at\" IS NOT NULL AND \"support_access_grants\".\"reviewed_by_account_id\" IS NOT NULL AND \"support_access_grants\".\"reviewed_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"review_outcome\" IN ('confirmed', 'no_impact', 'control_gap', 'incident') AND \"support_access_grants\".\"review_notes\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_access_notifications": {
+      "name": "support_access_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_grant_id": {
+          "name": "support_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tenant_security_admins'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_access_notifications_tenant_time_idx": {
+          "name": "support_access_notifications_tenant_time_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_access_notifications_tenant_id_tenants_id_fk": {
+          "name": "support_access_notifications_tenant_id_tenants_id_fk",
+          "tableFrom": "support_access_notifications",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_notifications_actor_account_id_accounts_id_fk": {
+          "name": "support_access_notifications_actor_account_id_accounts_id_fk",
+          "tableFrom": "support_access_notifications",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_notifications_grant_fk": {
+          "name": "support_access_notifications_grant_fk",
+          "tableFrom": "support_access_notifications",
+          "tableTo": "support_access_grants",
+          "columnsFrom": ["tenant_id", "support_grant_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_access_notifications_tenant_id_id_unique": {
+          "name": "support_access_notifications_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "support_access_notifications_operation_unique": {
+          "name": "support_access_notifications_operation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "support_grant_id", "event", "operation_id"]
+        }
+      },
+      "policies": {
+        "support_access_notifications_runtime_select": {
+          "name": "support_access_notifications_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.support.grants.manage'\n        AND openschool_private.tenant_admin_can_view_support_notification(\n          \"support_access_notifications\".\"tenant_id\",\n          nullif(current_setting('app.person_id', true), '')::uuid,\n          \"support_access_notifications\".\"support_grant_id\",\n          statement_timestamp()\n        )"
+        },
+        "support_access_notifications_manager_insert": {
+          "name": "support_access_notifications_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_notifications_resolver_insert": {
+          "name": "support_access_notifications_resolver_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_access_resolver"],
+          "withCheck": "\"support_access_notifications\".\"support_grant_id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_notifications_worker_insert": {
+          "name": "support_access_notifications_worker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        },
+        "support_access_notifications_worker_select": {
+          "name": "support_access_notifications_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        }
+      },
+      "checkConstraints": {
+        "support_access_notifications_event_check": {
+          "name": "support_access_notifications_event_check",
+          "value": "\"support_access_notifications\".\"event\" IN ('approved', 'opened', 'used', 'closed', 'revoked', 'expired', 'reviewed', 'break_glass_opened')"
+        },
+        "support_access_notifications_audience_check": {
+          "name": "support_access_notifications_audience_check",
+          "value": "\"support_access_notifications\".\"audience\" = 'tenant_security_admins'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_notification_outbox": {
+      "name": "support_notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_notification_outbox_claim_idx": {
+          "name": "support_notification_outbox_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_notification_outbox_tenant_id_tenants_id_fk": {
+          "name": "support_notification_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "support_notification_outbox",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_notification_outbox_notification_fk": {
+          "name": "support_notification_outbox_notification_fk",
+          "tableFrom": "support_notification_outbox",
+          "tableTo": "support_access_notifications",
+          "columnsFrom": ["tenant_id", "notification_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_notification_outbox_notification_unique": {
+          "name": "support_notification_outbox_notification_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "notification_id"]
+        }
+      },
+      "policies": {
+        "support_notification_outbox_manager_insert": {
+          "name": "support_notification_outbox_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_notification_outbox_resolver_insert": {
+          "name": "support_notification_outbox_resolver_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_access_resolver"],
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.support_grant_id', true), '') IS NOT NULL"
+        },
+        "support_notification_outbox_worker_select": {
+          "name": "support_notification_outbox_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        },
+        "support_notification_outbox_worker_update": {
+          "name": "support_notification_outbox_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'",
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        }
+      },
+      "checkConstraints": {
+        "support_notification_outbox_attempt_check": {
+          "name": "support_notification_outbox_attempt_check",
+          "value": "\"support_notification_outbox\".\"attempt_count\" >= 0"
+        },
+        "support_notification_outbox_status_check": {
+          "name": "support_notification_outbox_status_check",
+          "value": "\"support_notification_outbox\".\"status\" IN ('pending', 'processing', 'delivered', 'failed', 'dead_letter')"
+        },
+        "support_notification_outbox_state_check": {
+          "name": "support_notification_outbox_state_check",
+          "value": "(\"support_notification_outbox\".\"status\" = 'pending' AND \"support_notification_outbox\".\"attempt_count\" = 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" = 'processing' AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NOT NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" = 'delivered' AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NOT NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" IN ('failed', 'dead_letter') AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0043_snapshot.json
+++ b/packages/db/migrations/meta/0043_snapshot.json
@@ -1,0 +1,14360 @@
+{
+  "id": "2ca68449-0f32-49c5-8d54-fe3bda8fbe42",
+  "prevId": "2562a929-3d2e-490a-a7e4-9afbd8301819",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "columns": ["tenant_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tenant_placements_adapter_check": {
+          "name": "tenant_placements_adapter_check",
+          "value": "\"tenant_placements\".\"adapter\" = 'pooled'"
+        },
+        "tenant_placements_status_check": {
+          "name": "tenant_placements_status_check",
+          "value": "\"tenant_placements\".\"status\" IN ('active', 'migrating', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "columns": ["slug"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tenants_status_check": {
+          "name": "tenants_status_check",
+          "value": "\"tenants\".\"status\" IN ('active', 'suspended', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": ["slug"],
+          "nullsNotDistinct": false
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schools_tenant_organization_idx": {
+          "name": "schools_tenant_organization_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "schools_tenant_organization_fk": {
+          "name": "schools_tenant_organization_fk",
+          "tableFrom": "schools",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "tableTo": "organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "columns": ["tenant_id", "slug"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "schools_runtime_select": {
+          "name": "schools_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND (\n          \"schools\".\"id\" = nullif(current_setting('app.school_id', true), '')::uuid\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              IN (\n                'tenant.schools.read',\n                'tenant.students.create', 'tenant.students.read',\n                'tenant.students.update', 'tenant.students.delete',\n                'support.schools.read', 'support.students.read',\n                'tenant.accounts.invite', 'tenant.accounts.manage',\n                'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n                'tenant.student_enrollments.read', 'tenant.student_enrollments.manage',\n                'tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage',\n                'tenant.sections.read', 'tenant.sections.manage',\n                'identity.context.resolve'\n              )\n            AND public.openschool_school_scope_allows(\n              \"schools\".\"tenant_id\", \"schools\".\"id\"\n            )\n          )\n        )\n      "
+        },
+        "schools_identity_revoker_select": {
+          "name": "schools_identity_revoker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_identity_revoker"],
+          "using": "\n        \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND nullif(current_setting('app.assurance_level', true), '') = 'aal2'\n      "
+        },
+        "schools_worker_select": {
+          "name": "schools_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "schools_student_admitter_select": {
+          "name": "schools_student_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_school_scope_allows(\"schools\".\"tenant_id\", \"schools\".\"id\")\n      "
+        },
+        "schools_academic_configurator_select": {
+          "name": "schools_academic_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_academic_configurator'\n        AND \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.academic_structure.manage'\n        AND public.openschool_school_scope_allows(\"schools\".\"tenant_id\", \"schools\".\"id\")\n      "
+        },
+        "schools_runtime_insert_deny": {
+          "name": "schools_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "schools_runtime_update_deny": {
+          "name": "schools_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "schools_runtime_delete_deny": {
+          "name": "schools_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "schools_worker_insert_deny": {
+          "name": "schools_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "schools_worker_update_deny": {
+          "name": "schools_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "schools_worker_delete_deny": {
+          "name": "schools_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "schools_profile_check": {
+          "name": "schools_profile_check",
+          "value": "\"schools\".\"profile\" IN ('primary', 'secondary', 'all_through', 'special', 'other')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "education_organizations_legacy_organization_fk": {
+          "name": "education_organizations_legacy_organization_fk",
+          "tableFrom": "education_organizations",
+          "columnsFrom": ["tenant_id", "legacy_organization_id"],
+          "tableTo": "organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "columns": ["tenant_id", "slug"],
+          "nullsNotDistinct": false
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "columns": ["legacy_organization_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "education_organizations_type_check": {
+          "name": "education_organizations_type_check",
+          "value": "\"education_organizations\".\"type\" IN ('ministry', 'school_board', 'district', 'network', 'region', 'other')"
+        },
+        "education_organizations_status_check": {
+          "name": "education_organizations_status_check",
+          "value": "\"education_organizations\".\"status\" IN ('active', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "tableTo": "organization_tree_versions",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "tableTo": "organization_tree_versions",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "columns": ["tenant_id", "version"],
+          "nullsNotDistinct": false
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "columns": ["tenant_id", "effective_from"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_links": {
+      "name": "account_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_links_account_status_idx": {
+          "name": "account_links_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "account_links_tenant_person_status_idx": {
+          "name": "account_links_tenant_person_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_links_tenant_id_tenants_id_fk": {
+          "name": "account_links_tenant_id_tenants_id_fk",
+          "tableFrom": "account_links",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_links_account_id_accounts_id_fk": {
+          "name": "account_links_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "columnsFrom": ["account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_links_issued_by_account_id_accounts_id_fk": {
+          "name": "account_links_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_links_revoked_by_account_id_accounts_id_fk": {
+          "name": "account_links_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "columnsFrom": ["revoked_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_links_tenant_person_fk": {
+          "name": "account_links_tenant_person_fk",
+          "tableFrom": "account_links",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_links_tenant_id_id_unique": {
+          "name": "account_links_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_links_status_check": {
+          "name": "account_links_status_check",
+          "value": "\"account_links\".\"status\" IN ('pending', 'active', 'suspended', 'revoked', 'expired')"
+        },
+        "account_links_valid_period_check": {
+          "name": "account_links_valid_period_check",
+          "value": "\"account_links\".\"valid_from\" IS NULL OR \"account_links\".\"valid_until\" IS NULL OR \"account_links\".\"valid_until\" > \"account_links\".\"valid_from\""
+        },
+        "account_links_activation_evidence_check": {
+          "name": "account_links_activation_evidence_check",
+          "value": "\"account_links\".\"status\" <> 'active' OR (\"account_links\".\"valid_from\" IS NOT NULL AND \"account_links\".\"activated_at\" IS NOT NULL)"
+        },
+        "account_links_revocation_evidence_check": {
+          "name": "account_links_revocation_evidence_check",
+          "value": "\"account_links\".\"status\" <> 'revoked' OR (\"account_links\".\"revoked_at\" IS NOT NULL AND \"account_links\".\"revocation_reason\" IS NOT NULL AND \"account_links\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_sessions": {
+      "name": "account_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assurance_level": {
+          "name": "assurance_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_version": {
+          "name": "security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authenticated_at": {
+          "name": "authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reauthenticated_at": {
+          "name": "reauthenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_sessions_account_status_idx": {
+          "name": "account_sessions_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_sessions_account_id_accounts_id_fk": {
+          "name": "account_sessions_account_id_accounts_id_fk",
+          "tableFrom": "account_sessions",
+          "columnsFrom": ["account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_sessions_revoked_by_account_id_accounts_id_fk": {
+          "name": "account_sessions_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "account_sessions",
+          "columnsFrom": ["revoked_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_sessions_provider_session_id_unique": {
+          "name": "account_sessions_provider_session_id_unique",
+          "columns": ["provider_session_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_sessions_status_check": {
+          "name": "account_sessions_status_check",
+          "value": "\"account_sessions\".\"status\" IN ('active', 'revoked', 'expired')"
+        },
+        "account_sessions_assurance_level_check": {
+          "name": "account_sessions_assurance_level_check",
+          "value": "\"account_sessions\".\"assurance_level\" IN ('aal1', 'aal2')"
+        },
+        "account_sessions_security_version_positive": {
+          "name": "account_sessions_security_version_positive",
+          "value": "\"account_sessions\".\"security_version\" > 0"
+        },
+        "account_sessions_time_order_check": {
+          "name": "account_sessions_time_order_check",
+          "value": "\"account_sessions\".\"expires_at\" > \"account_sessions\".\"authenticated_at\""
+        },
+        "account_sessions_reauthentication_time_check": {
+          "name": "account_sessions_reauthentication_time_check",
+          "value": "\"account_sessions\".\"reauthenticated_at\" IS NULL OR \"account_sessions\".\"reauthenticated_at\" < \"account_sessions\".\"expires_at\""
+        },
+        "account_sessions_revocation_evidence_check": {
+          "name": "account_sessions_revocation_evidence_check",
+          "value": "\"account_sessions\".\"status\" <> 'revoked' OR (\"account_sessions\".\"revoked_at\" IS NOT NULL AND \"account_sessions\".\"revocation_reason\" IS NOT NULL AND btrim(\"account_sessions\".\"revocation_reason\") <> '')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "legacy_user_id": {
+          "name": "legacy_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_provider": {
+          "name": "identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'supabase'"
+        },
+        "provider_subject": {
+          "name": "provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "membership_version": {
+          "name": "membership_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "security_version": {
+          "name": "security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_legacy_user_id_users_id_fk": {
+          "name": "accounts_legacy_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "columnsFrom": ["legacy_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_legacy_user_id_unique": {
+          "name": "accounts_legacy_user_id_unique",
+          "columns": ["legacy_user_id"],
+          "nullsNotDistinct": false
+        },
+        "accounts_provider_subject_unique": {
+          "name": "accounts_provider_subject_unique",
+          "columns": ["identity_provider", "provider_subject"],
+          "nullsNotDistinct": false
+        },
+        "accounts_primary_email_unique": {
+          "name": "accounts_primary_email_unique",
+          "columns": ["primary_email"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "accounts_status_check": {
+          "name": "accounts_status_check",
+          "value": "\"accounts\".\"status\" IN ('active', 'disabled', 'deleted')"
+        },
+        "accounts_versions_positive": {
+          "name": "accounts_versions_positive",
+          "value": "\"accounts\".\"membership_version\" > 0 AND \"accounts\".\"security_version\" > 0"
+        },
+        "accounts_disabled_evidence_check": {
+          "name": "accounts_disabled_evidence_check",
+          "value": "\"accounts\".\"status\" = 'active' OR (\"accounts\".\"disabled_at\" IS NOT NULL AND \"accounts\".\"disabled_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_tenant_person_effective_idx": {
+          "name": "affiliations_tenant_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "affiliations_tenant_school_effective_idx": {
+          "name": "affiliations_tenant_school_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "affiliations_tenant_id_tenants_id_fk": {
+          "name": "affiliations_tenant_id_tenants_id_fk",
+          "tableFrom": "affiliations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "affiliations_issued_by_account_id_accounts_id_fk": {
+          "name": "affiliations_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "affiliations",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "affiliations_revoked_by_account_id_accounts_id_fk": {
+          "name": "affiliations_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "affiliations",
+          "columnsFrom": ["revoked_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "affiliations_tenant_person_fk": {
+          "name": "affiliations_tenant_person_fk",
+          "tableFrom": "affiliations",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "affiliations_tenant_education_organization_fk": {
+          "name": "affiliations_tenant_education_organization_fk",
+          "tableFrom": "affiliations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "affiliations_tenant_school_fk": {
+          "name": "affiliations_tenant_school_fk",
+          "tableFrom": "affiliations",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "affiliations_tenant_class_fk": {
+          "name": "affiliations_tenant_class_fk",
+          "tableFrom": "affiliations",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "affiliations_tenant_id_id_unique": {
+          "name": "affiliations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "affiliations_kind_check": {
+          "name": "affiliations_kind_check",
+          "value": "\"affiliations\".\"kind\" IN ('student', 'guardian', 'employee', 'teacher', 'administrator', 'member')"
+        },
+        "affiliations_status_check": {
+          "name": "affiliations_status_check",
+          "value": "\"affiliations\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "affiliations_scope_check": {
+          "name": "affiliations_scope_check",
+          "value": "(\"affiliations\".\"scope_type\" = 'tenant' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'education_organization' AND \"affiliations\".\"education_organization_id\" IS NOT NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'school' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NOT NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'class' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NOT NULL)"
+        },
+        "affiliations_valid_period_check": {
+          "name": "affiliations_valid_period_check",
+          "value": "\"affiliations\".\"valid_until\" IS NULL OR \"affiliations\".\"valid_until\" > \"affiliations\".\"valid_from\""
+        },
+        "affiliations_revocation_evidence_check": {
+          "name": "affiliations_revocation_evidence_check",
+          "value": "\"affiliations\".\"status\" <> 'revoked' OR (\"affiliations\".\"revoked_at\" IS NOT NULL AND \"affiliations\".\"revocation_reason\" IS NOT NULL AND \"affiliations\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.contact_profiles": {
+      "name": "contact_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_phone": {
+          "name": "normalized_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_profiles_tenant_phone_idx": {
+          "name": "contact_profiles_tenant_phone_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "contact_profiles_tenant_id_tenants_id_fk": {
+          "name": "contact_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "contact_profiles",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "contact_profiles_tenant_person_fk": {
+          "name": "contact_profiles_tenant_person_fk",
+          "tableFrom": "contact_profiles",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contact_profiles_pk": {
+          "name": "contact_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "contact_profiles_runtime_select": {
+          "name": "contact_profiles_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage')\n        AND public.openschool_contact_person_read_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_runtime_insert_deny": {
+          "name": "contact_profiles_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "contact_profiles_runtime_update_deny": {
+          "name": "contact_profiles_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "contact_profiles_runtime_delete_deny": {
+          "name": "contact_profiles_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "contact_profiles_contact_manager_select": {
+          "name": "contact_profiles_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_insert": {
+          "name": "contact_profiles_contact_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_guardian_contact_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_update": {
+          "name": "contact_profiles_contact_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_delete_deny": {
+          "name": "contact_profiles_contact_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "contact_profiles_phone_check": {
+          "name": "contact_profiles_phone_check",
+          "value": "\"contact_profiles\".\"phone\" IS NULL OR char_length(btrim(\"contact_profiles\".\"phone\")) BETWEEN 5 AND 32"
+        },
+        "contact_profiles_normalized_phone_check": {
+          "name": "contact_profiles_normalized_phone_check",
+          "value": "\"contact_profiles\".\"normalized_phone\" IS NULL OR char_length(\"contact_profiles\".\"normalized_phone\") BETWEEN 5 AND 20"
+        },
+        "contact_profiles_preferred_method_check": {
+          "name": "contact_profiles_preferred_method_check",
+          "value": "\"contact_profiles\".\"preferred_contact_method\" IN ('email', 'phone', 'sms', 'none')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.employee_profiles": {
+      "name": "employee_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_number": {
+          "name": "employee_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "employee_profiles_tenant_id_tenants_id_fk": {
+          "name": "employee_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "employee_profiles",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "employee_profiles_tenant_person_fk": {
+          "name": "employee_profiles_tenant_person_fk",
+          "tableFrom": "employee_profiles",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "employee_profiles_pk": {
+          "name": "employee_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "employee_profiles_tenant_employee_number_unique": {
+          "name": "employee_profiles_tenant_employee_number_unique",
+          "columns": ["tenant_id", "employee_number"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "employee_profiles_status_check": {
+          "name": "employee_profiles_status_check",
+          "value": "\"employee_profiles\".\"status\" IN ('active', 'leave', 'terminated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.guardian_profiles": {
+      "name": "guardian_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardian_profiles_tenant_id_tenants_id_fk": {
+          "name": "guardian_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "guardian_profiles",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "guardian_profiles_tenant_person_fk": {
+          "name": "guardian_profiles_tenant_person_fk",
+          "tableFrom": "guardian_profiles",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "guardian_profiles_pk": {
+          "name": "guardian_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "guardian_profiles_status_check": {
+          "name": "guardian_profiles_status_check",
+          "value": "\"guardian_profiles\".\"status\" IN ('active', 'inactive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.identity_migration_events": {
+      "name": "identity_migration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_link_id": {
+          "name": "account_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_version": {
+          "name": "membership_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identity_migration_events_account_version_idx": {
+          "name": "identity_migration_events_account_version_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "membership_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "identity_migration_events_tenant_person_idx": {
+          "name": "identity_migration_events_tenant_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "identity_migration_events_tenant_id_tenants_id_fk": {
+          "name": "identity_migration_events_tenant_id_tenants_id_fk",
+          "tableFrom": "identity_migration_events",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "identity_migration_events_account_id_accounts_id_fk": {
+          "name": "identity_migration_events_account_id_accounts_id_fk",
+          "tableFrom": "identity_migration_events",
+          "columnsFrom": ["account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "identity_migration_events_actor_account_id_accounts_id_fk": {
+          "name": "identity_migration_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "identity_migration_events",
+          "columnsFrom": ["actor_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "identity_migration_events_tenant_person_fk": {
+          "name": "identity_migration_events_tenant_person_fk",
+          "tableFrom": "identity_migration_events",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "identity_migration_events_tenant_account_link_fk": {
+          "name": "identity_migration_events_tenant_account_link_fk",
+          "tableFrom": "identity_migration_events",
+          "columnsFrom": ["tenant_id", "account_link_id"],
+          "tableTo": "account_links",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "identity_migration_events_tenant_id_id_unique": {
+          "name": "identity_migration_events_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "identity_migration_events_type_check": {
+          "name": "identity_migration_events_type_check",
+          "value": "\"identity_migration_events\".\"event_type\" IN ('account_link_backfilled', 'account_link_activated', 'account_link_revoked')"
+        },
+        "identity_migration_events_version_positive": {
+          "name": "identity_migration_events_version_positive",
+          "value": "\"identity_migration_events\".\"membership_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.people": {
+      "name": "people",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_user_id": {
+          "name": "legacy_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_display_name": {
+          "name": "normalized_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "people_tenant_name_idx": {
+          "name": "people_tenant_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "people_tenant_email_idx": {
+          "name": "people_tenant_email_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "people_tenant_id_tenants_id_fk": {
+          "name": "people_tenant_id_tenants_id_fk",
+          "tableFrom": "people",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "people_legacy_user_id_users_id_fk": {
+          "name": "people_legacy_user_id_users_id_fk",
+          "tableFrom": "people",
+          "columnsFrom": ["legacy_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "people_tenant_legacy_student_fk": {
+          "name": "people_tenant_legacy_student_fk",
+          "tableFrom": "people",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "tableTo": "students",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "people_tenant_id_id_unique": {
+          "name": "people_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "people_tenant_legacy_user_unique": {
+          "name": "people_tenant_legacy_user_unique",
+          "columns": ["tenant_id", "legacy_user_id"],
+          "nullsNotDistinct": false
+        },
+        "people_tenant_legacy_student_unique": {
+          "name": "people_tenant_legacy_student_unique",
+          "columns": ["tenant_id", "legacy_student_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "people_status_check": {
+          "name": "people_status_check",
+          "value": "\"people\".\"status\" IN ('active', 'suspended', 'archived', 'deceased')"
+        },
+        "people_source_check": {
+          "name": "people_source_check",
+          "value": "\"people\".\"source\" IN ('legacy_user', 'legacy_student', 'native')"
+        },
+        "people_legacy_source_check": {
+          "name": "people_legacy_source_check",
+          "value": "(\"people\".\"source\" <> 'legacy_user' OR \"people\".\"legacy_user_id\" IS NOT NULL)\n          AND (\"people\".\"source\" <> 'legacy_student' OR \"people\".\"legacy_student_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.person_merge_evidence": {
+      "name": "person_merge_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "recorded_by_account_id": {
+          "name": "recorded_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_evidence_tenant_people_idx": {
+          "name": "person_merge_evidence_tenant_people_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_merge_evidence_tenant_id_tenants_id_fk": {
+          "name": "person_merge_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_evidence",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_evidence_recorded_by_account_id_accounts_id_fk": {
+          "name": "person_merge_evidence_recorded_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_evidence",
+          "columnsFrom": ["recorded_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_evidence_tenant_source_fk": {
+          "name": "person_merge_evidence_tenant_source_fk",
+          "tableFrom": "person_merge_evidence",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_evidence_tenant_target_fk": {
+          "name": "person_merge_evidence_tenant_target_fk",
+          "tableFrom": "person_merge_evidence",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_evidence_tenant_id_id_unique": {
+          "name": "person_merge_evidence_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "person_merge_evidence_status_check": {
+          "name": "person_merge_evidence_status_check",
+          "value": "\"person_merge_evidence\".\"status\" IN ('proposed', 'approved', 'completed', 'rejected', 'reverted')"
+        },
+        "person_merge_evidence_distinct_people_check": {
+          "name": "person_merge_evidence_distinct_people_check",
+          "value": "\"person_merge_evidence\".\"source_person_id\" <> \"person_merge_evidence\".\"target_person_id\""
+        },
+        "person_merge_evidence_completion_check": {
+          "name": "person_merge_evidence_completion_check",
+          "value": "\"person_merge_evidence\".\"status\" <> 'completed' OR \"person_merge_evidence\".\"completed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.person_relationships": {
+      "name": "person_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_person_id": {
+          "name": "subject_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_person_id": {
+          "name": "related_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_authority": {
+          "name": "legal_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decision_authority": {
+          "name": "decision_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "emergency_priority": {
+          "name": "emergency_priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_authority": {
+          "name": "pickup_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "portal_eligible": {
+          "name": "portal_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_relationships_one_active_contact_per_learner_idx": {
+          "name": "person_relationships_one_active_contact_per_learner_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"person_relationships\".\"status\" = 'active' AND \"person_relationships\".\"type\" IN ('parent_of', 'guardian_of', 'emergency_contact_of')",
+          "concurrently": false
+        },
+        "person_relationships_subject_effective_idx": {
+          "name": "person_relationships_subject_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "person_relationships_related_effective_idx": {
+          "name": "person_relationships_related_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_relationships_tenant_id_tenants_id_fk": {
+          "name": "person_relationships_tenant_id_tenants_id_fk",
+          "tableFrom": "person_relationships",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_relationships_issued_by_account_id_accounts_id_fk": {
+          "name": "person_relationships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "person_relationships",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_relationships_revoked_by_account_id_accounts_id_fk": {
+          "name": "person_relationships_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "person_relationships",
+          "columnsFrom": ["revoked_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_relationships_tenant_subject_fk": {
+          "name": "person_relationships_tenant_subject_fk",
+          "tableFrom": "person_relationships",
+          "columnsFrom": ["tenant_id", "subject_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_relationships_tenant_related_fk": {
+          "name": "person_relationships_tenant_related_fk",
+          "tableFrom": "person_relationships",
+          "columnsFrom": ["tenant_id", "related_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_relationships_tenant_id_id_unique": {
+          "name": "person_relationships_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "person_relationships_runtime_select": {
+          "name": "person_relationships_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND (\n          (\n            nullif(current_setting('app.policy_capability', true), '')\n              = 'tenant.guardian_contacts.read'\n            AND public.openschool_guardian_contact_read_scope_allows(\n              \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n            )\n          )\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              = 'tenant.guardian_contacts.manage'\n            AND public.openschool_guardian_contact_manage_scope_allows(\n              \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n            )\n          )\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              IN ('identity.context.resolve', 'tenant.students.read')\n            AND \"person_relationships\".\"subject_person_id\"::text\n              = nullif(current_setting('app.person_id', true), '')\n            AND \"person_relationships\".\"type\" IN ('guardian_of', 'parent_of')\n            AND \"person_relationships\".\"portal_eligible\"\n            AND \"person_relationships\".\"status\" = 'active'\n            AND \"person_relationships\".\"valid_from\" <= now()\n            AND (\"person_relationships\".\"valid_until\" IS NULL OR \"person_relationships\".\"valid_until\" > now())\n            AND EXISTS (\n              SELECT 1\n              FROM jsonb_array_elements(public.openschool_policy_constraints()) AS constraint_row\n              WHERE constraint_row ->> 'kind' = 'linked_student'\n                AND constraint_row ->> 'tenantId' = \"person_relationships\".\"tenant_id\"::text\n                AND constraint_row ->> 'guardianPersonId' = \"person_relationships\".\"subject_person_id\"::text\n                AND (\n                  constraint_row ->> 'studentId' IS NULL\n                  OR constraint_row ->> 'studentId' = \"person_relationships\".\"related_person_id\"::text\n                )\n            )\n          )\n        )\n      "
+        },
+        "person_relationships_runtime_insert_deny": {
+          "name": "person_relationships_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "person_relationships_runtime_update_deny": {
+          "name": "person_relationships_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_relationships_runtime_delete_deny": {
+          "name": "person_relationships_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "person_relationships_contact_manager_select": {
+          "name": "person_relationships_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_insert": {
+          "name": "person_relationships_contact_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_guardian_contact_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_update": {
+          "name": "person_relationships_contact_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_delete_deny": {
+          "name": "person_relationships_contact_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "person_relationships_type_check": {
+          "name": "person_relationships_type_check",
+          "value": "\"person_relationships\".\"type\" IN ('guardian_of', 'parent_of', 'emergency_contact_of', 'spouse_of', 'sibling_of', 'other')"
+        },
+        "person_relationships_status_check": {
+          "name": "person_relationships_status_check",
+          "value": "\"person_relationships\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "person_relationships_distinct_people_check": {
+          "name": "person_relationships_distinct_people_check",
+          "value": "\"person_relationships\".\"subject_person_id\" <> \"person_relationships\".\"related_person_id\""
+        },
+        "person_relationships_valid_period_check": {
+          "name": "person_relationships_valid_period_check",
+          "value": "\"person_relationships\".\"valid_until\" IS NULL OR \"person_relationships\".\"valid_until\" > \"person_relationships\".\"valid_from\""
+        },
+        "person_relationships_revocation_evidence_check": {
+          "name": "person_relationships_revocation_evidence_check",
+          "value": "\"person_relationships\".\"status\" <> 'revoked' OR (\"person_relationships\".\"revoked_at\" IS NOT NULL AND \"person_relationships\".\"revocation_reason\" IS NOT NULL AND \"person_relationships\".\"valid_until\" IS NOT NULL)"
+        },
+        "person_relationships_decision_authority_check": {
+          "name": "person_relationships_decision_authority_check",
+          "value": "\"person_relationships\".\"decision_authority\" IN ('none', 'shared', 'sole', 'limited')"
+        },
+        "person_relationships_emergency_priority_check": {
+          "name": "person_relationships_emergency_priority_check",
+          "value": "\"person_relationships\".\"emergency_priority\" IS NULL OR \"person_relationships\".\"emergency_priority\" BETWEEN 1 AND 99"
+        },
+        "person_relationships_portal_eligibility_check": {
+          "name": "person_relationships_portal_eligibility_check",
+          "value": "NOT \"person_relationships\".\"portal_eligible\" OR \"person_relationships\".\"type\" IN ('guardian_of', 'parent_of')"
+        },
+        "person_relationships_version_positive": {
+          "name": "person_relationships_version_positive",
+          "value": "\"person_relationships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.role_template_assignments": {
+      "name": "role_template_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliation_id": {
+          "name": "affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_template_key": {
+          "name": "role_template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_template_assignments_affiliation_effective_idx": {
+          "name": "role_template_assignments_affiliation_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affiliation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "role_template_assignments_tenant_id_tenants_id_fk": {
+          "name": "role_template_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "role_template_assignments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "role_template_assignments_issued_by_account_id_accounts_id_fk": {
+          "name": "role_template_assignments_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "role_template_assignments",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "role_template_assignments_revoked_by_account_id_accounts_id_fk": {
+          "name": "role_template_assignments_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "role_template_assignments",
+          "columnsFrom": ["revoked_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "role_template_assignments_tenant_affiliation_fk": {
+          "name": "role_template_assignments_tenant_affiliation_fk",
+          "tableFrom": "role_template_assignments",
+          "columnsFrom": ["tenant_id", "affiliation_id"],
+          "tableTo": "affiliations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_template_assignments_tenant_id_id_unique": {
+          "name": "role_template_assignments_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "role_template_assignments_status_check": {
+          "name": "role_template_assignments_status_check",
+          "value": "\"role_template_assignments\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "role_template_assignments_valid_period_check": {
+          "name": "role_template_assignments_valid_period_check",
+          "value": "\"role_template_assignments\".\"valid_until\" IS NULL OR \"role_template_assignments\".\"valid_until\" > \"role_template_assignments\".\"valid_from\""
+        },
+        "role_template_assignments_revocation_evidence_check": {
+          "name": "role_template_assignments_revocation_evidence_check",
+          "value": "\"role_template_assignments\".\"status\" <> 'revoked' OR (\"role_template_assignments\".\"revoked_at\" IS NOT NULL AND \"role_template_assignments\".\"revocation_reason\" IS NOT NULL AND \"role_template_assignments\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.student_profiles": {
+      "name": "student_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_profiles_tenant_id_tenants_id_fk": {
+          "name": "student_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "student_profiles",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "student_profiles_tenant_person_fk": {
+          "name": "student_profiles_tenant_person_fk",
+          "tableFrom": "student_profiles",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "student_profiles_tenant_legacy_student_fk": {
+          "name": "student_profiles_tenant_legacy_student_fk",
+          "tableFrom": "student_profiles",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "tableTo": "students",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_profiles_pk": {
+          "name": "student_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "student_profiles_tenant_student_number_unique": {
+          "name": "student_profiles_tenant_student_number_unique",
+          "columns": ["tenant_id", "student_number"],
+          "nullsNotDistinct": false
+        },
+        "student_profiles_tenant_legacy_student_unique": {
+          "name": "student_profiles_tenant_legacy_student_unique",
+          "columns": ["tenant_id", "legacy_student_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "student_profiles_status_check": {
+          "name": "student_profiles_status_check",
+          "value": "\"student_profiles\".\"status\" IN ('active', 'inactive', 'graduated', 'withdrawn')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teacher_profiles": {
+      "name": "teacher_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teacher_profiles_tenant_id_tenants_id_fk": {
+          "name": "teacher_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "teacher_profiles",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "teacher_profiles_tenant_person_fk": {
+          "name": "teacher_profiles_tenant_person_fk",
+          "tableFrom": "teacher_profiles",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_profiles_pk": {
+          "name": "teacher_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "teacher_profiles_tenant_registration_number_unique": {
+          "name": "teacher_profiles_tenant_registration_number_unique",
+          "columns": ["tenant_id", "registration_number"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "teacher_profiles_status_check": {
+          "name": "teacher_profiles_status_check",
+          "value": "\"teacher_profiles\".\"status\" IN ('active', 'inactive', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classes_tenant_school_idx": {
+          "name": "classes_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "classes_tenant_school_fk": {
+          "name": "classes_tenant_school_fk",
+          "tableFrom": "classes",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_tenant_school_idx": {
+          "name": "students_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "students_tenant_school_fk": {
+          "name": "students_tenant_school_fk",
+          "tableFrom": "students",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "columns": ["tenant_id", "student_number"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "students_runtime_select": {
+          "name": "students_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          'tenant.students.create', 'tenant.students.read',\n          'tenant.students.update', 'tenant.students.delete',\n          'support.students.read',\n          'identity.context.resolve'\n        )\n        AND public.openschool_student_scope_allows(\n          \"students\".\"tenant_id\", \"students\".\"school_id\", \"students\".\"id\"\n        )\n      "
+        },
+        "students_runtime_insert": {
+          "name": "students_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "students_runtime_update": {
+          "name": "students_runtime_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "students_runtime_delete": {
+          "name": "students_runtime_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "students_admitter_select": {
+          "name": "students_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_insert": {
+          "name": "students_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.students.create'\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_update": {
+          "name": "students_admitter_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.update', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.update', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_delete_deny": {
+          "name": "students_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        },
+        "students_worker_select": {
+          "name": "students_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "students_worker_insert_deny": {
+          "name": "students_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "students_worker_update_deny": {
+          "name": "students_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "students_worker_delete_deny": {
+          "name": "students_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.school_enrollment_transition_events": {
+      "name": "school_enrollment_transition_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_id": {
+          "name": "transition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_enrollment_id": {
+          "name": "from_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_enrollment_id": {
+          "name": "to_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_school_id": {
+          "name": "source_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_school_id": {
+          "name": "destination_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_type": {
+          "name": "transition_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_reference": {
+          "name": "evidence_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_enrollment_version": {
+          "name": "expected_enrollment_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_tree_version_id": {
+          "name": "organization_tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_version_evidence": {
+          "name": "authorization_version_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_enrollment_transition_events_timeline_idx": {
+          "name": "school_enrollment_transition_events_timeline_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "school_enrollment_transition_events_due_idx": {
+          "name": "school_enrollment_transition_events_due_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "school_enrollment_transition_events_tenant_id_tenants_id_fk": {
+          "name": "school_enrollment_transition_events_tenant_id_tenants_id_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollment_transition_events_actor_account_id_accounts_id_fk": {
+          "name": "school_enrollment_transition_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "columnsFrom": ["actor_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_person_fk": {
+          "name": "school_enrollment_transition_events_tenant_person_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_from_fk": {
+          "name": "school_enrollment_transition_events_tenant_from_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "columnsFrom": ["tenant_id", "from_enrollment_id", "person_id", "source_school_id"],
+          "tableTo": "school_enrollments",
+          "columnsTo": ["tenant_id", "id", "person_id", "school_id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_to_fk": {
+          "name": "school_enrollment_transition_events_tenant_to_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "columnsFrom": ["tenant_id", "to_enrollment_id", "person_id", "destination_school_id"],
+          "tableTo": "school_enrollments",
+          "columnsTo": ["tenant_id", "id", "person_id", "school_id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_source_school_fk": {
+          "name": "school_enrollment_transition_events_tenant_source_school_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "columnsFrom": ["tenant_id", "source_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_destination_school_fk": {
+          "name": "school_enrollment_transition_events_tenant_destination_school_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "columnsFrom": ["tenant_id", "destination_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_tree_version_fk": {
+          "name": "school_enrollment_transition_events_tenant_tree_version_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "columnsFrom": ["tenant_id", "organization_tree_version_id"],
+          "tableTo": "organization_tree_versions",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_enrollment_transition_events_tenant_id_id_unique": {
+          "name": "school_enrollment_transition_events_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "school_enrollment_transition_events_kind_unique": {
+          "name": "school_enrollment_transition_events_kind_unique",
+          "columns": ["tenant_id", "transition_id", "event_type"],
+          "nullsNotDistinct": false
+        },
+        "school_enrollment_transition_events_request_unique": {
+          "name": "school_enrollment_transition_events_request_unique",
+          "columns": ["tenant_id", "request_id", "event_type"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "school_enrollment_transition_events_runtime_select": {
+          "name": "school_enrollment_transition_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.student_enrollments.read', 'tenant.student_enrollments.manage')\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_runtime_insert_deny": {
+          "name": "school_enrollment_transition_events_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_runtime_update_deny": {
+          "name": "school_enrollment_transition_events_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_runtime_delete_deny": {
+          "name": "school_enrollment_transition_events_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "school_enrollment_transition_events_admitter_select": {
+          "name": "school_enrollment_transition_events_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_admitter_insert": {
+          "name": "school_enrollment_transition_events_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_admitter_update_deny": {
+          "name": "school_enrollment_transition_events_admitter_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_admitter_delete_deny": {
+          "name": "school_enrollment_transition_events_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "school_enrollment_transition_events_event_check": {
+          "name": "school_enrollment_transition_events_event_check",
+          "value": "\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'applied', 'cancelled')"
+        },
+        "school_enrollment_transition_events_transition_check": {
+          "name": "school_enrollment_transition_events_transition_check",
+          "value": "\"school_enrollment_transition_events\".\"transition_type\" IN ('withdraw', 'transfer', 'graduate', 'reenroll', 'add_secondary', 'end_secondary')"
+        },
+        "school_enrollment_transition_events_reason_check": {
+          "name": "school_enrollment_transition_events_reason_check",
+          "value": "char_length(btrim(\"school_enrollment_transition_events\".\"reason\")) BETWEEN 3 AND 512"
+        },
+        "school_enrollment_transition_events_evidence_check": {
+          "name": "school_enrollment_transition_events_evidence_check",
+          "value": "\"school_enrollment_transition_events\".\"evidence_reference\" IS NULL OR char_length(btrim(\"school_enrollment_transition_events\".\"evidence_reference\")) BETWEEN 3 AND 512"
+        },
+        "school_enrollment_transition_events_expected_version_check": {
+          "name": "school_enrollment_transition_events_expected_version_check",
+          "value": "\"school_enrollment_transition_events\".\"expected_enrollment_version\" IS NULL OR \"school_enrollment_transition_events\".\"expected_enrollment_version\" > 0"
+        },
+        "school_enrollment_transition_events_shape_check": {
+          "name": "school_enrollment_transition_events_shape_check",
+          "value": "(\n          \"school_enrollment_transition_events\".\"transition_type\" IN ('withdraw', 'graduate', 'end_secondary')\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL\n        ) OR (\n          \"school_enrollment_transition_events\".\"transition_type\" = 'transfer'\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NOT NULL\n          AND (\n            (\"school_enrollment_transition_events\".\"event_type\" = 'applied' AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NOT NULL)\n            OR (\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'cancelled') AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL)\n          )\n        ) OR (\n          \"school_enrollment_transition_events\".\"transition_type\" IN ('reenroll', 'add_secondary')\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NOT NULL\n          AND (\n            (\"school_enrollment_transition_events\".\"event_type\" = 'applied' AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NOT NULL)\n            OR (\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'cancelled') AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.school_enrollments": {
+      "name": "school_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_affiliation_id": {
+          "name": "student_affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollment_type": {
+          "name": "enrollment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_reason": {
+          "name": "admission_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_evidence_reference": {
+          "name": "end_evidence_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supersedes_enrollment_id": {
+          "name": "supersedes_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_tree_version_id": {
+          "name": "organization_tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_enrollments_tenant_school_current_idx": {
+          "name": "school_enrollments_tenant_school_current_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "school_enrollments_tenant_person_history_idx": {
+          "name": "school_enrollments_tenant_person_history_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "school_enrollments_tenant_id_tenants_id_fk": {
+          "name": "school_enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollments_ended_by_account_id_accounts_id_fk": {
+          "name": "school_enrollments_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["ended_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollments_created_by_account_id_accounts_id_fk": {
+          "name": "school_enrollments_created_by_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["created_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollments_tenant_person_fk": {
+          "name": "school_enrollments_tenant_person_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollments_tenant_school_fk": {
+          "name": "school_enrollments_tenant_school_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollments_tenant_affiliation_fk": {
+          "name": "school_enrollments_tenant_affiliation_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["tenant_id", "student_affiliation_id"],
+          "tableTo": "affiliations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollments_tenant_legacy_student_fk": {
+          "name": "school_enrollments_tenant_legacy_student_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "tableTo": "students",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollments_tenant_supersedes_fk": {
+          "name": "school_enrollments_tenant_supersedes_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["tenant_id", "supersedes_enrollment_id"],
+          "tableTo": "school_enrollments",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "school_enrollments_tenant_tree_version_fk": {
+          "name": "school_enrollments_tenant_tree_version_fk",
+          "tableFrom": "school_enrollments",
+          "columnsFrom": ["tenant_id", "organization_tree_version_id"],
+          "tableTo": "organization_tree_versions",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_enrollments_tenant_id_id_unique": {
+          "name": "school_enrollments_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "school_enrollments_transition_reference_unique": {
+          "name": "school_enrollments_transition_reference_unique",
+          "columns": ["tenant_id", "id", "person_id", "school_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "school_enrollments_runtime_select": {
+          "name": "school_enrollments_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          \n  'tenant.students.read', 'tenant.students.update',\n  'tenant.students.delete', 'support.students.read',\n  'tenant.student_enrollments.read', 'tenant.student_enrollments.manage'\n,\n          'tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage',\n          'tenant.households.read', 'tenant.households.manage',\n          'tenant.sections.read', 'tenant.sections.manage',\n          'identity.context.resolve'\n        )\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_section_manager_select": {
+          "name": "school_enrollments_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_section_manager'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n        AND public.openschool_school_scope_allows(\"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\")\n      "
+        },
+        "school_enrollments_runtime_insert_deny": {
+          "name": "school_enrollments_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "school_enrollments_runtime_update_deny": {
+          "name": "school_enrollments_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollments_runtime_delete_deny": {
+          "name": "school_enrollments_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "school_enrollments_admitter_select": {
+          "name": "school_enrollments_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_admitter_insert": {
+          "name": "school_enrollments_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.create', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\")\n      "
+        },
+        "school_enrollments_admitter_update": {
+          "name": "school_enrollments_admitter_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_admitter_delete_deny": {
+          "name": "school_enrollments_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        },
+        "school_enrollments_contact_manager_select": {
+          "name": "school_enrollments_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "school_enrollments_type_check": {
+          "name": "school_enrollments_type_check",
+          "value": "\"school_enrollments\".\"enrollment_type\" IN ('primary', 'secondary')"
+        },
+        "school_enrollments_status_check": {
+          "name": "school_enrollments_status_check",
+          "value": "\"school_enrollments\".\"status\" IN ('enrolled', 'withdrawn', 'graduated', 'cancelled')"
+        },
+        "school_enrollments_source_check": {
+          "name": "school_enrollments_source_check",
+          "value": "\"school_enrollments\".\"source\" IN ('legacy_backfill', 'native')"
+        },
+        "school_enrollments_valid_period_check": {
+          "name": "school_enrollments_valid_period_check",
+          "value": "\"school_enrollments\".\"valid_until\" IS NULL OR \"school_enrollments\".\"valid_until\" > \"school_enrollments\".\"valid_from\""
+        },
+        "school_enrollments_closed_status_check": {
+          "name": "school_enrollments_closed_status_check",
+          "value": "\"school_enrollments\".\"status\" = 'enrolled' OR \"school_enrollments\".\"valid_until\" IS NOT NULL"
+        },
+        "school_enrollments_legacy_source_check": {
+          "name": "school_enrollments_legacy_source_check",
+          "value": "\"school_enrollments\".\"source\" <> 'legacy_backfill' OR \"school_enrollments\".\"legacy_student_id\" IS NOT NULL"
+        },
+        "school_enrollments_native_tree_version_check": {
+          "name": "school_enrollments_native_tree_version_check",
+          "value": "\"school_enrollments\".\"source\" = 'legacy_backfill' OR \"school_enrollments\".\"organization_tree_version_id\" IS NOT NULL"
+        },
+        "school_enrollments_version_positive": {
+          "name": "school_enrollments_version_positive",
+          "value": "\"school_enrollments\".\"version\" > 0"
+        },
+        "school_enrollments_end_evidence_check": {
+          "name": "school_enrollments_end_evidence_check",
+          "value": "(\"school_enrollments\".\"valid_until\" IS NULL AND \"school_enrollments\".\"end_reason\" IS NULL AND \"school_enrollments\".\"ended_by_account_id\" IS NULL AND \"school_enrollments\".\"ended_at\" IS NULL)\n        OR (\"school_enrollments\".\"valid_until\" IS NOT NULL AND \"school_enrollments\".\"end_reason\" IS NOT NULL AND \"school_enrollments\".\"ended_at\" IS NOT NULL)"
+        },
+        "school_enrollments_end_reason_check": {
+          "name": "school_enrollments_end_reason_check",
+          "value": "\"school_enrollments\".\"end_reason\" IS NULL OR \"school_enrollments\".\"end_reason\" IN ('withdrawal', 'transfer', 'graduation', 'secondary_ended', 'correction')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.student_compatibility_evidence": {
+      "name": "student_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_enrollment_id": {
+          "name": "school_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_affiliation_id": {
+          "name": "student_affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parity_status": {
+          "name": "parity_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_snapshot": {
+          "name": "canonical_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "legacy_snapshot": {
+          "name": "legacy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_account_id": {
+          "name": "recorded_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_compatibility_evidence_tenant_person_idx": {
+          "name": "student_compatibility_evidence_tenant_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "student_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "student_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "student_compatibility_evidence_recorded_by_account_id_accounts_id_fk": {
+          "name": "student_compatibility_evidence_recorded_by_account_id_accounts_id_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "columnsFrom": ["recorded_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "student_compatibility_evidence_tenant_person_fk": {
+          "name": "student_compatibility_evidence_tenant_person_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "student_compatibility_evidence_tenant_school_fk": {
+          "name": "student_compatibility_evidence_tenant_school_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "student_compatibility_evidence_tenant_enrollment_fk": {
+          "name": "student_compatibility_evidence_tenant_enrollment_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "school_enrollment_id"],
+          "tableTo": "school_enrollments",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "student_compatibility_evidence_tenant_affiliation_fk": {
+          "name": "student_compatibility_evidence_tenant_affiliation_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "student_affiliation_id"],
+          "tableTo": "affiliations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "student_compatibility_evidence_tenant_legacy_student_fk": {
+          "name": "student_compatibility_evidence_tenant_legacy_student_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "tableTo": "students",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_compatibility_evidence_tenant_id_id_unique": {
+          "name": "student_compatibility_evidence_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "student_compatibility_evidence_request_unique": {
+          "name": "student_compatibility_evidence_request_unique",
+          "columns": ["tenant_id", "person_id", "request_id", "operation"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "student_compatibility_evidence_runtime_select": {
+          "name": "student_compatibility_evidence_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          \n  'tenant.students.read', 'tenant.students.update',\n  'tenant.students.delete', 'support.students.read',\n  'tenant.student_enrollments.read', 'tenant.student_enrollments.manage'\n\n        )\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_runtime_insert_deny": {
+          "name": "student_compatibility_evidence_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_runtime_update_deny": {
+          "name": "student_compatibility_evidence_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_runtime_delete_deny": {
+          "name": "student_compatibility_evidence_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "student_compatibility_evidence_admitter_select": {
+          "name": "student_compatibility_evidence_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_admitter_insert": {
+          "name": "student_compatibility_evidence_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_admitter_update_deny": {
+          "name": "student_compatibility_evidence_admitter_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_admitter_delete_deny": {
+          "name": "student_compatibility_evidence_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "student_compatibility_evidence_operation_check": {
+          "name": "student_compatibility_evidence_operation_check",
+          "value": "\"student_compatibility_evidence\".\"operation\" IN ('backfill', 'create', 'update', 'transition')"
+        },
+        "student_compatibility_evidence_parity_check": {
+          "name": "student_compatibility_evidence_parity_check",
+          "value": "\"student_compatibility_evidence\".\"parity_status\" IN ('matched', 'mismatch')"
+        },
+        "student_compatibility_evidence_request_check": {
+          "name": "student_compatibility_evidence_request_check",
+          "value": "btrim(\"student_compatibility_evidence\".\"request_id\") <> ''"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_compatibility_evidence": {
+      "name": "academic_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_value": {
+          "name": "legacy_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_status": {
+          "name": "mapping_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_term_id": {
+          "name": "academic_term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_compatibility_evidence_tenant_school_idx": {
+          "name": "academic_compatibility_evidence_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mapping_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "academic_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "academic_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_school_fk": {
+          "name": "academic_compatibility_evidence_tenant_school_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_year_fk": {
+          "name": "academic_compatibility_evidence_tenant_year_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "academic_year_id"],
+          "tableTo": "academic_years",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_term_fk": {
+          "name": "academic_compatibility_evidence_tenant_term_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "academic_term_id"],
+          "tableTo": "academic_terms",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_compatibility_evidence_tenant_id_id_unique": {
+          "name": "academic_compatibility_evidence_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "academic_compatibility_evidence_source_unique": {
+          "name": "academic_compatibility_evidence_source_unique",
+          "columns": ["tenant_id", "source_type", "source_key"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "academic_compatibility_evidence_runtime_select": {
+          "name": "academic_compatibility_evidence_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_compatibility_evidence\".\"tenant_id\", \"academic_compatibility_evidence\".\"school_id\")\n"
+        },
+        "academic_compatibility_evidence_runtime_insert_deny": {
+          "name": "academic_compatibility_evidence_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_compatibility_evidence_runtime_update_deny": {
+          "name": "academic_compatibility_evidence_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_compatibility_evidence_runtime_delete_deny": {
+          "name": "academic_compatibility_evidence_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_compatibility_evidence_source_type_check": {
+          "name": "academic_compatibility_evidence_source_type_check",
+          "value": "\"academic_compatibility_evidence\".\"source_type\" IN ('school_academic_year', 'school_term', 'class_academic_year')"
+        },
+        "academic_compatibility_evidence_mapping_status_check": {
+          "name": "academic_compatibility_evidence_mapping_status_check",
+          "value": "\"academic_compatibility_evidence\".\"mapping_status\" IN ('mapped', 'unmapped', 'review_required')"
+        },
+        "academic_compatibility_evidence_source_key_check": {
+          "name": "academic_compatibility_evidence_source_key_check",
+          "value": "char_length(btrim(\"academic_compatibility_evidence\".\"source_key\")) BETWEEN 1 AND 256"
+        },
+        "academic_compatibility_evidence_reason_check": {
+          "name": "academic_compatibility_evidence_reason_check",
+          "value": "char_length(btrim(\"academic_compatibility_evidence\".\"reason\")) BETWEEN 3 AND 512"
+        },
+        "academic_compatibility_evidence_mapping_check": {
+          "name": "academic_compatibility_evidence_mapping_check",
+          "value": "\"academic_compatibility_evidence\".\"mapping_status\" <> 'mapped' OR \"academic_compatibility_evidence\".\"academic_year_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_terms": {
+      "name": "academic_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_terms_year_dates_idx": {
+          "name": "academic_terms_year_dates_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "academic_terms_tenant_id_tenants_id_fk": {
+          "name": "academic_terms_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_terms",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "academic_terms_tenant_school_year_fk": {
+          "name": "academic_terms_tenant_school_year_fk",
+          "tableFrom": "academic_terms",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "tableTo": "academic_years",
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_terms_tenant_id_id_unique": {
+          "name": "academic_terms_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "academic_terms_tenant_school_id_id_unique": {
+          "name": "academic_terms_tenant_school_id_id_unique",
+          "columns": ["tenant_id", "school_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "academic_terms_year_code_unique": {
+          "name": "academic_terms_year_code_unique",
+          "columns": ["tenant_id", "academic_year_id", "code"],
+          "nullsNotDistinct": false
+        },
+        "academic_terms_year_ordinal_unique": {
+          "name": "academic_terms_year_ordinal_unique",
+          "columns": ["tenant_id", "academic_year_id", "ordinal"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "academic_terms_runtime_select": {
+          "name": "academic_terms_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_runtime_insert_deny": {
+          "name": "academic_terms_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_terms_runtime_update_deny": {
+          "name": "academic_terms_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_terms_runtime_delete_deny": {
+          "name": "academic_terms_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "academic_terms_configurator_select": {
+          "name": "academic_terms_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_section_manager_select": {
+          "name": "academic_terms_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_configurator_insert": {
+          "name": "academic_terms_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_configurator_update_deny": {
+          "name": "academic_terms_configurator_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_terms_configurator_delete_deny": {
+          "name": "academic_terms_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_terms_code_check": {
+          "name": "academic_terms_code_check",
+          "value": "char_length(btrim(\"academic_terms\".\"code\")) BETWEEN 1 AND 64 AND \"academic_terms\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "academic_terms_name_check": {
+          "name": "academic_terms_name_check",
+          "value": "char_length(btrim(\"academic_terms\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "academic_terms_ordinal_check": {
+          "name": "academic_terms_ordinal_check",
+          "value": "\"academic_terms\".\"ordinal\" BETWEEN 1 AND 20"
+        },
+        "academic_terms_dates_check": {
+          "name": "academic_terms_dates_check",
+          "value": "\"academic_terms\".\"end_date\" >= \"academic_terms\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_years": {
+      "name": "academic_years",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "migration_review_status": {
+          "name": "migration_review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "legacy_academic_year": {
+          "name": "legacy_academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by_account_id": {
+          "name": "published_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_years_tenant_school_status_dates_idx": {
+          "name": "academic_years_tenant_school_status_dates_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "academic_years_tenant_id_tenants_id_fk": {
+          "name": "academic_years_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_years",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "academic_years_created_by_account_id_accounts_id_fk": {
+          "name": "academic_years_created_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "columnsFrom": ["created_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "academic_years_published_by_account_id_accounts_id_fk": {
+          "name": "academic_years_published_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "columnsFrom": ["published_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "academic_years_closed_by_account_id_accounts_id_fk": {
+          "name": "academic_years_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "columnsFrom": ["closed_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "academic_years_tenant_school_fk": {
+          "name": "academic_years_tenant_school_fk",
+          "tableFrom": "academic_years",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_years_tenant_id_id_unique": {
+          "name": "academic_years_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "academic_years_tenant_school_id_id_unique": {
+          "name": "academic_years_tenant_school_id_id_unique",
+          "columns": ["tenant_id", "school_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "academic_years_tenant_school_code_unique": {
+          "name": "academic_years_tenant_school_code_unique",
+          "columns": ["tenant_id", "school_id", "code"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "academic_years_runtime_select": {
+          "name": "academic_years_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_runtime_insert_deny": {
+          "name": "academic_years_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_years_runtime_update_deny": {
+          "name": "academic_years_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_years_runtime_delete_deny": {
+          "name": "academic_years_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "academic_years_configurator_select": {
+          "name": "academic_years_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_section_manager_select": {
+          "name": "academic_years_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_insert": {
+          "name": "academic_years_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_update": {
+          "name": "academic_years_configurator_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_delete_deny": {
+          "name": "academic_years_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_years_code_check": {
+          "name": "academic_years_code_check",
+          "value": "char_length(btrim(\"academic_years\".\"code\")) BETWEEN 1 AND 64 AND \"academic_years\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "academic_years_name_check": {
+          "name": "academic_years_name_check",
+          "value": "char_length(btrim(\"academic_years\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "academic_years_timezone_check": {
+          "name": "academic_years_timezone_check",
+          "value": "char_length(btrim(\"academic_years\".\"time_zone\")) BETWEEN 1 AND 128"
+        },
+        "academic_years_dates_check": {
+          "name": "academic_years_dates_check",
+          "value": "\"academic_years\".\"end_date\" >= \"academic_years\".\"start_date\""
+        },
+        "academic_years_status_check": {
+          "name": "academic_years_status_check",
+          "value": "\"academic_years\".\"status\" IN ('draft', 'published', 'closed')"
+        },
+        "academic_years_source_check": {
+          "name": "academic_years_source_check",
+          "value": "\"academic_years\".\"source\" IN ('native', 'legacy_backfill')"
+        },
+        "academic_years_review_check": {
+          "name": "academic_years_review_check",
+          "value": "\"academic_years\".\"migration_review_status\" IN ('not_required', 'needs_review', 'approved')"
+        },
+        "academic_years_review_source_check": {
+          "name": "academic_years_review_source_check",
+          "value": "\"academic_years\".\"source\" = 'legacy_backfill' OR \"academic_years\".\"migration_review_status\" = 'not_required'"
+        },
+        "academic_years_publish_evidence_check": {
+          "name": "academic_years_publish_evidence_check",
+          "value": "\"academic_years\".\"status\" = 'draft' OR (\"academic_years\".\"published_at\" IS NOT NULL AND \"academic_years\".\"published_by_account_id\" IS NOT NULL)"
+        },
+        "academic_years_close_evidence_check": {
+          "name": "academic_years_close_evidence_check",
+          "value": "\"academic_years\".\"status\" <> 'closed' OR (\"academic_years\".\"closed_at\" IS NOT NULL AND \"academic_years\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"academic_years\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.learner_levels": {
+      "name": "learner_levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_stage": {
+          "name": "education_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "learner_levels_year_order_idx": {
+          "name": "learner_levels_year_order_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "learner_levels_tenant_id_tenants_id_fk": {
+          "name": "learner_levels_tenant_id_tenants_id_fk",
+          "tableFrom": "learner_levels",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "learner_levels_tenant_school_year_fk": {
+          "name": "learner_levels_tenant_school_year_fk",
+          "tableFrom": "learner_levels",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "tableTo": "academic_years",
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "learner_levels_tenant_id_id_unique": {
+          "name": "learner_levels_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "learner_levels_tenant_school_id_id_unique": {
+          "name": "learner_levels_tenant_school_id_id_unique",
+          "columns": ["tenant_id", "school_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "learner_levels_year_code_unique": {
+          "name": "learner_levels_year_code_unique",
+          "columns": ["tenant_id", "academic_year_id", "code"],
+          "nullsNotDistinct": false
+        },
+        "learner_levels_year_ordinal_unique": {
+          "name": "learner_levels_year_ordinal_unique",
+          "columns": ["tenant_id", "academic_year_id", "ordinal"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "learner_levels_runtime_select": {
+          "name": "learner_levels_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_runtime_insert_deny": {
+          "name": "learner_levels_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "learner_levels_runtime_update_deny": {
+          "name": "learner_levels_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "learner_levels_runtime_delete_deny": {
+          "name": "learner_levels_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "learner_levels_configurator_select": {
+          "name": "learner_levels_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_section_manager_select": {
+          "name": "learner_levels_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_configurator_insert": {
+          "name": "learner_levels_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_configurator_update_deny": {
+          "name": "learner_levels_configurator_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "learner_levels_configurator_delete_deny": {
+          "name": "learner_levels_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "learner_levels_code_check": {
+          "name": "learner_levels_code_check",
+          "value": "char_length(btrim(\"learner_levels\".\"code\")) BETWEEN 1 AND 64 AND \"learner_levels\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "learner_levels_name_check": {
+          "name": "learner_levels_name_check",
+          "value": "char_length(btrim(\"learner_levels\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "learner_levels_ordinal_check": {
+          "name": "learner_levels_ordinal_check",
+          "value": "\"learner_levels\".\"ordinal\" BETWEEN 1 AND 30"
+        },
+        "learner_levels_stage_check": {
+          "name": "learner_levels_stage_check",
+          "value": "\"learner_levels\".\"education_stage\" IS NULL OR char_length(btrim(\"learner_levels\".\"education_stage\")) BETWEEN 1 AND 64"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_type": {
+          "name": "course_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_area": {
+          "name": "subject_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_value": {
+          "name": "credit_value",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by_account_id": {
+          "name": "archived_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "courses_tenant_school_status_name_idx": {
+          "name": "courses_tenant_school_status_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "courses_tenant_id_tenants_id_fk": {
+          "name": "courses_tenant_id_tenants_id_fk",
+          "tableFrom": "courses",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "courses_created_by_account_id_accounts_id_fk": {
+          "name": "courses_created_by_account_id_accounts_id_fk",
+          "tableFrom": "courses",
+          "columnsFrom": ["created_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "courses_archived_by_account_id_accounts_id_fk": {
+          "name": "courses_archived_by_account_id_accounts_id_fk",
+          "tableFrom": "courses",
+          "columnsFrom": ["archived_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "courses_tenant_school_fk": {
+          "name": "courses_tenant_school_fk",
+          "tableFrom": "courses",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "courses_tenant_id_id_unique": {
+          "name": "courses_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "courses_tenant_school_id_id_unique": {
+          "name": "courses_tenant_school_id_id_unique",
+          "columns": ["tenant_id", "school_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "courses_tenant_school_code_unique": {
+          "name": "courses_tenant_school_code_unique",
+          "columns": ["tenant_id", "school_id", "code"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "courses_runtime_select": {
+          "name": "courses_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_course_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\", \"courses\".\"id\")\n      "
+        },
+        "courses_runtime_write_deny": {
+          "name": "courses_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "courses_manager_all": {
+          "name": "courses_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "courses_code_check": {
+          "name": "courses_code_check",
+          "value": "char_length(btrim(\"courses\".\"code\")) BETWEEN 1 AND 64 AND \"courses\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "courses_name_check": {
+          "name": "courses_name_check",
+          "value": "char_length(btrim(\"courses\".\"name\")) BETWEEN 1 AND 160"
+        },
+        "courses_type_check": {
+          "name": "courses_type_check",
+          "value": "\"courses\".\"course_type\" IN ('general', 'subject', 'elective', 'support')"
+        },
+        "courses_status_check": {
+          "name": "courses_status_check",
+          "value": "\"courses\".\"status\" IN ('active', 'archived')"
+        },
+        "courses_credit_check": {
+          "name": "courses_credit_check",
+          "value": "\"courses\".\"credit_value\" IS NULL OR (\"courses\".\"credit_value\" >= 0 AND \"courses\".\"credit_value\" <= 100)"
+        },
+        "courses_creation_reason_check": {
+          "name": "courses_creation_reason_check",
+          "value": "char_length(btrim(\"courses\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "courses_archive_evidence_check": {
+          "name": "courses_archive_evidence_check",
+          "value": "\"courses\".\"status\" <> 'archived' OR (\"courses\".\"archived_at\" IS NOT NULL AND \"courses\".\"archived_by_account_id\" IS NOT NULL AND char_length(btrim(\"courses\".\"archive_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_compatibility_evidence": {
+      "name": "section_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_class_id": {
+          "name": "legacy_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapping_status": {
+          "name": "mapping_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_roster_count": {
+          "name": "legacy_roster_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_roster_count": {
+          "name": "canonical_roster_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_roster_hash": {
+          "name": "legacy_roster_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_roster_hash": {
+          "name": "canonical_roster_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_compatibility_tenant_school_status_idx": {
+          "name": "section_compatibility_tenant_school_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mapping_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "section_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "section_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_compatibility_tenant_school_fk": {
+          "name": "section_compatibility_tenant_school_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_compatibility_tenant_legacy_class_fk": {
+          "name": "section_compatibility_tenant_legacy_class_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "legacy_class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_compatibility_tenant_section_fk": {
+          "name": "section_compatibility_tenant_section_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "columnsFrom": ["tenant_id", "section_id"],
+          "tableTo": "sections",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_compatibility_tenant_id_id_unique": {
+          "name": "section_compatibility_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "section_compatibility_legacy_class_unique": {
+          "name": "section_compatibility_legacy_class_unique",
+          "columns": ["tenant_id", "legacy_class_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "section_compatibility_runtime_select": {
+          "name": "section_compatibility_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"section_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_school_scope_allows(\"section_compatibility_evidence\".\"tenant_id\", \"section_compatibility_evidence\".\"school_id\")\n      "
+        },
+        "section_compatibility_runtime_write_deny": {
+          "name": "section_compatibility_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        }
+      },
+      "checkConstraints": {
+        "section_compatibility_status_check": {
+          "name": "section_compatibility_status_check",
+          "value": "\"section_compatibility_evidence\".\"mapping_status\" IN ('mapped', 'unmapped', 'review_required')"
+        },
+        "section_compatibility_counts_check": {
+          "name": "section_compatibility_counts_check",
+          "value": "\"section_compatibility_evidence\".\"legacy_roster_count\" >= 0 AND \"section_compatibility_evidence\".\"canonical_roster_count\" >= 0"
+        },
+        "section_compatibility_mapping_check": {
+          "name": "section_compatibility_mapping_check",
+          "value": "\"section_compatibility_evidence\".\"mapping_status\" <> 'mapped' OR (\"section_compatibility_evidence\".\"section_id\" IS NOT NULL AND \"section_compatibility_evidence\".\"legacy_roster_count\" = \"section_compatibility_evidence\".\"canonical_roster_count\" AND \"section_compatibility_evidence\".\"legacy_roster_hash\" = \"section_compatibility_evidence\".\"canonical_roster_hash\")"
+        },
+        "section_compatibility_reason_check": {
+          "name": "section_compatibility_reason_check",
+          "value": "char_length(btrim(\"section_compatibility_evidence\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_roster_memberships": {
+      "name": "section_roster_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_enrollment_id": {
+          "name": "school_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_key": {
+          "name": "roster_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_enrollment_id": {
+          "name": "legacy_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_rosters_tenant_section_effective_idx": {
+          "name": "section_rosters_tenant_section_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "section_rosters_tenant_person_effective_idx": {
+          "name": "section_rosters_tenant_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "section_roster_memberships_tenant_id_tenants_id_fk": {
+          "name": "section_roster_memberships_tenant_id_tenants_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_roster_memberships_issued_by_account_id_accounts_id_fk": {
+          "name": "section_roster_memberships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_roster_memberships_ended_by_account_id_accounts_id_fk": {
+          "name": "section_roster_memberships_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "columnsFrom": ["ended_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_rosters_tenant_section_fk": {
+          "name": "section_rosters_tenant_section_fk",
+          "tableFrom": "section_roster_memberships",
+          "columnsFrom": ["tenant_id", "school_id", "section_id"],
+          "tableTo": "sections",
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_rosters_tenant_person_fk": {
+          "name": "section_rosters_tenant_person_fk",
+          "tableFrom": "section_roster_memberships",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_rosters_tenant_school_enrollment_fk": {
+          "name": "section_rosters_tenant_school_enrollment_fk",
+          "tableFrom": "section_roster_memberships",
+          "columnsFrom": ["tenant_id", "school_enrollment_id"],
+          "tableTo": "school_enrollments",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_rosters_tenant_legacy_enrollment_fk": {
+          "name": "section_rosters_tenant_legacy_enrollment_fk",
+          "tableFrom": "section_roster_memberships",
+          "columnsFrom": ["tenant_id", "legacy_enrollment_id"],
+          "tableTo": "enrollments",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_rosters_tenant_id_id_unique": {
+          "name": "section_rosters_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "section_rosters_key_version_unique": {
+          "name": "section_rosters_key_version_unique",
+          "columns": ["tenant_id", "roster_key", "version"],
+          "nullsNotDistinct": false
+        },
+        "section_rosters_legacy_enrollment_unique": {
+          "name": "section_rosters_legacy_enrollment_unique",
+          "columns": ["tenant_id", "legacy_enrollment_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "section_rosters_runtime_select": {
+          "name": "section_rosters_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_section_roster_scope_allows(\n          \"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\", \"section_roster_memberships\".\"section_id\", \"section_roster_memberships\".\"person_id\"\n        )\n      "
+        },
+        "section_rosters_runtime_write_deny": {
+          "name": "section_rosters_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "section_rosters_manager_all": {
+          "name": "section_rosters_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "section_rosters_period_check": {
+          "name": "section_rosters_period_check",
+          "value": "\"section_roster_memberships\".\"valid_until\" IS NULL OR \"section_roster_memberships\".\"valid_until\" > \"section_roster_memberships\".\"valid_from\""
+        },
+        "section_rosters_status_check": {
+          "name": "section_rosters_status_check",
+          "value": "\"section_roster_memberships\".\"status\" IN ('active', 'ended')"
+        },
+        "section_rosters_end_evidence_check": {
+          "name": "section_rosters_end_evidence_check",
+          "value": "\"section_roster_memberships\".\"status\" <> 'ended' OR (\"section_roster_memberships\".\"valid_until\" IS NOT NULL AND \"section_roster_memberships\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"section_roster_memberships\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "section_rosters_version_positive": {
+          "name": "section_rosters_version_positive",
+          "value": "\"section_roster_memberships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_staff_assignments": {
+      "name": "section_staff_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_key": {
+          "name": "assignment_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_teacher_class_id": {
+          "name": "legacy_teacher_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_staff_tenant_section_effective_idx": {
+          "name": "section_staff_tenant_section_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "section_staff_assignments_tenant_id_tenants_id_fk": {
+          "name": "section_staff_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_staff_assignments_issued_by_account_id_accounts_id_fk": {
+          "name": "section_staff_assignments_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_staff_assignments_ended_by_account_id_accounts_id_fk": {
+          "name": "section_staff_assignments_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "columnsFrom": ["ended_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_staff_tenant_section_fk": {
+          "name": "section_staff_tenant_section_fk",
+          "tableFrom": "section_staff_assignments",
+          "columnsFrom": ["tenant_id", "school_id", "section_id"],
+          "tableTo": "sections",
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_staff_tenant_person_fk": {
+          "name": "section_staff_tenant_person_fk",
+          "tableFrom": "section_staff_assignments",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "section_staff_tenant_legacy_assignment_fk": {
+          "name": "section_staff_tenant_legacy_assignment_fk",
+          "tableFrom": "section_staff_assignments",
+          "columnsFrom": ["tenant_id", "legacy_teacher_class_id"],
+          "tableTo": "teachers_on_class",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_staff_tenant_id_id_unique": {
+          "name": "section_staff_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "section_staff_key_version_unique": {
+          "name": "section_staff_key_version_unique",
+          "columns": ["tenant_id", "assignment_key", "version"],
+          "nullsNotDistinct": false
+        },
+        "section_staff_legacy_assignment_unique": {
+          "name": "section_staff_legacy_assignment_unique",
+          "columns": ["tenant_id", "legacy_teacher_class_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "section_staff_runtime_select": {
+          "name": "section_staff_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.sections.read', 'tenant.sections.manage')\n  AND public.openschool_section_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\", \"section_staff_assignments\".\"section_id\")\n"
+        },
+        "section_staff_runtime_write_deny": {
+          "name": "section_staff_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "section_staff_manager_all": {
+          "name": "section_staff_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "section_staff_role_check": {
+          "name": "section_staff_role_check",
+          "value": "\"section_staff_assignments\".\"role\" IN ('lead_teacher', 'teacher', 'assistant', 'counselor')"
+        },
+        "section_staff_status_check": {
+          "name": "section_staff_status_check",
+          "value": "\"section_staff_assignments\".\"status\" IN ('active', 'ended')"
+        },
+        "section_staff_period_check": {
+          "name": "section_staff_period_check",
+          "value": "\"section_staff_assignments\".\"valid_until\" IS NULL OR \"section_staff_assignments\".\"valid_until\" > \"section_staff_assignments\".\"valid_from\""
+        },
+        "section_staff_end_evidence_check": {
+          "name": "section_staff_end_evidence_check",
+          "value": "\"section_staff_assignments\".\"status\" <> 'ended' OR (\"section_staff_assignments\".\"valid_until\" IS NOT NULL AND \"section_staff_assignments\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"section_staff_assignments\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "section_staff_version_positive": {
+          "name": "section_staff_version_positive",
+          "value": "\"section_staff_assignments\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_term_id": {
+          "name": "academic_term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learner_level_id": {
+          "name": "learner_level_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "legacy_class_id": {
+          "name": "legacy_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_by_account_id": {
+          "name": "activated_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sections_tenant_school_year_status_idx": {
+          "name": "sections_tenant_school_year_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sections_tenant_id_tenants_id_fk": {
+          "name": "sections_tenant_id_tenants_id_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_created_by_account_id_accounts_id_fk": {
+          "name": "sections_created_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["created_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_activated_by_account_id_accounts_id_fk": {
+          "name": "sections_activated_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["activated_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_closed_by_account_id_accounts_id_fk": {
+          "name": "sections_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["closed_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_tenant_school_fk": {
+          "name": "sections_tenant_school_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_tenant_school_year_fk": {
+          "name": "sections_tenant_school_year_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "tableTo": "academic_years",
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_tenant_school_term_fk": {
+          "name": "sections_tenant_school_term_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["tenant_id", "school_id", "academic_term_id"],
+          "tableTo": "academic_terms",
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_tenant_school_level_fk": {
+          "name": "sections_tenant_school_level_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["tenant_id", "school_id", "learner_level_id"],
+          "tableTo": "learner_levels",
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_tenant_school_course_fk": {
+          "name": "sections_tenant_school_course_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["tenant_id", "school_id", "course_id"],
+          "tableTo": "courses",
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "sections_tenant_legacy_class_fk": {
+          "name": "sections_tenant_legacy_class_fk",
+          "tableFrom": "sections",
+          "columnsFrom": ["tenant_id", "legacy_class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sections_tenant_id_id_unique": {
+          "name": "sections_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "sections_tenant_school_id_id_unique": {
+          "name": "sections_tenant_school_id_id_unique",
+          "columns": ["tenant_id", "school_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "sections_year_code_unique": {
+          "name": "sections_year_code_unique",
+          "columns": ["tenant_id", "academic_year_id", "code"],
+          "nullsNotDistinct": false
+        },
+        "sections_legacy_class_unique": {
+          "name": "sections_legacy_class_unique",
+          "columns": ["tenant_id", "legacy_class_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "sections_runtime_select": {
+          "name": "sections_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.sections.read', 'tenant.sections.manage')\n  AND public.openschool_section_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\", \"sections\".\"id\")\n"
+        },
+        "sections_runtime_write_deny": {
+          "name": "sections_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "sections_manager_all": {
+          "name": "sections_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "sections_code_check": {
+          "name": "sections_code_check",
+          "value": "char_length(btrim(\"sections\".\"code\")) BETWEEN 1 AND 64 AND \"sections\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "sections_name_check": {
+          "name": "sections_name_check",
+          "value": "char_length(btrim(\"sections\".\"name\")) BETWEEN 1 AND 160"
+        },
+        "sections_type_check": {
+          "name": "sections_type_check",
+          "value": "\"sections\".\"section_type\" IN ('homeroom', 'course')"
+        },
+        "sections_course_requirement_check": {
+          "name": "sections_course_requirement_check",
+          "value": "\"sections\".\"section_type\" <> 'course' OR \"sections\".\"course_id\" IS NOT NULL"
+        },
+        "sections_dates_check": {
+          "name": "sections_dates_check",
+          "value": "\"sections\".\"end_date\" >= \"sections\".\"start_date\""
+        },
+        "sections_status_check": {
+          "name": "sections_status_check",
+          "value": "\"sections\".\"status\" IN ('draft', 'active', 'closed')"
+        },
+        "sections_capacity_check": {
+          "name": "sections_capacity_check",
+          "value": "\"sections\".\"capacity\" IS NULL OR \"sections\".\"capacity\" > 0"
+        },
+        "sections_version_positive": {
+          "name": "sections_version_positive",
+          "value": "\"sections\".\"version\" > 0"
+        },
+        "sections_source_check": {
+          "name": "sections_source_check",
+          "value": "\"sections\".\"source\" IN ('native', 'legacy_backfill') AND (\"sections\".\"source\" <> 'legacy_backfill' OR \"sections\".\"legacy_class_id\" IS NOT NULL)"
+        },
+        "sections_creation_reason_check": {
+          "name": "sections_creation_reason_check",
+          "value": "char_length(btrim(\"sections\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "sections_activation_evidence_check": {
+          "name": "sections_activation_evidence_check",
+          "value": "\"sections\".\"status\" = 'draft' OR (\"sections\".\"activated_at\" IS NOT NULL AND \"sections\".\"activated_by_account_id\" IS NOT NULL)"
+        },
+        "sections_closure_evidence_check": {
+          "name": "sections_closure_evidence_check",
+          "value": "\"sections\".\"status\" <> 'closed' OR (\"sections\".\"closed_at\" IS NOT NULL AND \"sections\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"sections\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_duplicate_case_events": {
+      "name": "person_duplicate_case_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signals": {
+          "name": "signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_hash": {
+          "name": "evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_duplicate_case_events_history_idx": {
+          "name": "person_duplicate_case_events_history_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_duplicate_case_events_tenant_id_tenants_id_fk": {
+          "name": "person_duplicate_case_events_tenant_id_tenants_id_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_duplicate_case_events_actor_account_id_accounts_id_fk": {
+          "name": "person_duplicate_case_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "columnsFrom": ["actor_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_duplicate_case_events_tenant_case_fk": {
+          "name": "person_duplicate_case_events_tenant_case_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "columnsFrom": ["tenant_id", "case_id"],
+          "tableTo": "person_duplicate_cases",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_duplicate_case_events_tenant_school_fk": {
+          "name": "person_duplicate_case_events_tenant_school_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_duplicate_case_events_tenant_id_id_unique": {
+          "name": "person_duplicate_case_events_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "person_duplicate_case_events_case_version_unique": {
+          "name": "person_duplicate_case_events_case_version_unique",
+          "columns": ["tenant_id", "case_id", "version"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "person_duplicate_case_events_runtime_select": {
+          "name": "person_duplicate_case_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_duplicates.read',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        },
+        "person_duplicate_case_events_runtime_write_deny": {
+          "name": "person_duplicate_case_events_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_duplicate_case_events_manager_select": {
+          "name": "person_duplicate_case_events_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_duplicate_review_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        },
+        "person_duplicate_case_events_manager_insert": {
+          "name": "person_duplicate_case_events_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_duplicate_review_manager"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_duplicate_case_events_version_check": {
+          "name": "person_duplicate_case_events_version_check",
+          "value": "\"person_duplicate_case_events\".\"version\" > 0"
+        },
+        "person_duplicate_case_events_type_check": {
+          "name": "person_duplicate_case_events_type_check",
+          "value": "\"person_duplicate_case_events\".\"event_type\" IN ('candidate_detected', 'evidence_refreshed', 'evidence_no_longer_matches', 'marked_distinct', 'merge_approval_requested')"
+        },
+        "person_duplicate_case_events_score_check": {
+          "name": "person_duplicate_case_events_score_check",
+          "value": "\"person_duplicate_case_events\".\"score\" BETWEEN 0 AND 100"
+        },
+        "person_duplicate_case_events_signals_check": {
+          "name": "person_duplicate_case_events_signals_check",
+          "value": "jsonb_typeof(\"person_duplicate_case_events\".\"signals\") = 'array' AND jsonb_array_length(\"person_duplicate_case_events\".\"signals\") <= 4"
+        },
+        "person_duplicate_case_events_hash_check": {
+          "name": "person_duplicate_case_events_hash_check",
+          "value": "\"person_duplicate_case_events\".\"evidence_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_duplicate_case_events_reason_check": {
+          "name": "person_duplicate_case_events_reason_check",
+          "value": "char_length(btrim(\"person_duplicate_case_events\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_duplicate_cases": {
+      "name": "person_duplicate_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_person_id": {
+          "name": "first_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_person_id": {
+          "name": "second_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_score": {
+          "name": "current_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_signals": {
+          "name": "current_signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_evidence_hash": {
+          "name": "current_evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_duplicate_cases_queue_idx": {
+          "name": "person_duplicate_cases_queue_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "person_duplicate_cases_first_person_idx": {
+          "name": "person_duplicate_cases_first_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "person_duplicate_cases_second_person_idx": {
+          "name": "person_duplicate_cases_second_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "second_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_duplicate_cases_tenant_id_tenants_id_fk": {
+          "name": "person_duplicate_cases_tenant_id_tenants_id_fk",
+          "tableFrom": "person_duplicate_cases",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_duplicate_cases_created_by_account_id_accounts_id_fk": {
+          "name": "person_duplicate_cases_created_by_account_id_accounts_id_fk",
+          "tableFrom": "person_duplicate_cases",
+          "columnsFrom": ["created_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_duplicate_cases_tenant_school_fk": {
+          "name": "person_duplicate_cases_tenant_school_fk",
+          "tableFrom": "person_duplicate_cases",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_duplicate_cases_tenant_first_person_fk": {
+          "name": "person_duplicate_cases_tenant_first_person_fk",
+          "tableFrom": "person_duplicate_cases",
+          "columnsFrom": ["tenant_id", "first_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_duplicate_cases_tenant_second_person_fk": {
+          "name": "person_duplicate_cases_tenant_second_person_fk",
+          "tableFrom": "person_duplicate_cases",
+          "columnsFrom": ["tenant_id", "second_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_duplicate_cases_tenant_id_id_unique": {
+          "name": "person_duplicate_cases_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "person_duplicate_cases_school_pair_unique": {
+          "name": "person_duplicate_cases_school_pair_unique",
+          "columns": ["tenant_id", "review_school_id", "first_person_id", "second_person_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "person_duplicate_cases_runtime_select": {
+          "name": "person_duplicate_cases_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_duplicates.read',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n"
+        },
+        "person_duplicate_cases_runtime_write_deny": {
+          "name": "person_duplicate_cases_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_duplicate_cases_manager_all": {
+          "name": "person_duplicate_cases_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_duplicate_review_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_duplicate_cases_pair_order_check": {
+          "name": "person_duplicate_cases_pair_order_check",
+          "value": "\"person_duplicate_cases\".\"first_person_id\"::text < \"person_duplicate_cases\".\"second_person_id\"::text"
+        },
+        "person_duplicate_cases_status_check": {
+          "name": "person_duplicate_cases_status_check",
+          "value": "\"person_duplicate_cases\".\"status\" IN ('open', 'distinct', 'merge_approval_requested', 'superseded')"
+        },
+        "person_duplicate_cases_version_check": {
+          "name": "person_duplicate_cases_version_check",
+          "value": "\"person_duplicate_cases\".\"current_version\" > 0"
+        },
+        "person_duplicate_cases_score_check": {
+          "name": "person_duplicate_cases_score_check",
+          "value": "\"person_duplicate_cases\".\"current_score\" BETWEEN 0 AND 100"
+        },
+        "person_duplicate_cases_signals_check": {
+          "name": "person_duplicate_cases_signals_check",
+          "value": "jsonb_typeof(\"person_duplicate_cases\".\"current_signals\") = 'array' AND jsonb_array_length(\"person_duplicate_cases\".\"current_signals\") <= 4"
+        },
+        "person_duplicate_cases_hash_check": {
+          "name": "person_duplicate_cases_hash_check",
+          "value": "\"person_duplicate_cases\".\"current_evidence_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_aliases": {
+      "name": "person_merge_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_by_account_id": {
+          "name": "reversed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_aliases_target_idx": {
+          "name": "person_merge_aliases_target_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_merge_aliases_tenant_id_tenants_id_fk": {
+          "name": "person_merge_aliases_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_aliases",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_aliases_reversed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_aliases_reversed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_aliases",
+          "columnsFrom": ["reversed_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_aliases_tenant_operation_fk": {
+          "name": "person_merge_aliases_tenant_operation_fk",
+          "tableFrom": "person_merge_aliases",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "tableTo": "person_merge_operations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_aliases_tenant_school_fk": {
+          "name": "person_merge_aliases_tenant_school_fk",
+          "tableFrom": "person_merge_aliases",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_aliases_tenant_source_fk": {
+          "name": "person_merge_aliases_tenant_source_fk",
+          "tableFrom": "person_merge_aliases",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_aliases_tenant_target_fk": {
+          "name": "person_merge_aliases_tenant_target_fk",
+          "tableFrom": "person_merge_aliases",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_aliases_tenant_id_id_unique": {
+          "name": "person_merge_aliases_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "person_merge_aliases_tenant_source_unique": {
+          "name": "person_merge_aliases_tenant_source_unique",
+          "columns": ["tenant_id", "source_person_id"],
+          "nullsNotDistinct": false
+        },
+        "person_merge_aliases_tenant_operation_unique": {
+          "name": "person_merge_aliases_tenant_operation_unique",
+          "columns": ["tenant_id", "operation_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "person_merge_aliases_runtime_select": {
+          "name": "person_merge_aliases_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n"
+        },
+        "person_merge_aliases_runtime_write_deny": {
+          "name": "person_merge_aliases_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_aliases_manager_all": {
+          "name": "person_merge_aliases_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_aliases_people_check": {
+          "name": "person_merge_aliases_people_check",
+          "value": "\"person_merge_aliases\".\"source_person_id\" <> \"person_merge_aliases\".\"target_person_id\""
+        },
+        "person_merge_aliases_status_check": {
+          "name": "person_merge_aliases_status_check",
+          "value": "\"person_merge_aliases\".\"status\" IN ('active', 'reversed')"
+        },
+        "person_merge_aliases_version_check": {
+          "name": "person_merge_aliases_version_check",
+          "value": "\"person_merge_aliases\".\"version\" > 0"
+        },
+        "person_merge_aliases_reversal_check": {
+          "name": "person_merge_aliases_reversal_check",
+          "value": "\"person_merge_aliases\".\"status\" <> 'reversed'\n        OR (\"person_merge_aliases\".\"reversed_at\" IS NOT NULL AND \"person_merge_aliases\".\"reversed_by_account_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_events": {
+      "name": "person_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_status": {
+          "name": "operation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_digest": {
+          "name": "preview_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_events_operation_idx": {
+          "name": "person_merge_events_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_merge_events_tenant_id_tenants_id_fk": {
+          "name": "person_merge_events_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_events",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_events_actor_account_id_accounts_id_fk": {
+          "name": "person_merge_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_events",
+          "columnsFrom": ["actor_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_events_tenant_operation_fk": {
+          "name": "person_merge_events_tenant_operation_fk",
+          "tableFrom": "person_merge_events",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "tableTo": "person_merge_operations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_events_tenant_school_fk": {
+          "name": "person_merge_events_tenant_school_fk",
+          "tableFrom": "person_merge_events",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_events_tenant_id_id_unique": {
+          "name": "person_merge_events_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "person_merge_events_operation_version_unique": {
+          "name": "person_merge_events_operation_version_unique",
+          "columns": ["tenant_id", "operation_id", "version"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "person_merge_events_runtime_select": {
+          "name": "person_merge_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n"
+        },
+        "person_merge_events_runtime_write_deny": {
+          "name": "person_merge_events_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_events_manager_all": {
+          "name": "person_merge_events_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_events_version_check": {
+          "name": "person_merge_events_version_check",
+          "value": "\"person_merge_events\".\"version\" > 0"
+        },
+        "person_merge_events_type_check": {
+          "name": "person_merge_events_type_check",
+          "value": "\"person_merge_events\".\"event_type\" IN ('preview_created', 'approval_granted', 'executed', 'reversal_requested', 'reversed', 'manual_recovery_required')"
+        },
+        "person_merge_events_status_check": {
+          "name": "person_merge_events_status_check",
+          "value": "\"person_merge_events\".\"operation_status\" IN ('blocked', 'pending_approval', 'approved', 'executed', 'reversed', 'manual_recovery')"
+        },
+        "person_merge_events_hash_check": {
+          "name": "person_merge_events_hash_check",
+          "value": "\"person_merge_events\".\"preview_digest\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_merge_events_reason_check": {
+          "name": "person_merge_events_reason_check",
+          "value": "char_length(btrim(\"person_merge_events\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_moves": {
+      "name": "person_merge_moves",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_name": {
+          "name": "relation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_key": {
+          "name": "source_record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_record_key": {
+          "name": "replacement_record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_fingerprint": {
+          "name": "before_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after_fingerprint": {
+          "name": "after_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_moves_operation_idx": {
+          "name": "person_merge_moves_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_merge_moves_tenant_id_tenants_id_fk": {
+          "name": "person_merge_moves_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_moves",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_moves_tenant_operation_fk": {
+          "name": "person_merge_moves_tenant_operation_fk",
+          "tableFrom": "person_merge_moves",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "tableTo": "person_merge_operations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_moves_tenant_school_fk": {
+          "name": "person_merge_moves_tenant_school_fk",
+          "tableFrom": "person_merge_moves",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_moves_tenant_id_id_unique": {
+          "name": "person_merge_moves_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "person_merge_moves_operation_sequence_unique": {
+          "name": "person_merge_moves_operation_sequence_unique",
+          "columns": ["tenant_id", "operation_id", "sequence"],
+          "nullsNotDistinct": false
+        },
+        "person_merge_moves_operation_record_unique": {
+          "name": "person_merge_moves_operation_record_unique",
+          "columns": ["tenant_id", "operation_id", "relation_name", "source_record_key"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "person_merge_moves_runtime_select": {
+          "name": "person_merge_moves_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n"
+        },
+        "person_merge_moves_runtime_write_deny": {
+          "name": "person_merge_moves_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_moves_manager_all": {
+          "name": "person_merge_moves_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_moves_sequence_check": {
+          "name": "person_merge_moves_sequence_check",
+          "value": "\"person_merge_moves\".\"sequence\" > 0"
+        },
+        "person_merge_moves_action_check": {
+          "name": "person_merge_moves_action_check",
+          "value": "\"person_merge_moves\".\"action\" IN ('repoint', 'end_and_recreate', 'preserve_history', 'invalidate', 'archive_source')"
+        },
+        "person_merge_moves_text_check": {
+          "name": "person_merge_moves_text_check",
+          "value": "char_length(\"person_merge_moves\".\"relation_name\") BETWEEN 3 AND 128\n        AND char_length(\"person_merge_moves\".\"source_record_key\") BETWEEN 1 AND 512\n        AND (\"person_merge_moves\".\"replacement_record_key\" IS NULL\n          OR char_length(\"person_merge_moves\".\"replacement_record_key\") BETWEEN 1 AND 512)"
+        },
+        "person_merge_moves_hash_check": {
+          "name": "person_merge_moves_hash_check",
+          "value": "\"person_merge_moves\".\"before_fingerprint\" ~ '^[0-9a-f]{64}$'\n        AND \"person_merge_moves\".\"after_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_operations": {
+      "name": "person_merge_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_case_id": {
+          "name": "duplicate_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_case_version": {
+          "name": "duplicate_case_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_evidence_hash": {
+          "name": "duplicate_evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plan_version": {
+          "name": "plan_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "preview_digest": {
+          "name": "preview_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_digest": {
+          "name": "execution_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_count": {
+          "name": "dependency_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "invalidation_count": {
+          "name": "invalidation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "initiated_by_account_id": {
+          "name": "initiated_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiation_reason": {
+          "name": "initiation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by_account_id": {
+          "name": "approved_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_reason": {
+          "name": "approval_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_by_account_id": {
+          "name": "executed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_by_account_id": {
+          "name": "reversed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_operations_active_source_unique": {
+          "name": "person_merge_operations_active_source_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"person_merge_operations\".\"status\" IN ('pending_approval', 'approved', 'executed')",
+          "concurrently": false
+        },
+        "person_merge_operations_school_status_idx": {
+          "name": "person_merge_operations_school_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "person_merge_operations_case_idx": {
+          "name": "person_merge_operations_case_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "duplicate_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_merge_operations_tenant_id_tenants_id_fk": {
+          "name": "person_merge_operations_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_operations_initiated_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_initiated_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["initiated_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_operations_approved_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_approved_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["approved_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_operations_executed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_executed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["executed_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_operations_reversed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_reversed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["reversed_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_operations_tenant_school_fk": {
+          "name": "person_merge_operations_tenant_school_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_operations_tenant_case_fk": {
+          "name": "person_merge_operations_tenant_case_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "duplicate_case_id"],
+          "tableTo": "person_duplicate_cases",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_operations_tenant_source_fk": {
+          "name": "person_merge_operations_tenant_source_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_operations_tenant_target_fk": {
+          "name": "person_merge_operations_tenant_target_fk",
+          "tableFrom": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_operations_tenant_id_id_unique": {
+          "name": "person_merge_operations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "person_merge_operations_runtime_select": {
+          "name": "person_merge_operations_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n"
+        },
+        "person_merge_operations_runtime_write_deny": {
+          "name": "person_merge_operations_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_operations_manager_all": {
+          "name": "person_merge_operations_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_operations_status_check": {
+          "name": "person_merge_operations_status_check",
+          "value": "\"person_merge_operations\".\"status\" IN ('blocked', 'pending_approval', 'approved', 'executed', 'reversed', 'manual_recovery')"
+        },
+        "person_merge_operations_people_check": {
+          "name": "person_merge_operations_people_check",
+          "value": "\"person_merge_operations\".\"source_person_id\" <> \"person_merge_operations\".\"target_person_id\""
+        },
+        "person_merge_operations_version_check": {
+          "name": "person_merge_operations_version_check",
+          "value": "\"person_merge_operations\".\"current_version\" > 0 AND \"person_merge_operations\".\"plan_version\" > 0"
+        },
+        "person_merge_operations_hash_check": {
+          "name": "person_merge_operations_hash_check",
+          "value": "\"person_merge_operations\".\"duplicate_evidence_hash\" ~ '^[0-9a-f]{64}$'\n        AND \"person_merge_operations\".\"preview_digest\" ~ '^[0-9a-f]{64}$'\n        AND (\"person_merge_operations\".\"execution_digest\" IS NULL OR \"person_merge_operations\".\"execution_digest\" ~ '^[0-9a-f]{64}$')"
+        },
+        "person_merge_operations_count_check": {
+          "name": "person_merge_operations_count_check",
+          "value": "\"person_merge_operations\".\"dependency_count\" >= 0 AND \"person_merge_operations\".\"conflict_count\" >= 0\n        AND \"person_merge_operations\".\"conflict_count\" <= \"person_merge_operations\".\"dependency_count\"\n        AND \"person_merge_operations\".\"invalidation_count\" >= 0"
+        },
+        "person_merge_operations_reason_check": {
+          "name": "person_merge_operations_reason_check",
+          "value": "char_length(btrim(\"person_merge_operations\".\"initiation_reason\")) BETWEEN 3 AND 512\n        AND (\"person_merge_operations\".\"approval_reason\" IS NULL OR char_length(btrim(\"person_merge_operations\".\"approval_reason\")) BETWEEN 3 AND 512)"
+        },
+        "person_merge_operations_approval_check": {
+          "name": "person_merge_operations_approval_check",
+          "value": "(\"person_merge_operations\".\"status\" NOT IN ('approved', 'executed', 'reversed', 'manual_recovery'))\n        OR (\"person_merge_operations\".\"approved_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"approval_reason\" IS NOT NULL\n          AND \"person_merge_operations\".\"approved_at\" IS NOT NULL AND \"person_merge_operations\".\"approved_by_account_id\" <> \"person_merge_operations\".\"initiated_by_account_id\")"
+        },
+        "person_merge_operations_execution_check": {
+          "name": "person_merge_operations_execution_check",
+          "value": "\"person_merge_operations\".\"status\" NOT IN ('executed', 'reversed', 'manual_recovery')\n        OR (\"person_merge_operations\".\"executed_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"executed_at\" IS NOT NULL\n          AND \"person_merge_operations\".\"execution_digest\" IS NOT NULL)"
+        },
+        "person_merge_operations_reversal_check": {
+          "name": "person_merge_operations_reversal_check",
+          "value": "\"person_merge_operations\".\"status\" <> 'reversed'\n        OR (\"person_merge_operations\".\"reversed_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"reversed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_preview_items": {
+      "name": "person_merge_preview_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_name": {
+          "name": "relation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflict_code": {
+          "name": "conflict_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_fingerprint": {
+          "name": "row_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_preview_items_operation_idx": {
+          "name": "person_merge_preview_items_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_merge_preview_items_tenant_id_tenants_id_fk": {
+          "name": "person_merge_preview_items_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_preview_items",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_preview_items_tenant_operation_fk": {
+          "name": "person_merge_preview_items_tenant_operation_fk",
+          "tableFrom": "person_merge_preview_items",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "tableTo": "person_merge_operations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "person_merge_preview_items_tenant_school_fk": {
+          "name": "person_merge_preview_items_tenant_school_fk",
+          "tableFrom": "person_merge_preview_items",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_preview_items_tenant_id_id_unique": {
+          "name": "person_merge_preview_items_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "person_merge_preview_items_operation_record_unique": {
+          "name": "person_merge_preview_items_operation_record_unique",
+          "columns": ["tenant_id", "operation_id", "relation_name", "record_key", "direction"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "person_merge_preview_items_runtime_select": {
+          "name": "person_merge_preview_items_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n"
+        },
+        "person_merge_preview_items_runtime_write_deny": {
+          "name": "person_merge_preview_items_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_preview_items_manager_all": {
+          "name": "person_merge_preview_items_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_preview_items_category_check": {
+          "name": "person_merge_preview_items_category_check",
+          "value": "\"person_merge_preview_items\".\"category\" IN ('account_link', 'profile', 'affiliation', 'relationship', 'household_membership', 'school_enrollment', 'section_staff', 'section_roster', 'invitation', 'authorization_history', 'academic_history', 'duplicate_case', 'audit_history', 'compatibility_evidence')"
+        },
+        "person_merge_preview_items_direction_check": {
+          "name": "person_merge_preview_items_direction_check",
+          "value": "\"person_merge_preview_items\".\"direction\" IN ('source', 'subject', 'related', 'actor', 'none')"
+        },
+        "person_merge_preview_items_disposition_check": {
+          "name": "person_merge_preview_items_disposition_check",
+          "value": "\"person_merge_preview_items\".\"disposition\" IN ('move', 'end_and_recreate', 'preserve_history', 'block')"
+        },
+        "person_merge_preview_items_text_check": {
+          "name": "person_merge_preview_items_text_check",
+          "value": "char_length(\"person_merge_preview_items\".\"relation_name\") BETWEEN 3 AND 128\n        AND char_length(\"person_merge_preview_items\".\"record_key\") BETWEEN 1 AND 512\n        AND (\"person_merge_preview_items\".\"conflict_code\" IS NULL OR \"person_merge_preview_items\".\"conflict_code\" ~ '^[A-Z][A-Z0-9_]{2,127}$')"
+        },
+        "person_merge_preview_items_hash_check": {
+          "name": "person_merge_preview_items_hash_check",
+          "value": "\"person_merge_preview_items\".\"row_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_merge_preview_items_conflict_check": {
+          "name": "person_merge_preview_items_conflict_check",
+          "value": "(\"person_merge_preview_items\".\"disposition\" = 'block') = (\"person_merge_preview_items\".\"conflict_code\" IS NOT NULL)"
+        },
+        "person_merge_preview_items_metadata_check": {
+          "name": "person_merge_preview_items_metadata_check",
+          "value": "jsonb_typeof(\"person_merge_preview_items\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.household_addresses": {
+      "name": "household_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_key": {
+          "name": "address_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "address_type": {
+          "name": "address_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line1": {
+          "name": "line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line2": {
+          "name": "line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administrative_area": {
+          "name": "administrative_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_address": {
+          "name": "normalized_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_addresses_household_effective_idx": {
+          "name": "household_addresses_household_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "household_addresses_issued_by_account_id_accounts_id_fk": {
+          "name": "household_addresses_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "household_addresses",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "household_addresses_ended_by_account_id_accounts_id_fk": {
+          "name": "household_addresses_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "household_addresses",
+          "columnsFrom": ["ended_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "household_addresses_tenant_household_fk": {
+          "name": "household_addresses_tenant_household_fk",
+          "tableFrom": "household_addresses",
+          "columnsFrom": ["tenant_id", "household_id"],
+          "tableTo": "households",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_addresses_tenant_id_id_unique": {
+          "name": "household_addresses_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "household_addresses_tenant_key_version_unique": {
+          "name": "household_addresses_tenant_key_version_unique",
+          "columns": ["tenant_id", "address_key", "version"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "household_addresses_runtime_select": {
+          "name": "household_addresses_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.households.read', 'tenant.households.manage')\n  AND public.openschool_household_read_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_runtime_insert_deny": {
+          "name": "household_addresses_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "household_addresses_runtime_update_deny": {
+          "name": "household_addresses_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "household_addresses_runtime_delete_deny": {
+          "name": "household_addresses_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "household_addresses_manager_select": {
+          "name": "household_addresses_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_insert": {
+          "name": "household_addresses_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_update": {
+          "name": "household_addresses_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_delete_deny": {
+          "name": "household_addresses_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "household_addresses_type_check": {
+          "name": "household_addresses_type_check",
+          "value": "\"household_addresses\".\"address_type\" IN ('residential', 'mailing', 'temporary', 'other')"
+        },
+        "household_addresses_country_code_check": {
+          "name": "household_addresses_country_code_check",
+          "value": "\"household_addresses\".\"country_code\" ~ '^[A-Z]{2}$'"
+        },
+        "household_addresses_required_text_check": {
+          "name": "household_addresses_required_text_check",
+          "value": "char_length(btrim(\"household_addresses\".\"line1\")) BETWEEN 1 AND 200 AND char_length(btrim(\"household_addresses\".\"locality\")) BETWEEN 1 AND 120 AND char_length(btrim(\"household_addresses\".\"normalized_address\")) BETWEEN 3 AND 600"
+        },
+        "household_addresses_valid_period_check": {
+          "name": "household_addresses_valid_period_check",
+          "value": "\"household_addresses\".\"valid_until\" IS NULL OR \"household_addresses\".\"valid_until\" > \"household_addresses\".\"valid_from\""
+        },
+        "household_addresses_end_evidence_check": {
+          "name": "household_addresses_end_evidence_check",
+          "value": "\"household_addresses\".\"status\" <> 'ended' OR (\"household_addresses\".\"valid_until\" IS NOT NULL AND \"household_addresses\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"household_addresses\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "household_addresses_version_positive": {
+          "name": "household_addresses_version_positive",
+          "value": "\"household_addresses\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.household_memberships": {
+      "name": "household_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "membership_kind": {
+          "name": "membership_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary_residence": {
+          "name": "is_primary_residence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary_mailing": {
+          "name": "is_primary_mailing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_memberships_household_effective_idx": {
+          "name": "household_memberships_household_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "household_memberships_person_effective_idx": {
+          "name": "household_memberships_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "household_memberships_issued_by_account_id_accounts_id_fk": {
+          "name": "household_memberships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "household_memberships",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "household_memberships_ended_by_account_id_accounts_id_fk": {
+          "name": "household_memberships_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "household_memberships",
+          "columnsFrom": ["ended_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "household_memberships_tenant_household_fk": {
+          "name": "household_memberships_tenant_household_fk",
+          "tableFrom": "household_memberships",
+          "columnsFrom": ["tenant_id", "household_id"],
+          "tableTo": "households",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "household_memberships_tenant_person_fk": {
+          "name": "household_memberships_tenant_person_fk",
+          "tableFrom": "household_memberships",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_memberships_tenant_id_id_unique": {
+          "name": "household_memberships_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "household_memberships_tenant_key_version_unique": {
+          "name": "household_memberships_tenant_key_version_unique",
+          "columns": ["tenant_id", "membership_key", "version"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "household_memberships_runtime_select": {
+          "name": "household_memberships_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.households.read', 'tenant.households.manage')\n        AND public.openschool_household_member_read_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"household_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_runtime_insert_deny": {
+          "name": "household_memberships_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "household_memberships_runtime_update_deny": {
+          "name": "household_memberships_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "household_memberships_runtime_delete_deny": {
+          "name": "household_memberships_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "household_memberships_manager_select": {
+          "name": "household_memberships_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n        \n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_memberships\".\"tenant_id\", \"household_memberships\".\"household_id\")\n\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_insert": {
+          "name": "household_memberships_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_update": {
+          "name": "household_memberships_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_delete_deny": {
+          "name": "household_memberships_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "household_memberships_kind_check": {
+          "name": "household_memberships_kind_check",
+          "value": "\"household_memberships\".\"membership_kind\" IN ('resident', 'associated')"
+        },
+        "household_memberships_primary_requires_resident": {
+          "name": "household_memberships_primary_requires_resident",
+          "value": "(NOT \"household_memberships\".\"is_primary_residence\" AND NOT \"household_memberships\".\"is_primary_mailing\") OR \"household_memberships\".\"membership_kind\" = 'resident'"
+        },
+        "household_memberships_valid_period_check": {
+          "name": "household_memberships_valid_period_check",
+          "value": "\"household_memberships\".\"valid_until\" IS NULL OR \"household_memberships\".\"valid_until\" > \"household_memberships\".\"valid_from\""
+        },
+        "household_memberships_end_evidence_check": {
+          "name": "household_memberships_end_evidence_check",
+          "value": "\"household_memberships\".\"status\" <> 'ended' OR (\"household_memberships\".\"valid_until\" IS NOT NULL AND \"household_memberships\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"household_memberships\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "household_memberships_version_positive": {
+          "name": "household_memberships_version_positive",
+          "value": "\"household_memberships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.households": {
+      "name": "households",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_display_name": {
+          "name": "normalized_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "households_tenant_status_name_idx": {
+          "name": "households_tenant_status_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "households_tenant_id_tenants_id_fk": {
+          "name": "households_tenant_id_tenants_id_fk",
+          "tableFrom": "households",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "households_created_by_account_id_accounts_id_fk": {
+          "name": "households_created_by_account_id_accounts_id_fk",
+          "tableFrom": "households",
+          "columnsFrom": ["created_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "households_closed_by_account_id_accounts_id_fk": {
+          "name": "households_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "households",
+          "columnsFrom": ["closed_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "households_tenant_id_id_unique": {
+          "name": "households_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "households_runtime_select": {
+          "name": "households_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.households.read', 'tenant.households.manage')\n  AND public.openschool_household_read_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_runtime_insert_deny": {
+          "name": "households_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "households_runtime_update_deny": {
+          "name": "households_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "households_runtime_delete_deny": {
+          "name": "households_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "households_manager_select": {
+          "name": "households_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_manager_insert": {
+          "name": "households_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n      "
+        },
+        "households_manager_update": {
+          "name": "households_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_manager_delete_deny": {
+          "name": "households_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "households_name_check": {
+          "name": "households_name_check",
+          "value": "char_length(btrim(\"households\".\"display_name\")) BETWEEN 1 AND 160 AND char_length(btrim(\"households\".\"normalized_display_name\")) BETWEEN 1 AND 160"
+        },
+        "households_status_check": {
+          "name": "households_status_check",
+          "value": "\"households\".\"status\" IN ('active', 'closed')"
+        },
+        "households_version_positive": {
+          "name": "households_version_positive",
+          "value": "\"households\".\"version\" > 0"
+        },
+        "households_creation_reason_check": {
+          "name": "households_creation_reason_check",
+          "value": "char_length(btrim(\"households\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "households_closure_evidence_check": {
+          "name": "households_closure_evidence_check",
+          "value": "\"households\".\"status\" <> 'closed' OR (\"households\".\"closed_at\" IS NOT NULL AND \"households\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"households\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_student_tenant_parent_idx": {
+          "name": "parent_student_tenant_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["parent_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "parent_student_tenant_student_fk": {
+          "name": "parent_student_tenant_student_fk",
+          "tableFrom": "parent_student",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "tableTo": "students",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_student_tenant_id_id_unique": {
+          "name": "parent_student_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teachers_on_class_tenant_user_idx": {
+          "name": "teachers_on_class_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "teachers_on_class_tenant_class_fk": {
+          "name": "teachers_on_class_tenant_class_fk",
+          "tableFrom": "teachers_on_class",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teachers_on_class_tenant_id_id_unique": {
+          "name": "teachers_on_class_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_org_tenant_user_idx": {
+          "name": "users_on_org_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "users_on_org_tenant_organization_fk": {
+          "name": "users_on_org_tenant_organization_fk",
+          "tableFrom": "users_on_org",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "tableTo": "organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_org_tenant_id_id_unique": {
+          "name": "users_on_org_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_school_tenant_user_idx": {
+          "name": "users_on_school_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "users_on_school_tenant_school_fk": {
+          "name": "users_on_school_tenant_school_fk",
+          "tableFrom": "users_on_school",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_school_tenant_id_id_unique": {
+          "name": "users_on_school_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "enrollments_tenant_student_idx": {
+          "name": "enrollments_tenant_student_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "enrollments_tenant_class_idx": {
+          "name": "enrollments_tenant_class_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "enrollments_tenant_student_fk": {
+          "name": "enrollments_tenant_student_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "tableTo": "students",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "enrollments_tenant_class_fk": {
+          "name": "enrollments_tenant_class_fk",
+          "tableFrom": "enrollments",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grades_tenant_enrollment_idx": {
+          "name": "grades_tenant_enrollment_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrollment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["graded_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "grades_tenant_enrollment_fk": {
+          "name": "grades_tenant_enrollment_fk",
+          "tableFrom": "grades",
+          "columnsFrom": ["tenant_id", "enrollment_id"],
+          "tableTo": "enrollments",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grades_tenant_id_id_unique": {
+          "name": "grades_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_archive_manifests": {
+      "name": "audit_archive_manifests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_class": {
+          "name": "retention_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_event_hash": {
+          "name": "first_event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_hash": {
+          "name": "last_event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_hash": {
+          "name": "root_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_manifest_hash": {
+          "name": "previous_manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_location_hash": {
+          "name": "archive_location_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "includes_legal_hold": {
+          "name": "includes_legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_archive_manifest_chain_idx": {
+          "name": "audit_archive_manifest_chain_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retention_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "audit_archive_manifests_tenant_id_tenants_id_fk": {
+          "name": "audit_archive_manifests_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_archive_manifests",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audit_archive_manifest_period_unique": {
+          "name": "audit_archive_manifest_period_unique",
+          "columns": ["tenant_id", "period_start", "retention_class"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "audit_archive_manifest_period_check": {
+          "name": "audit_archive_manifest_period_check",
+          "value": "\"audit_archive_manifests\".\"period_end\" > \"audit_archive_manifests\".\"period_start\""
+        },
+        "audit_archive_manifest_count_check": {
+          "name": "audit_archive_manifest_count_check",
+          "value": "\"audit_archive_manifests\".\"event_count\" >= 0"
+        },
+        "audit_archive_manifest_hashes_check": {
+          "name": "audit_archive_manifest_hashes_check",
+          "value": "\"audit_archive_manifests\".\"first_event_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"last_event_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"root_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"manifest_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"archive_location_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_version": {
+          "name": "event_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_person_id": {
+          "name": "actor_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "causation_id": {
+          "name": "causation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_operation_receipt_id": {
+          "name": "pre_operation_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_grant_id": {
+          "name": "support_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_classes": {
+          "name": "data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_class": {
+          "name": "retention_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'security'"
+        },
+        "legal_hold": {
+          "name": "legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_tenant_time_idx": {
+          "name": "audit_events_tenant_time_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "audit_events_tenant_target_idx": {
+          "name": "audit_events_tenant_target_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "audit_events_correlation_idx": {
+          "name": "audit_events_correlation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "audit_events_tenant_id_tenants_id_fk": {
+          "name": "audit_events_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_events",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "audit_events_actor_account_id_accounts_id_fk": {
+          "name": "audit_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "audit_events",
+          "columnsFrom": ["actor_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "audit_events_tenant_actor_person_fk": {
+          "name": "audit_events_tenant_actor_person_fk",
+          "tableFrom": "audit_events",
+          "columnsFrom": ["tenant_id", "actor_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "audit_events_tenant_organization_fk": {
+          "name": "audit_events_tenant_organization_fk",
+          "tableFrom": "audit_events",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "audit_events_tenant_school_fk": {
+          "name": "audit_events_tenant_school_fk",
+          "tableFrom": "audit_events",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audit_events_pk": {
+          "name": "audit_events_pk",
+          "columns": ["occurred_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "audit_events_runtime_select": {
+          "name": "audit_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.audit.read'\n        AND public.openschool_audit_scope_allows(\n          \"audit_events\".\"tenant_id\", \"audit_events\".\"education_organization_id\", \"audit_events\".\"school_id\"\n        )\n      "
+        },
+        "audit_events_runtime_insert": {
+          "name": "audit_events_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" IN ('account', 'support')\n        AND \"audit_events\".\"actor_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND \"audit_events\".\"actor_person_id\" IS NOT DISTINCT FROM nullif(current_setting('app.person_id', true), '')::uuid\n        AND \"audit_events\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_events\".\"education_organization_id\" IS NOT DISTINCT FROM nullif(current_setting('app.education_organization_id', true), '')::uuid\n        AND \"audit_events\".\"school_id\" IS NOT DISTINCT FROM nullif(current_setting('app.school_id', true), '')::uuid\n        AND (\n          (\"audit_events\".\"actor_type\" = 'account' AND \"audit_events\".\"source\" = 'web' AND \"audit_events\".\"support_grant_id\" IS NULL)\n          OR (\"audit_events\".\"actor_type\" = 'support' AND \"audit_events\".\"source\" = 'support' AND \"audit_events\".\"support_grant_id\" IS NOT NULL AND \"audit_events\".\"purpose\" IS NOT NULL)\n        )\n      "
+        },
+        "audit_events_invitation_denial_insert": {
+          "name": "audit_events_invitation_denial_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" = 'system'\n        AND \"audit_events\".\"actor_account_id\" IS NULL\n        AND \"audit_events\".\"actor_person_id\" IS NULL\n        AND \"audit_events\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_events\".\"education_organization_id\" IS NOT DISTINCT FROM nullif(current_setting('app.education_organization_id', true), '')::uuid\n        AND \"audit_events\".\"school_id\" IS NOT DISTINCT FROM nullif(current_setting('app.school_id', true), '')::uuid\n        AND \"audit_events\".\"event_type\" = 'account.invitation.accept'\n        AND \"audit_events\".\"outcome\" = 'denied'\n        AND \"audit_events\".\"capability\" = 'identity.invitation.accept'\n        AND \"audit_events\".\"policy_version\" = 'identity-invitation.v1'\n        AND \"audit_events\".\"policy_decision\" ->> 'effect' = 'deny'\n        AND \"audit_events\".\"policy_decision\" ->> 'reason' IN (\n          'INVITATION_UNAVAILABLE', 'INVITATION_IDENTITY_MISMATCH', 'INVITATION_ACCOUNT_CONFLICT'\n        )\n        AND \"audit_events\".\"target_type\" = 'account.invitation'\n        AND \"audit_events\".\"target_id\" IS NOT NULL\n        AND \"audit_events\".\"data_classes\" = '[\"credential\"]'::jsonb\n        AND \"audit_events\".\"purpose\" = 'account_onboarding'\n        AND \"audit_events\".\"source\" = 'web'\n        AND \"audit_events\".\"retention_class\" = 'security'\n      "
+        },
+        "audit_events_runtime_update_deny": {
+          "name": "audit_events_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_events_runtime_delete_deny": {
+          "name": "audit_events_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "audit_events_worker_select": {
+          "name": "audit_events_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_events_worker_insert": {
+          "name": "audit_events_worker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" = 'worker'\n        AND \"audit_events\".\"actor_account_id\" IS NULL\n        AND \"audit_events\".\"actor_person_id\" IS NULL\n        AND \"audit_events\".\"source\" = 'worker'\n      "
+        },
+        "audit_events_worker_update_deny": {
+          "name": "audit_events_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_events_worker_delete_deny": {
+          "name": "audit_events_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "audit_events_version_positive": {
+          "name": "audit_events_version_positive",
+          "value": "\"audit_events\".\"event_version\" > 0"
+        },
+        "audit_events_type_format": {
+          "name": "audit_events_type_format",
+          "value": "\"audit_events\".\"event_type\" ~ '^[a-z][a-z0-9_.]{2,127}$'"
+        },
+        "audit_events_reference_format": {
+          "name": "audit_events_reference_format",
+          "value": "\"audit_events\".\"target_type\" ~ '^[a-z][a-z0-9_.]{2,127}$' AND char_length(\"audit_events\".\"request_id\") BETWEEN 1 AND 512 AND char_length(\"audit_events\".\"correlation_id\") BETWEEN 1 AND 512 AND (\"audit_events\".\"target_id\" IS NULL OR char_length(\"audit_events\".\"target_id\") BETWEEN 1 AND 512) AND (\"audit_events\".\"purpose\" IS NULL OR \"audit_events\".\"purpose\" ~ '^[a-z][a-z0-9_.-]{2,63}$')"
+        },
+        "audit_events_outcome_check": {
+          "name": "audit_events_outcome_check",
+          "value": "\"audit_events\".\"outcome\" IN ('attempted', 'succeeded', 'denied', 'failed')"
+        },
+        "audit_events_actor_type_check": {
+          "name": "audit_events_actor_type_check",
+          "value": "\"audit_events\".\"actor_type\" IN ('account', 'worker', 'system', 'support', 'platform')"
+        },
+        "audit_events_source_check": {
+          "name": "audit_events_source_check",
+          "value": "\"audit_events\".\"source\" IN ('web', 'worker', 'migration', 'support', 'system', 'platform')"
+        },
+        "audit_events_retention_check": {
+          "name": "audit_events_retention_check",
+          "value": "\"audit_events\".\"retention_class\" IN ('operational', 'security', 'financial', 'safeguarding', 'legal_hold')"
+        },
+        "audit_events_data_classes_check": {
+          "name": "audit_events_data_classes_check",
+          "value": "jsonb_typeof(\"audit_events\".\"data_classes\") = 'array' AND jsonb_array_length(\"audit_events\".\"data_classes\") BETWEEN 1 AND 8 AND \"audit_events\".\"data_classes\" <@ '[\"internal\", \"student_personal\", \"financial\", \"health\", \"safeguarding\", \"credential\"]'::jsonb"
+        },
+        "audit_events_json_shape_check": {
+          "name": "audit_events_json_shape_check",
+          "value": "jsonb_typeof(\"audit_events\".\"change_summary\") = 'object' AND (\"audit_events\".\"policy_decision\" IS NULL OR jsonb_typeof(\"audit_events\".\"policy_decision\") = 'object')"
+        },
+        "audit_events_account_actor_check": {
+          "name": "audit_events_account_actor_check",
+          "value": "(\"audit_events\".\"actor_type\" NOT IN ('account', 'support', 'platform')) OR (\"audit_events\".\"actor_account_id\" IS NOT NULL AND (\"audit_events\".\"actor_type\" IN ('support', 'platform') OR \"audit_events\".\"actor_person_id\" IS NOT NULL))"
+        },
+        "audit_events_support_context_check": {
+          "name": "audit_events_support_context_check",
+          "value": "(\"audit_events\".\"actor_type\" = 'support' AND \"audit_events\".\"support_grant_id\" IS NOT NULL AND \"audit_events\".\"purpose\" IS NOT NULL AND \"audit_events\".\"source\" = 'support') OR (\"audit_events\".\"actor_type\" <> 'support' AND \"audit_events\".\"support_grant_id\" IS NULL AND (\"audit_events\".\"actor_type\" <> 'platform' OR (\"audit_events\".\"actor_person_id\" IS NULL AND \"audit_events\".\"source\" = 'platform')))"
+        },
+        "audit_events_content_hash_check": {
+          "name": "audit_events_content_hash_check",
+          "value": "\"audit_events\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_outbox": {
+      "name": "audit_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_event_occurred_at": {
+          "name": "audit_event_occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deduplication_key": {
+          "name": "deduplication_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_outbox_claim_idx": {
+          "name": "audit_outbox_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "audit_outbox_event_idx": {
+          "name": "audit_outbox_event_idx",
+          "columns": [
+            {
+              "expression": "audit_event_occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audit_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "audit_outbox_tenant_id_tenants_id_fk": {
+          "name": "audit_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_outbox",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "audit_outbox_event_fk": {
+          "name": "audit_outbox_event_fk",
+          "tableFrom": "audit_outbox",
+          "columnsFrom": ["audit_event_occurred_at", "audit_event_id"],
+          "tableTo": "audit_events",
+          "columnsTo": ["occurred_at", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audit_outbox_tenant_dedup_unique": {
+          "name": "audit_outbox_tenant_dedup_unique",
+          "columns": ["tenant_id", "deduplication_key"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "audit_outbox_runtime_select": {
+          "name": "audit_outbox_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' = nullif(current_setting('app.account_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' = nullif(current_setting('app.person_id', true), '')\n      "
+        },
+        "audit_outbox_runtime_insert": {
+          "name": "audit_outbox_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' = nullif(current_setting('app.account_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' = nullif(current_setting('app.person_id', true), '')\n      "
+        },
+        "audit_outbox_invitation_denial_select": {
+          "name": "audit_outbox_invitation_denial_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' IS NULL\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' IS NULL\n        AND \"audit_outbox\".\"topic\" = 'audit.event.committed'\n        AND \"audit_outbox\".\"payload\" ->> 'eventType' = 'account.invitation.accept'\n        AND \"audit_outbox\".\"payload\" ->> 'outcome' = 'denied'\n        AND \"audit_outbox\".\"payload\" ->> 'targetType' = 'account.invitation'\n        AND nullif(\"audit_outbox\".\"payload\" ->> 'targetId', '') IS NOT NULL\n        AND \"audit_outbox\".\"deduplication_key\" =\n          'account.invitation.accept.denied:' || (\"audit_outbox\".\"payload\" ->> 'targetId') || ':' ||\n          nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "audit_outbox_invitation_denial_insert": {
+          "name": "audit_outbox_invitation_denial_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' IS NULL\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' IS NULL\n        AND \"audit_outbox\".\"topic\" = 'audit.event.committed'\n        AND \"audit_outbox\".\"payload\" ->> 'eventType' = 'account.invitation.accept'\n        AND \"audit_outbox\".\"payload\" ->> 'outcome' = 'denied'\n        AND \"audit_outbox\".\"payload\" ->> 'targetType' = 'account.invitation'\n        AND nullif(\"audit_outbox\".\"payload\" ->> 'targetId', '') IS NOT NULL\n        AND \"audit_outbox\".\"deduplication_key\" =\n          'account.invitation.accept.denied:' || (\"audit_outbox\".\"payload\" ->> 'targetId') || ':' ||\n          nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "audit_outbox_runtime_update_deny": {
+          "name": "audit_outbox_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_outbox_runtime_delete_deny": {
+          "name": "audit_outbox_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "audit_outbox_worker_select": {
+          "name": "audit_outbox_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_outbox_worker_update": {
+          "name": "audit_outbox_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_outbox_worker_insert_deny": {
+          "name": "audit_outbox_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "audit_outbox_worker_delete_deny": {
+          "name": "audit_outbox_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "audit_outbox_attempt_nonnegative": {
+          "name": "audit_outbox_attempt_nonnegative",
+          "value": "\"audit_outbox\".\"attempt_count\" >= 0"
+        },
+        "audit_outbox_topic_format": {
+          "name": "audit_outbox_topic_format",
+          "value": "\"audit_outbox\".\"topic\" ~ '^[a-z][a-z0-9_.]{2,127}$'"
+        },
+        "audit_outbox_reference_format": {
+          "name": "audit_outbox_reference_format",
+          "value": "char_length(\"audit_outbox\".\"deduplication_key\") BETWEEN 1 AND 512 AND char_length(\"audit_outbox\".\"correlation_id\") BETWEEN 1 AND 512"
+        },
+        "audit_outbox_context_binding_check": {
+          "name": "audit_outbox_context_binding_check",
+          "value": "jsonb_typeof(\"audit_outbox\".\"context\") = 'object' AND jsonb_typeof(\"audit_outbox\".\"payload\") = 'object' AND \"audit_outbox\".\"context\" ->> 'tenantId' = \"audit_outbox\".\"tenant_id\"::text AND \"audit_outbox\".\"context\" ->> 'correlationId' = \"audit_outbox\".\"correlation_id\" AND nullif(\"audit_outbox\".\"context\" ->> 'requestId', '') IS NOT NULL AND \"audit_outbox\".\"payload\" ->> 'auditEventId' = \"audit_outbox\".\"audit_event_id\"::text"
+        },
+        "audit_outbox_status_check": {
+          "name": "audit_outbox_status_check",
+          "value": "\"audit_outbox\".\"status\" IN ('pending', 'processing', 'published', 'failed', 'dead_letter')"
+        },
+        "audit_outbox_payload_hash_check": {
+          "name": "audit_outbox_payload_hash_check",
+          "value": "\"audit_outbox\".\"payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.account_invitations": {
+      "name": "account_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intended_email": {
+          "name": "intended_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_provider": {
+          "name": "identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'supabase'"
+        },
+        "intended_provider_subject": {
+          "name": "intended_provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "affiliation_kind": {
+          "name": "affiliation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_template_keys": {
+          "name": "role_template_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliation_valid_until": {
+          "name": "affiliation_valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_account_id": {
+          "name": "accepted_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_provider_subject": {
+          "name": "accepted_provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_account_id": {
+          "name": "cancelled_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_invitations_tenant_status_expiry_idx": {
+          "name": "account_invitations_tenant_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "account_invitations_tenant_person_status_idx": {
+          "name": "account_invitations_tenant_person_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_tenant_id_tenants_id_fk": {
+          "name": "account_invitations_tenant_id_tenants_id_fk",
+          "tableFrom": "account_invitations",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_invitations_issued_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_invitations_accepted_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_accepted_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "columnsFrom": ["accepted_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_invitations_cancelled_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_cancelled_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "columnsFrom": ["cancelled_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_invitations_tenant_person_fk": {
+          "name": "account_invitations_tenant_person_fk",
+          "tableFrom": "account_invitations",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_invitations_tenant_organization_fk": {
+          "name": "account_invitations_tenant_organization_fk",
+          "tableFrom": "account_invitations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_invitations_tenant_school_fk": {
+          "name": "account_invitations_tenant_school_fk",
+          "tableFrom": "account_invitations",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "account_invitations_tenant_class_fk": {
+          "name": "account_invitations_tenant_class_fk",
+          "tableFrom": "account_invitations",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "tableTo": "classes",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_invitations_tenant_id_id_unique": {
+          "name": "account_invitations_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "account_invitations_token_hash_unique": {
+          "name": "account_invitations_token_hash_unique",
+          "columns": ["token_hash"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "account_invitations_runtime_select": {
+          "name": "account_invitations_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          'tenant.accounts.invite', 'tenant.accounts.manage'\n        )\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_insert": {
+          "name": "account_invitations_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"issued_by_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.invite'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_update": {
+          "name": "account_invitations_runtime_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      ",
+          "withCheck": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"cancelled_by_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_delete_deny": {
+          "name": "account_invitations_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "account_invitations_worker_select": {
+          "name": "account_invitations_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "account_invitations_acceptance_select": {
+          "name": "account_invitations_acceptance_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n      "
+        },
+        "account_invitations_acceptance_update": {
+          "name": "account_invitations_acceptance_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["public"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n        AND \"account_invitations\".\"status\" = 'pending'\n        AND \"account_invitations\".\"expires_at\" > now()\n        AND \"account_invitations\".\"identity_provider\" = nullif(current_setting('app.identity_provider', true), '')\n        AND \"account_invitations\".\"intended_email\" = lower(btrim(nullif(current_setting('app.identity_email', true), '')))\n        AND (\n          \"account_invitations\".\"intended_provider_subject\" IS NULL\n          OR \"account_invitations\".\"intended_provider_subject\" = nullif(current_setting('app.provider_subject', true), '')\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n        AND \"account_invitations\".\"status\" = 'accepted'\n        AND \"account_invitations\".\"accepted_provider_subject\" = nullif(current_setting('app.provider_subject', true), '')\n        AND EXISTS (\n          SELECT 1 FROM public.accounts AS accepted_account\n          WHERE accepted_account.id = \"account_invitations\".\"accepted_by_account_id\"\n            AND accepted_account.identity_provider = nullif(current_setting('app.identity_provider', true), '')\n            AND accepted_account.provider_subject = nullif(current_setting('app.provider_subject', true), '')\n            AND lower(btrim(accepted_account.primary_email)) = lower(btrim(nullif(current_setting('app.identity_email', true), '')))\n            AND accepted_account.status = 'active'\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "account_invitations_email_normalized_check": {
+          "name": "account_invitations_email_normalized_check",
+          "value": "\"account_invitations\".\"intended_email\" = lower(btrim(\"account_invitations\".\"intended_email\")) AND char_length(\"account_invitations\".\"intended_email\") BETWEEN 3 AND 320 AND \"account_invitations\".\"intended_email\" ~ '^[^[:space:]@]+@[^[:space:]@]+$'"
+        },
+        "account_invitations_identity_check": {
+          "name": "account_invitations_identity_check",
+          "value": "char_length(\"account_invitations\".\"identity_provider\") BETWEEN 1 AND 128 AND (\"account_invitations\".\"intended_provider_subject\" IS NULL OR char_length(\"account_invitations\".\"intended_provider_subject\") BETWEEN 1 AND 512)"
+        },
+        "account_invitations_token_check": {
+          "name": "account_invitations_token_check",
+          "value": "\"account_invitations\".\"token_version\" = 1 AND \"account_invitations\".\"token_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "account_invitations_scope_check": {
+          "name": "account_invitations_scope_check",
+          "value": "(\"account_invitations\".\"scope_type\" = 'tenant' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"education_organization_id\" IS NOT NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NOT NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'class' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NOT NULL)"
+        },
+        "account_invitations_roles_check": {
+          "name": "account_invitations_roles_check",
+          "value": "jsonb_typeof(\"account_invitations\".\"role_template_keys\") = 'array'\n          AND jsonb_array_length(\"account_invitations\".\"role_template_keys\") = 1\n          AND NOT jsonb_path_exists(\"account_invitations\".\"role_template_keys\", '$[*] ? (@.type() != \"string\")')\n          AND (\n            (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"affiliation_kind\" = 'administrator' AND \"account_invitations\".\"role_template_keys\" = '[\"org_admin\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"affiliation_kind\" = 'member' AND \"account_invitations\".\"role_template_keys\" = '[\"org_viewer\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'administrator' AND \"account_invitations\".\"role_template_keys\" = '[\"school_admin\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'employee' AND \"account_invitations\".\"role_template_keys\" = '[\"staff\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'guardian' AND \"account_invitations\".\"role_template_keys\" = '[\"parent\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'student' AND \"account_invitations\".\"role_template_keys\" = '[\"student\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'class' AND \"account_invitations\".\"affiliation_kind\" = 'teacher' AND \"account_invitations\".\"role_template_keys\" = '[\"teacher\"]'::jsonb)\n          )"
+        },
+        "account_invitations_affiliation_kind_check": {
+          "name": "account_invitations_affiliation_kind_check",
+          "value": "\"account_invitations\".\"affiliation_kind\" IN ('student', 'guardian', 'employee', 'teacher', 'administrator', 'member')"
+        },
+        "account_invitations_period_check": {
+          "name": "account_invitations_period_check",
+          "value": "\"account_invitations\".\"expires_at\" > \"account_invitations\".\"created_at\" AND (\"account_invitations\".\"affiliation_valid_until\" IS NULL OR \"account_invitations\".\"affiliation_valid_until\" > \"account_invitations\".\"created_at\")"
+        },
+        "account_invitations_status_evidence_check": {
+          "name": "account_invitations_status_evidence_check",
+          "value": "(\"account_invitations\".\"status\" = 'pending' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)\n          OR (\"account_invitations\".\"status\" = 'accepted' AND \"account_invitations\".\"accepted_at\" IS NOT NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NOT NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NOT NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)\n          OR (\"account_invitations\".\"status\" = 'cancelled' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NOT NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NOT NULL AND nullif(btrim(\"account_invitations\".\"cancellation_reason\"), '') IS NOT NULL)\n          OR (\"account_invitations\".\"status\" = 'expired' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.invitation_acceptance_rate_limits": {
+      "name": "invitation_acceptance_rate_limits",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_acceptance_rate_limits_pkey": {
+          "name": "invitation_acceptance_rate_limits_pkey",
+          "columns": ["key_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "invitation_acceptance_rate_limits_acceptor_select": {
+          "name": "invitation_acceptance_rate_limits_acceptor_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        },
+        "invitation_acceptance_rate_limits_acceptor_insert": {
+          "name": "invitation_acceptance_rate_limits_acceptor_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["public"],
+          "withCheck": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        },
+        "invitation_acceptance_rate_limits_acceptor_update": {
+          "name": "invitation_acceptance_rate_limits_acceptor_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["public"],
+          "using": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'",
+          "withCheck": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        }
+      },
+      "checkConstraints": {
+        "invitation_acceptance_rate_limits_key_check": {
+          "name": "invitation_acceptance_rate_limits_key_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"key_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "invitation_acceptance_rate_limits_count_check": {
+          "name": "invitation_acceptance_rate_limits_count_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"attempt_count\" BETWEEN 1 AND 1000000"
+        },
+        "invitation_acceptance_rate_limits_time_check": {
+          "name": "invitation_acceptance_rate_limits_time_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"updated_at\" >= \"invitation_acceptance_rate_limits\".\"window_started_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.invitation_delivery_outbox": {
+      "name": "invitation_delivery_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_key_id": {
+          "name": "encryption_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_auth_tag": {
+          "name": "token_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_delivery_claim_idx": {
+          "name": "invitation_delivery_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_delivery_outbox_tenant_id_tenants_id_fk": {
+          "name": "invitation_delivery_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "invitation_delivery_outbox",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "invitation_delivery_invitation_fk": {
+          "name": "invitation_delivery_invitation_fk",
+          "tableFrom": "invitation_delivery_outbox",
+          "columnsFrom": ["tenant_id", "invitation_id"],
+          "tableTo": "account_invitations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_delivery_invitation_unique": {
+          "name": "invitation_delivery_invitation_unique",
+          "columns": ["tenant_id", "invitation_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "invitation_delivery_runtime_insert": {
+          "name": "invitation_delivery_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.invite'\n        AND EXISTS (\n          SELECT 1 FROM public.account_invitations AS invitation\n          WHERE invitation.tenant_id = \"invitation_delivery_outbox\".\"tenant_id\"\n            AND invitation.id = \"invitation_delivery_outbox\".\"invitation_id\"\n            AND invitation.intended_email = \"invitation_delivery_outbox\".\"recipient_email\"\n            AND invitation.issued_by_account_id = nullif(current_setting('app.account_id', true), '')::uuid\n            AND invitation.status = 'pending'\n        )\n      "
+        },
+        "invitation_delivery_runtime_select_deny": {
+          "name": "invitation_delivery_runtime_select_deny",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "invitation_delivery_runtime_update_deny": {
+          "name": "invitation_delivery_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "invitation_delivery_runtime_delete_deny": {
+          "name": "invitation_delivery_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "invitation_delivery_worker_select": {
+          "name": "invitation_delivery_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "invitation_delivery_worker_update": {
+          "name": "invitation_delivery_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "invitation_delivery_worker_insert_deny": {
+          "name": "invitation_delivery_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "invitation_delivery_worker_delete_deny": {
+          "name": "invitation_delivery_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "invitation_delivery_email_normalized_check": {
+          "name": "invitation_delivery_email_normalized_check",
+          "value": "\"invitation_delivery_outbox\".\"recipient_email\" = lower(btrim(\"invitation_delivery_outbox\".\"recipient_email\")) AND char_length(\"invitation_delivery_outbox\".\"recipient_email\") BETWEEN 3 AND 320"
+        },
+        "invitation_delivery_encryption_check": {
+          "name": "invitation_delivery_encryption_check",
+          "value": "(\n            \"invitation_delivery_outbox\".\"status\" IN ('pending', 'processing', 'failed')\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" ~ '^[A-Za-z0-9_.-]{1,64}$'\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" ~ '^[A-Za-z0-9_-]+$'\n            AND char_length(\"invitation_delivery_outbox\".\"token_ciphertext\") BETWEEN 16 AND 1024\n            AND \"invitation_delivery_outbox\".\"token_iv\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_iv\" ~ '^[A-Za-z0-9_-]{16}$'\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" ~ '^[A-Za-z0-9_-]{22}$'\n          ) OR (\n            \"invitation_delivery_outbox\".\"status\" IN ('delivered', 'dead_letter')\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_iv\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" IS NULL\n          )"
+        },
+        "invitation_delivery_attempt_nonnegative": {
+          "name": "invitation_delivery_attempt_nonnegative",
+          "value": "\"invitation_delivery_outbox\".\"attempt_count\" >= 0"
+        },
+        "invitation_delivery_status_check": {
+          "name": "invitation_delivery_status_check",
+          "value": "\"invitation_delivery_outbox\".\"status\" IN ('pending', 'processing', 'delivered', 'failed', 'dead_letter')"
+        },
+        "invitation_delivery_status_evidence_check": {
+          "name": "invitation_delivery_status_evidence_check",
+          "value": "(\"invitation_delivery_outbox\".\"status\" = 'pending' AND \"invitation_delivery_outbox\".\"attempt_count\" = 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'processing' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NOT NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'delivered' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NOT NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'failed' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')\n          OR (\"invitation_delivery_outbox\".\"status\" = 'dead_letter' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.platform_access_grants": {
+      "name": "platform_access_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_template_key": {
+          "name": "role_template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_source": {
+          "name": "issuance_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_access_grants_account_status_idx": {
+          "name": "platform_access_grants_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "platform_access_grants_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "columnsFrom": ["account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "platform_access_grants_issued_by_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "columnsFrom": ["issued_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "platform_access_grants_revoked_by_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "columnsFrom": ["revoked_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_access_grants_role_check": {
+          "name": "platform_access_grants_role_check",
+          "value": "\"platform_access_grants\".\"role_template_key\" IN ('super_admin', 'support_agent', 'break_glass_operator')"
+        },
+        "platform_access_grants_status_check": {
+          "name": "platform_access_grants_status_check",
+          "value": "\"platform_access_grants\".\"status\" IN ('active', 'revoked')"
+        },
+        "platform_access_grants_issuance_source_check": {
+          "name": "platform_access_grants_issuance_source_check",
+          "value": "\"platform_access_grants\".\"issuance_source\" IN ('bootstrap', 'platform')"
+        },
+        "platform_access_grants_period_check": {
+          "name": "platform_access_grants_period_check",
+          "value": "\"platform_access_grants\".\"valid_until\" > \"platform_access_grants\".\"valid_from\" AND \"platform_access_grants\".\"valid_until\" <= \"platform_access_grants\".\"valid_from\" + interval '90 days'"
+        },
+        "platform_access_grants_reason_check": {
+          "name": "platform_access_grants_reason_check",
+          "value": "char_length(btrim(\"platform_access_grants\".\"issuance_reason\")) BETWEEN 3 AND 512 AND (\"platform_access_grants\".\"revocation_reason\" IS NULL OR char_length(btrim(\"platform_access_grants\".\"revocation_reason\")) BETWEEN 3 AND 512)"
+        },
+        "platform_access_grants_issuer_check": {
+          "name": "platform_access_grants_issuer_check",
+          "value": "(\"platform_access_grants\".\"issuance_source\" = 'bootstrap' AND \"platform_access_grants\".\"issued_by_account_id\" IS NULL) OR (\"platform_access_grants\".\"issuance_source\" = 'platform' AND \"platform_access_grants\".\"issued_by_account_id\" IS NOT NULL)"
+        },
+        "platform_access_grants_revocation_check": {
+          "name": "platform_access_grants_revocation_check",
+          "value": "(\"platform_access_grants\".\"status\" = 'active' AND \"platform_access_grants\".\"revoked_at\" IS NULL AND \"platform_access_grants\".\"revoked_by_account_id\" IS NULL AND \"platform_access_grants\".\"revocation_reason\" IS NULL) OR (\"platform_access_grants\".\"status\" = 'revoked' AND \"platform_access_grants\".\"revoked_at\" IS NOT NULL AND \"platform_access_grants\".\"revoked_by_account_id\" IS NOT NULL AND \"platform_access_grants\".\"revocation_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_security_reconciliation_outbox": {
+      "name": "provider_security_reconciliation_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_security_version": {
+          "name": "expected_security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_person_id": {
+          "name": "actor_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_factor_count": {
+          "name": "deleted_factor_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_security_reconciliation_claim_idx": {
+          "name": "provider_security_reconciliation_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "provider_security_reconciliation_outbox_tenant_id_tenants_id_fk": {
+          "name": "provider_security_reconciliation_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "provider_security_reconciliation_outbox_account_id_accounts_id_fk": {
+          "name": "provider_security_reconciliation_outbox_account_id_accounts_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "columnsFrom": ["account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "provider_security_reconciliation_outbox_actor_account_id_accounts_id_fk": {
+          "name": "provider_security_reconciliation_outbox_actor_account_id_accounts_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "columnsFrom": ["actor_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "provider_security_reconciliation_actor_person_fk": {
+          "name": "provider_security_reconciliation_actor_person_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "columnsFrom": ["tenant_id", "actor_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_security_reconciliation_effect_unique": {
+          "name": "provider_security_reconciliation_effect_unique",
+          "columns": ["tenant_id", "account_id", "action", "expected_security_version"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "provider_security_reconciliation_revoker_insert": {
+          "name": "provider_security_reconciliation_revoker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_identity_revoker"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_identity_revoker'\n        AND \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"actor_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"actor_person_id\" = nullif(current_setting('app.person_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "provider_security_reconciliation_worker_select": {
+          "name": "provider_security_reconciliation_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_worker_update": {
+          "name": "provider_security_reconciliation_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      ",
+          "withCheck": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_resolver_select": {
+          "name": "provider_security_reconciliation_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_provider_security_resolver"],
+          "using": "\n        session_user = 'openschool_worker'\n        AND current_user = 'openschool_provider_security_resolver'\n        AND \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_identity_resolver_select": {
+          "name": "provider_security_reconciliation_identity_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_provider_security_resolver"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_provider_security_resolver'\n        AND EXISTS (\n          SELECT 1 FROM public.accounts AS verified_account\n          WHERE verified_account.id = \"provider_security_reconciliation_outbox\".\"account_id\"\n            AND verified_account.identity_provider = nullif(current_setting('app.identity_provider', true), '')\n            AND verified_account.provider_subject = nullif(current_setting('app.provider_subject', true), '')\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "provider_security_reconciliation_action_check": {
+          "name": "provider_security_reconciliation_action_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"action\" = 'reset_mfa'"
+        },
+        "provider_security_reconciliation_version_check": {
+          "name": "provider_security_reconciliation_version_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"expected_security_version\" > 0"
+        },
+        "provider_security_reconciliation_request_check": {
+          "name": "provider_security_reconciliation_request_check",
+          "value": "char_length(\"provider_security_reconciliation_outbox\".\"request_id\") BETWEEN 1 AND 512"
+        },
+        "provider_security_reconciliation_attempt_check": {
+          "name": "provider_security_reconciliation_attempt_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"attempt_count\" >= 0"
+        },
+        "provider_security_reconciliation_status_check": {
+          "name": "provider_security_reconciliation_status_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"status\" IN ('pending', 'processing', 'completed', 'failed', 'dead_letter')"
+        },
+        "provider_security_reconciliation_status_evidence_check": {
+          "name": "provider_security_reconciliation_status_evidence_check",
+          "value": "(\"provider_security_reconciliation_outbox\".\"status\" = 'pending' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" = 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'processing' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NOT NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'completed' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NOT NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" >= 0 AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'failed' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'dead_letter' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_access_grants": {
+      "name": "support_access_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_account_id": {
+          "name": "support_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_access_grant_id": {
+          "name": "platform_access_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_capabilities": {
+          "name": "allowed_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_reference": {
+          "name": "ticket_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emergency_rule_reference": {
+          "name": "emergency_rule_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_by_account_id": {
+          "name": "authorized_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_by_person_id": {
+          "name": "authorized_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_reason": {
+          "name": "authorization_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_account_session_id": {
+          "name": "bound_account_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_person_id": {
+          "name": "closed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_person_id": {
+          "name": "revoked_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_due'"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_account_id": {
+          "name": "reviewed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_person_id": {
+          "name": "reviewed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_outcome": {
+          "name": "review_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_notes": {
+          "name": "review_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_access_grants_resolve_idx": {
+          "name": "support_access_grants_resolve_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "support_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "support_access_grants_review_idx": {
+          "name": "support_access_grants_review_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "support_access_grants_tenant_id_tenants_id_fk": {
+          "name": "support_access_grants_tenant_id_tenants_id_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_support_account_id_accounts_id_fk": {
+          "name": "support_access_grants_support_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["support_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_platform_access_grant_id_platform_access_grants_id_fk": {
+          "name": "support_access_grants_platform_access_grant_id_platform_access_grants_id_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["platform_access_grant_id"],
+          "tableTo": "platform_access_grants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_authorized_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_authorized_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["authorized_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_bound_account_session_id_account_sessions_id_fk": {
+          "name": "support_access_grants_bound_account_session_id_account_sessions_id_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["bound_account_session_id"],
+          "tableTo": "account_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_closed_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["closed_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_revoked_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["revoked_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_reviewed_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_reviewed_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["reviewed_by_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_tenant_organization_fk": {
+          "name": "support_access_grants_tenant_organization_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "tableTo": "education_organizations",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_tenant_school_fk": {
+          "name": "support_access_grants_tenant_school_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "tableTo": "schools",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_tenant_authorizer_person_fk": {
+          "name": "support_access_grants_tenant_authorizer_person_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["tenant_id", "authorized_by_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_tenant_closer_person_fk": {
+          "name": "support_access_grants_tenant_closer_person_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["tenant_id", "closed_by_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_tenant_revoker_person_fk": {
+          "name": "support_access_grants_tenant_revoker_person_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["tenant_id", "revoked_by_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_grants_tenant_reviewer_person_fk": {
+          "name": "support_access_grants_tenant_reviewer_person_fk",
+          "tableFrom": "support_access_grants",
+          "columnsFrom": ["tenant_id", "reviewed_by_person_id"],
+          "tableTo": "people",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_access_grants_tenant_id_id_unique": {
+          "name": "support_access_grants_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "support_access_grants_manager_select": {
+          "name": "support_access_grants_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_support_grant_manager"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_manager_insert": {
+          "name": "support_access_grants_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_manager_update": {
+          "name": "support_access_grants_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_support_grant_manager"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_resolver_select": {
+          "name": "support_access_grants_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_support_access_resolver"],
+          "using": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_grants_resolver_update": {
+          "name": "support_access_grants_resolver_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_support_access_resolver"],
+          "using": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid",
+          "withCheck": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_grants_worker_select": {
+          "name": "support_access_grants_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        },
+        "support_access_grants_worker_update": {
+          "name": "support_access_grants_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'",
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        }
+      },
+      "checkConstraints": {
+        "support_access_grants_kind_check": {
+          "name": "support_access_grants_kind_check",
+          "value": "\"support_access_grants\".\"kind\" IN ('support', 'break_glass')"
+        },
+        "support_access_grants_status_check": {
+          "name": "support_access_grants_status_check",
+          "value": "\"support_access_grants\".\"status\" IN ('approved', 'active', 'closed', 'revoked', 'expired')"
+        },
+        "support_access_grants_scope_check": {
+          "name": "support_access_grants_scope_check",
+          "value": "(\"support_access_grants\".\"scope_type\" = 'tenant' AND \"support_access_grants\".\"education_organization_id\" IS NULL AND \"support_access_grants\".\"school_id\" IS NULL)\n          OR (\"support_access_grants\".\"scope_type\" = 'organization_subtree' AND \"support_access_grants\".\"education_organization_id\" IS NOT NULL AND \"support_access_grants\".\"school_id\" IS NULL)\n          OR (\"support_access_grants\".\"scope_type\" = 'school' AND \"support_access_grants\".\"education_organization_id\" IS NULL AND \"support_access_grants\".\"school_id\" IS NOT NULL)"
+        },
+        "support_access_grants_capabilities_check": {
+          "name": "support_access_grants_capabilities_check",
+          "value": "jsonb_typeof(\"support_access_grants\".\"allowed_capabilities\") = 'array'\n          AND jsonb_array_length(\"support_access_grants\".\"allowed_capabilities\") BETWEEN 1 AND 2\n          AND \"support_access_grants\".\"allowed_capabilities\" <@ '[\"support.schools.read\", \"support.students.read\"]'::jsonb\n          AND (jsonb_array_length(\"support_access_grants\".\"allowed_capabilities\") = 1\n            OR (\"support_access_grants\".\"allowed_capabilities\" ? 'support.schools.read'\n              AND \"support_access_grants\".\"allowed_capabilities\" ? 'support.students.read'))"
+        },
+        "support_access_grants_purpose_check": {
+          "name": "support_access_grants_purpose_check",
+          "value": "\"support_access_grants\".\"purpose\" IN ('customer_support', 'incident_response')\n          AND (\"support_access_grants\".\"kind\" <> 'break_glass' OR \"support_access_grants\".\"purpose\" = 'incident_response')"
+        },
+        "support_access_grants_reference_check": {
+          "name": "support_access_grants_reference_check",
+          "value": "char_length(btrim(\"support_access_grants\".\"ticket_reference\")) BETWEEN 3 AND 128\n          AND char_length(btrim(\"support_access_grants\".\"authorization_reason\")) BETWEEN 3 AND 512\n          AND (\"support_access_grants\".\"emergency_rule_reference\" IS NULL OR char_length(btrim(\"support_access_grants\".\"emergency_rule_reference\")) BETWEEN 3 AND 128)\n          AND (\"support_access_grants\".\"close_reason\" IS NULL OR char_length(btrim(\"support_access_grants\".\"close_reason\")) BETWEEN 3 AND 512)\n          AND (\"support_access_grants\".\"revocation_reason\" IS NULL OR char_length(btrim(\"support_access_grants\".\"revocation_reason\")) BETWEEN 3 AND 512)\n          AND (\"support_access_grants\".\"review_notes\" IS NULL OR char_length(btrim(\"support_access_grants\".\"review_notes\")) BETWEEN 3 AND 2048)"
+        },
+        "support_access_grants_authorizer_check": {
+          "name": "support_access_grants_authorizer_check",
+          "value": "(\"support_access_grants\".\"kind\" = 'support' AND \"support_access_grants\".\"authorized_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"emergency_rule_reference\" IS NULL)\n          OR (\"support_access_grants\".\"kind\" = 'break_glass' AND \"support_access_grants\".\"authorized_by_person_id\" IS NULL AND \"support_access_grants\".\"emergency_rule_reference\" IS NOT NULL)"
+        },
+        "support_access_grants_period_check": {
+          "name": "support_access_grants_period_check",
+          "value": "\"support_access_grants\".\"valid_until\" > \"support_access_grants\".\"valid_from\"\n          AND ((\"support_access_grants\".\"kind\" = 'support' AND \"support_access_grants\".\"valid_until\" <= \"support_access_grants\".\"valid_from\" + interval '8 hours')\n            OR (\"support_access_grants\".\"kind\" = 'break_glass' AND \"support_access_grants\".\"valid_until\" <= \"support_access_grants\".\"valid_from\" + interval '30 minutes'))"
+        },
+        "support_access_grants_state_evidence_check": {
+          "name": "support_access_grants_state_evidence_check",
+          "value": "(\"support_access_grants\".\"status\" = 'approved' AND \"support_access_grants\".\"bound_account_session_id\" IS NULL AND \"support_access_grants\".\"opened_at\" IS NULL AND \"support_access_grants\".\"closed_at\" IS NULL AND \"support_access_grants\".\"closed_by_account_id\" IS NULL AND \"support_access_grants\".\"closed_by_person_id\" IS NULL AND \"support_access_grants\".\"close_reason\" IS NULL AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"review_status\" = 'not_due')\n          OR (\"support_access_grants\".\"status\" = 'active' AND \"support_access_grants\".\"bound_account_session_id\" IS NOT NULL AND \"support_access_grants\".\"opened_at\" IS NOT NULL AND \"support_access_grants\".\"closed_at\" IS NULL AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"review_status\" = 'not_due')\n          OR (\"support_access_grants\".\"status\" IN ('closed', 'expired') AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"closed_at\" IS NOT NULL AND \"support_access_grants\".\"close_reason\" IS NOT NULL AND \"support_access_grants\".\"review_status\" IN ('pending', 'completed'))\n          OR (\"support_access_grants\".\"status\" = 'revoked' AND \"support_access_grants\".\"revoked_at\" IS NOT NULL AND \"support_access_grants\".\"revoked_by_account_id\" IS NOT NULL AND \"support_access_grants\".\"revoked_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"revocation_reason\" IS NOT NULL AND \"support_access_grants\".\"review_status\" IN ('pending', 'completed'))"
+        },
+        "support_access_grants_review_evidence_check": {
+          "name": "support_access_grants_review_evidence_check",
+          "value": "(\"support_access_grants\".\"review_status\" IN ('not_due', 'pending') AND \"support_access_grants\".\"reviewed_at\" IS NULL AND \"support_access_grants\".\"reviewed_by_account_id\" IS NULL AND \"support_access_grants\".\"reviewed_by_person_id\" IS NULL AND \"support_access_grants\".\"review_outcome\" IS NULL AND \"support_access_grants\".\"review_notes\" IS NULL)\n          OR (\"support_access_grants\".\"review_status\" = 'completed' AND \"support_access_grants\".\"reviewed_at\" IS NOT NULL AND \"support_access_grants\".\"reviewed_by_account_id\" IS NOT NULL AND \"support_access_grants\".\"reviewed_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"review_outcome\" IN ('confirmed', 'no_impact', 'control_gap', 'incident') AND \"support_access_grants\".\"review_notes\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_access_notifications": {
+      "name": "support_access_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_grant_id": {
+          "name": "support_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tenant_security_admins'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_access_notifications_tenant_time_idx": {
+          "name": "support_access_notifications_tenant_time_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "support_access_notifications_tenant_id_tenants_id_fk": {
+          "name": "support_access_notifications_tenant_id_tenants_id_fk",
+          "tableFrom": "support_access_notifications",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_notifications_actor_account_id_accounts_id_fk": {
+          "name": "support_access_notifications_actor_account_id_accounts_id_fk",
+          "tableFrom": "support_access_notifications",
+          "columnsFrom": ["actor_account_id"],
+          "tableTo": "accounts",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_access_notifications_grant_fk": {
+          "name": "support_access_notifications_grant_fk",
+          "tableFrom": "support_access_notifications",
+          "columnsFrom": ["tenant_id", "support_grant_id"],
+          "tableTo": "support_access_grants",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_access_notifications_tenant_id_id_unique": {
+          "name": "support_access_notifications_tenant_id_id_unique",
+          "columns": ["tenant_id", "id"],
+          "nullsNotDistinct": false
+        },
+        "support_access_notifications_operation_unique": {
+          "name": "support_access_notifications_operation_unique",
+          "columns": ["tenant_id", "support_grant_id", "event", "operation_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "support_access_notifications_runtime_select": {
+          "name": "support_access_notifications_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.support.grants.manage'\n        AND openschool_private.tenant_admin_can_view_support_notification(\n          \"support_access_notifications\".\"tenant_id\",\n          nullif(current_setting('app.person_id', true), '')::uuid,\n          \"support_access_notifications\".\"support_grant_id\",\n          statement_timestamp()\n        )"
+        },
+        "support_access_notifications_manager_insert": {
+          "name": "support_access_notifications_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_notifications_resolver_insert": {
+          "name": "support_access_notifications_resolver_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_access_resolver"],
+          "withCheck": "\"support_access_notifications\".\"support_grant_id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_notifications_worker_insert": {
+          "name": "support_access_notifications_worker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        },
+        "support_access_notifications_worker_select": {
+          "name": "support_access_notifications_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        }
+      },
+      "checkConstraints": {
+        "support_access_notifications_event_check": {
+          "name": "support_access_notifications_event_check",
+          "value": "\"support_access_notifications\".\"event\" IN ('approved', 'opened', 'used', 'closed', 'revoked', 'expired', 'reviewed', 'break_glass_opened')"
+        },
+        "support_access_notifications_audience_check": {
+          "name": "support_access_notifications_audience_check",
+          "value": "\"support_access_notifications\".\"audience\" = 'tenant_security_admins'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_notification_outbox": {
+      "name": "support_notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_notification_outbox_claim_idx": {
+          "name": "support_notification_outbox_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "support_notification_outbox_tenant_id_tenants_id_fk": {
+          "name": "support_notification_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "support_notification_outbox",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenants",
+          "columnsTo": ["id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        },
+        "support_notification_outbox_notification_fk": {
+          "name": "support_notification_outbox_notification_fk",
+          "tableFrom": "support_notification_outbox",
+          "columnsFrom": ["tenant_id", "notification_id"],
+          "tableTo": "support_access_notifications",
+          "columnsTo": ["tenant_id", "id"],
+          "onUpdate": "restrict",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_notification_outbox_notification_unique": {
+          "name": "support_notification_outbox_notification_unique",
+          "columns": ["tenant_id", "notification_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "support_notification_outbox_manager_insert": {
+          "name": "support_notification_outbox_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_notification_outbox_resolver_insert": {
+          "name": "support_notification_outbox_resolver_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_access_resolver"],
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.support_grant_id', true), '') IS NOT NULL"
+        },
+        "support_notification_outbox_worker_select": {
+          "name": "support_notification_outbox_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        },
+        "support_notification_outbox_worker_update": {
+          "name": "support_notification_outbox_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'",
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        }
+      },
+      "checkConstraints": {
+        "support_notification_outbox_attempt_check": {
+          "name": "support_notification_outbox_attempt_check",
+          "value": "\"support_notification_outbox\".\"attempt_count\" >= 0"
+        },
+        "support_notification_outbox_status_check": {
+          "name": "support_notification_outbox_status_check",
+          "value": "\"support_notification_outbox\".\"status\" IN ('pending', 'processing', 'delivered', 'failed', 'dead_letter')"
+        },
+        "support_notification_outbox_state_check": {
+          "name": "support_notification_outbox_state_check",
+          "value": "(\"support_notification_outbox\".\"status\" = 'pending' AND \"support_notification_outbox\".\"attempt_count\" = 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" = 'processing' AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NOT NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" = 'delivered' AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NOT NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" IN ('failed', 'dead_letter') AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0044_snapshot.json
+++ b/packages/db/migrations/meta/0044_snapshot.json
@@ -1,0 +1,14360 @@
+{
+  "id": "7e9e4356-4346-40b4-8abd-5b806b115386",
+  "prevId": "2ca68449-0f32-49c5-8d54-fe3bda8fbe42",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tenant_placements": {
+      "name": "tenant_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pooled'"
+        },
+        "placement_key": {
+          "name": "placement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_placements_tenant_id_tenants_id_fk": {
+          "name": "tenant_placements_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_placements",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_placements_tenant_id_unique": {
+          "name": "tenant_placements_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tenant_placements_adapter_check": {
+          "name": "tenant_placements_adapter_check",
+          "value": "\"tenant_placements\".\"adapter\" = 'pooled'"
+        },
+        "tenant_placements_status_check": {
+          "name": "tenant_placements_status_check",
+          "value": "\"tenant_placements\".\"status\" IN ('active', 'migrating', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tenants_status_check": {
+          "name": "tenants_status_check",
+          "value": "\"tenants\".\"status\" IN ('active', 'suspended', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_tenant_id_tenants_id_fk": {
+          "name": "organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organizations_tenant_id_id_unique": {
+          "name": "organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schools_tenant_organization_idx": {
+          "name": "schools_tenant_organization_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schools_tenant_id_tenants_id_fk": {
+          "name": "schools_tenant_id_tenants_id_fk",
+          "tableFrom": "schools",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "schools_tenant_organization_fk": {
+          "name": "schools_tenant_organization_fk",
+          "tableFrom": "schools",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schools_tenant_id_id_unique": {
+          "name": "schools_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "schools_tenant_id_slug_unique": {
+          "name": "schools_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        }
+      },
+      "policies": {
+        "schools_runtime_select": {
+          "name": "schools_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND (\n          \"schools\".\"id\" = nullif(current_setting('app.school_id', true), '')::uuid\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              IN (\n                'tenant.schools.read',\n                'tenant.students.create', 'tenant.students.read',\n                'tenant.students.update', 'tenant.students.delete',\n                'support.schools.read', 'support.students.read',\n                'tenant.accounts.invite', 'tenant.accounts.manage',\n                'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n                'tenant.student_enrollments.read', 'tenant.student_enrollments.manage',\n                'tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage',\n                'tenant.sections.read', 'tenant.sections.manage',\n                'identity.context.resolve'\n              )\n            AND public.openschool_school_scope_allows(\n              \"schools\".\"tenant_id\", \"schools\".\"id\"\n            )\n          )\n        )\n      "
+        },
+        "schools_identity_revoker_select": {
+          "name": "schools_identity_revoker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_identity_revoker"],
+          "using": "\n        \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND nullif(current_setting('app.assurance_level', true), '') = 'aal2'\n      "
+        },
+        "schools_worker_select": {
+          "name": "schools_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "schools_student_admitter_select": {
+          "name": "schools_student_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_school_scope_allows(\"schools\".\"tenant_id\", \"schools\".\"id\")\n      "
+        },
+        "schools_academic_configurator_select": {
+          "name": "schools_academic_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_academic_configurator'\n        AND \"schools\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.academic_structure.manage'\n        AND public.openschool_school_scope_allows(\"schools\".\"tenant_id\", \"schools\".\"id\")\n      "
+        },
+        "schools_runtime_insert_deny": {
+          "name": "schools_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "schools_runtime_update_deny": {
+          "name": "schools_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "schools_runtime_delete_deny": {
+          "name": "schools_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "schools_worker_insert_deny": {
+          "name": "schools_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "schools_worker_update_deny": {
+          "name": "schools_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "schools_worker_delete_deny": {
+          "name": "schools_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "schools_profile_check": {
+          "name": "schools_profile_check",
+          "value": "\"schools\".\"profile\" IN ('primary', 'secondary', 'all_through', 'special', 'other')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.education_organizations": {
+      "name": "education_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_organization_id": {
+          "name": "legacy_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_organizations_tenant_type_idx": {
+          "name": "education_organizations_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_organizations_tenant_id_tenants_id_fk": {
+          "name": "education_organizations_tenant_id_tenants_id_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "education_organizations_legacy_organization_fk": {
+          "name": "education_organizations_legacy_organization_fk",
+          "tableFrom": "education_organizations",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "legacy_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "education_organizations_tenant_id_id_unique": {
+          "name": "education_organizations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "education_organizations_tenant_id_slug_unique": {
+          "name": "education_organizations_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "slug"]
+        },
+        "education_organizations_legacy_organization_id_unique": {
+          "name": "education_organizations_legacy_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "education_organizations_type_check": {
+          "name": "education_organizations_type_check",
+          "value": "\"education_organizations\".\"type\" IN ('ministry', 'school_board', 'district', 'network', 'region', 'other')"
+        },
+        "education_organizations_status_check": {
+          "name": "education_organizations_status_check",
+          "value": "\"education_organizations\".\"status\" IN ('active', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_closure": {
+      "name": "organization_tree_closure",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_organization_id": {
+          "name": "ancestor_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_organization_id": {
+          "name": "descendant_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_tree_closure_descendants_idx": {
+          "name": "organization_tree_closure_descendants_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_tree_closure_ancestors_idx": {
+          "name": "organization_tree_closure_ancestors_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_closure_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_closure_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_closure_version_fk": {
+          "name": "organization_tree_closure_version_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_ancestor_fk": {
+          "name": "organization_tree_closure_ancestor_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "ancestor_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_closure_descendant_fk": {
+          "name": "organization_tree_closure_descendant_fk",
+          "tableFrom": "organization_tree_closure",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "descendant_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_closure_pk": {
+          "name": "organization_tree_closure_pk",
+          "columns": [
+            "tenant_id",
+            "tree_version_id",
+            "ancestor_organization_id",
+            "descendant_organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_closure_depth_nonnegative": {
+          "name": "organization_tree_closure_depth_nonnegative",
+          "value": "\"organization_tree_closure\".\"depth\" >= 0"
+        },
+        "organization_tree_closure_self_depth": {
+          "name": "organization_tree_closure_self_depth",
+          "value": "(\"organization_tree_closure\".\"ancestor_organization_id\" = \"organization_tree_closure\".\"descendant_organization_id\") = (\"organization_tree_closure\".\"depth\" = 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_nodes": {
+      "name": "organization_tree_nodes",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_version_id": {
+          "name": "tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_tree_nodes_parent_idx": {
+          "name": "organization_tree_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tree_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_nodes_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "organization_tree_nodes_version_fk": {
+          "name": "organization_tree_nodes_version_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_organization_fk": {
+          "name": "organization_tree_nodes_organization_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "organization_tree_nodes_parent_fk": {
+          "name": "organization_tree_nodes_parent_fk",
+          "tableFrom": "organization_tree_nodes",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "parent_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_tree_nodes_pk": {
+          "name": "organization_tree_nodes_pk",
+          "columns": ["tenant_id", "tree_version_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_nodes_not_self_parent": {
+          "name": "organization_tree_nodes_not_self_parent",
+          "value": "\"organization_tree_nodes\".\"parent_organization_id\" IS NULL OR \"organization_tree_nodes\".\"parent_organization_id\" <> \"organization_tree_nodes\".\"organization_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_tree_versions": {
+      "name": "organization_tree_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_tree_versions_effective_lookup_idx": {
+          "name": "organization_tree_versions_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tree_versions_tenant_id_tenants_id_fk": {
+          "name": "organization_tree_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "organization_tree_versions",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_tree_versions_tenant_id_id_unique": {
+          "name": "organization_tree_versions_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "organization_tree_versions_tenant_id_version_unique": {
+          "name": "organization_tree_versions_tenant_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "version"]
+        },
+        "organization_tree_versions_tenant_effective_from_unique": {
+          "name": "organization_tree_versions_tenant_effective_from_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_tree_versions_version_positive": {
+          "name": "organization_tree_versions_version_positive",
+          "value": "\"organization_tree_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.school_governance_assignments": {
+      "name": "school_governance_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_governance_assignments_effective_lookup_idx": {
+          "name": "school_governance_assignments_effective_lookup_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_governance_assignments_tenant_id_tenants_id_fk": {
+          "name": "school_governance_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_governance_assignments_school_fk": {
+          "name": "school_governance_assignments_school_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "school_governance_assignments_organization_fk": {
+          "name": "school_governance_assignments_organization_fk",
+          "tableFrom": "school_governance_assignments",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_governance_assignments_tenant_id_id_unique": {
+          "name": "school_governance_assignments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "school_governance_assignments_valid_period": {
+          "name": "school_governance_assignments_valid_period",
+          "value": "\"school_governance_assignments\".\"valid_until\" IS NULL OR \"school_governance_assignments\".\"valid_until\" > \"school_governance_assignments\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_links": {
+      "name": "account_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_links_account_status_idx": {
+          "name": "account_links_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_links_tenant_person_status_idx": {
+          "name": "account_links_tenant_person_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_links_tenant_id_tenants_id_fk": {
+          "name": "account_links_tenant_id_tenants_id_fk",
+          "tableFrom": "account_links",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_links_account_id_accounts_id_fk": {
+          "name": "account_links_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_links_issued_by_account_id_accounts_id_fk": {
+          "name": "account_links_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_links_revoked_by_account_id_accounts_id_fk": {
+          "name": "account_links_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "account_links",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_links_tenant_person_fk": {
+          "name": "account_links_tenant_person_fk",
+          "tableFrom": "account_links",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_links_tenant_id_id_unique": {
+          "name": "account_links_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_links_status_check": {
+          "name": "account_links_status_check",
+          "value": "\"account_links\".\"status\" IN ('pending', 'active', 'suspended', 'revoked', 'expired')"
+        },
+        "account_links_valid_period_check": {
+          "name": "account_links_valid_period_check",
+          "value": "\"account_links\".\"valid_from\" IS NULL OR \"account_links\".\"valid_until\" IS NULL OR \"account_links\".\"valid_until\" > \"account_links\".\"valid_from\""
+        },
+        "account_links_activation_evidence_check": {
+          "name": "account_links_activation_evidence_check",
+          "value": "\"account_links\".\"status\" <> 'active' OR (\"account_links\".\"valid_from\" IS NOT NULL AND \"account_links\".\"activated_at\" IS NOT NULL)"
+        },
+        "account_links_revocation_evidence_check": {
+          "name": "account_links_revocation_evidence_check",
+          "value": "\"account_links\".\"status\" <> 'revoked' OR (\"account_links\".\"revoked_at\" IS NOT NULL AND \"account_links\".\"revocation_reason\" IS NOT NULL AND \"account_links\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_sessions": {
+      "name": "account_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assurance_level": {
+          "name": "assurance_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_version": {
+          "name": "security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authenticated_at": {
+          "name": "authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reauthenticated_at": {
+          "name": "reauthenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_sessions_account_status_idx": {
+          "name": "account_sessions_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_sessions_account_id_accounts_id_fk": {
+          "name": "account_sessions_account_id_accounts_id_fk",
+          "tableFrom": "account_sessions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_sessions_revoked_by_account_id_accounts_id_fk": {
+          "name": "account_sessions_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "account_sessions",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_sessions_provider_session_id_unique": {
+          "name": "account_sessions_provider_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider_session_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_sessions_status_check": {
+          "name": "account_sessions_status_check",
+          "value": "\"account_sessions\".\"status\" IN ('active', 'revoked', 'expired')"
+        },
+        "account_sessions_assurance_level_check": {
+          "name": "account_sessions_assurance_level_check",
+          "value": "\"account_sessions\".\"assurance_level\" IN ('aal1', 'aal2')"
+        },
+        "account_sessions_security_version_positive": {
+          "name": "account_sessions_security_version_positive",
+          "value": "\"account_sessions\".\"security_version\" > 0"
+        },
+        "account_sessions_time_order_check": {
+          "name": "account_sessions_time_order_check",
+          "value": "\"account_sessions\".\"expires_at\" > \"account_sessions\".\"authenticated_at\""
+        },
+        "account_sessions_reauthentication_time_check": {
+          "name": "account_sessions_reauthentication_time_check",
+          "value": "\"account_sessions\".\"reauthenticated_at\" IS NULL OR \"account_sessions\".\"reauthenticated_at\" < \"account_sessions\".\"expires_at\""
+        },
+        "account_sessions_revocation_evidence_check": {
+          "name": "account_sessions_revocation_evidence_check",
+          "value": "\"account_sessions\".\"status\" <> 'revoked' OR (\"account_sessions\".\"revoked_at\" IS NOT NULL AND \"account_sessions\".\"revocation_reason\" IS NOT NULL AND btrim(\"account_sessions\".\"revocation_reason\") <> '')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "legacy_user_id": {
+          "name": "legacy_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_provider": {
+          "name": "identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'supabase'"
+        },
+        "provider_subject": {
+          "name": "provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "membership_version": {
+          "name": "membership_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "security_version": {
+          "name": "security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_legacy_user_id_users_id_fk": {
+          "name": "accounts_legacy_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["legacy_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_legacy_user_id_unique": {
+          "name": "accounts_legacy_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_user_id"]
+        },
+        "accounts_provider_subject_unique": {
+          "name": "accounts_provider_subject_unique",
+          "nullsNotDistinct": false,
+          "columns": ["identity_provider", "provider_subject"]
+        },
+        "accounts_primary_email_unique": {
+          "name": "accounts_primary_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["primary_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "accounts_status_check": {
+          "name": "accounts_status_check",
+          "value": "\"accounts\".\"status\" IN ('active', 'disabled', 'deleted')"
+        },
+        "accounts_versions_positive": {
+          "name": "accounts_versions_positive",
+          "value": "\"accounts\".\"membership_version\" > 0 AND \"accounts\".\"security_version\" > 0"
+        },
+        "accounts_disabled_evidence_check": {
+          "name": "accounts_disabled_evidence_check",
+          "value": "\"accounts\".\"status\" = 'active' OR (\"accounts\".\"disabled_at\" IS NOT NULL AND \"accounts\".\"disabled_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_tenant_person_effective_idx": {
+          "name": "affiliations_tenant_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "affiliations_tenant_school_effective_idx": {
+          "name": "affiliations_tenant_school_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "affiliations_tenant_id_tenants_id_fk": {
+          "name": "affiliations_tenant_id_tenants_id_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_issued_by_account_id_accounts_id_fk": {
+          "name": "affiliations_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_revoked_by_account_id_accounts_id_fk": {
+          "name": "affiliations_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_tenant_person_fk": {
+          "name": "affiliations_tenant_person_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_tenant_education_organization_fk": {
+          "name": "affiliations_tenant_education_organization_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_tenant_school_fk": {
+          "name": "affiliations_tenant_school_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "affiliations_tenant_class_fk": {
+          "name": "affiliations_tenant_class_fk",
+          "tableFrom": "affiliations",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "affiliations_tenant_id_id_unique": {
+          "name": "affiliations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "affiliations_kind_check": {
+          "name": "affiliations_kind_check",
+          "value": "\"affiliations\".\"kind\" IN ('student', 'guardian', 'employee', 'teacher', 'administrator', 'member')"
+        },
+        "affiliations_status_check": {
+          "name": "affiliations_status_check",
+          "value": "\"affiliations\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "affiliations_scope_check": {
+          "name": "affiliations_scope_check",
+          "value": "(\"affiliations\".\"scope_type\" = 'tenant' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'education_organization' AND \"affiliations\".\"education_organization_id\" IS NOT NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'school' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NOT NULL AND \"affiliations\".\"class_id\" IS NULL)\n          OR (\"affiliations\".\"scope_type\" = 'class' AND \"affiliations\".\"education_organization_id\" IS NULL AND \"affiliations\".\"school_id\" IS NULL AND \"affiliations\".\"class_id\" IS NOT NULL)"
+        },
+        "affiliations_valid_period_check": {
+          "name": "affiliations_valid_period_check",
+          "value": "\"affiliations\".\"valid_until\" IS NULL OR \"affiliations\".\"valid_until\" > \"affiliations\".\"valid_from\""
+        },
+        "affiliations_revocation_evidence_check": {
+          "name": "affiliations_revocation_evidence_check",
+          "value": "\"affiliations\".\"status\" <> 'revoked' OR (\"affiliations\".\"revoked_at\" IS NOT NULL AND \"affiliations\".\"revocation_reason\" IS NOT NULL AND \"affiliations\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.contact_profiles": {
+      "name": "contact_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_phone": {
+          "name": "normalized_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_profiles_tenant_phone_idx": {
+          "name": "contact_profiles_tenant_phone_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_profiles_tenant_id_tenants_id_fk": {
+          "name": "contact_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "contact_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "contact_profiles_tenant_person_fk": {
+          "name": "contact_profiles_tenant_person_fk",
+          "tableFrom": "contact_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contact_profiles_pk": {
+          "name": "contact_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "contact_profiles_runtime_select": {
+          "name": "contact_profiles_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage')\n        AND public.openschool_contact_person_read_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_runtime_insert_deny": {
+          "name": "contact_profiles_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "contact_profiles_runtime_update_deny": {
+          "name": "contact_profiles_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "contact_profiles_runtime_delete_deny": {
+          "name": "contact_profiles_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "contact_profiles_contact_manager_select": {
+          "name": "contact_profiles_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_insert": {
+          "name": "contact_profiles_contact_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_guardian_contact_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_update": {
+          "name": "contact_profiles_contact_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"contact_profiles\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_contact_person_manage_scope_allows(\n          \"contact_profiles\".\"tenant_id\", \"contact_profiles\".\"person_id\"\n        )\n      "
+        },
+        "contact_profiles_contact_manager_delete_deny": {
+          "name": "contact_profiles_contact_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "contact_profiles_phone_check": {
+          "name": "contact_profiles_phone_check",
+          "value": "\"contact_profiles\".\"phone\" IS NULL OR char_length(btrim(\"contact_profiles\".\"phone\")) BETWEEN 5 AND 32"
+        },
+        "contact_profiles_normalized_phone_check": {
+          "name": "contact_profiles_normalized_phone_check",
+          "value": "\"contact_profiles\".\"normalized_phone\" IS NULL OR char_length(\"contact_profiles\".\"normalized_phone\") BETWEEN 5 AND 20"
+        },
+        "contact_profiles_preferred_method_check": {
+          "name": "contact_profiles_preferred_method_check",
+          "value": "\"contact_profiles\".\"preferred_contact_method\" IN ('email', 'phone', 'sms', 'none')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.employee_profiles": {
+      "name": "employee_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_number": {
+          "name": "employee_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "employee_profiles_tenant_id_tenants_id_fk": {
+          "name": "employee_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "employee_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "employee_profiles_tenant_person_fk": {
+          "name": "employee_profiles_tenant_person_fk",
+          "tableFrom": "employee_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "employee_profiles_pk": {
+          "name": "employee_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "employee_profiles_tenant_employee_number_unique": {
+          "name": "employee_profiles_tenant_employee_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "employee_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "employee_profiles_status_check": {
+          "name": "employee_profiles_status_check",
+          "value": "\"employee_profiles\".\"status\" IN ('active', 'leave', 'terminated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.guardian_profiles": {
+      "name": "guardian_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardian_profiles_tenant_id_tenants_id_fk": {
+          "name": "guardian_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "guardian_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "guardian_profiles_tenant_person_fk": {
+          "name": "guardian_profiles_tenant_person_fk",
+          "tableFrom": "guardian_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "guardian_profiles_pk": {
+          "name": "guardian_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "guardian_profiles_status_check": {
+          "name": "guardian_profiles_status_check",
+          "value": "\"guardian_profiles\".\"status\" IN ('active', 'inactive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.identity_migration_events": {
+      "name": "identity_migration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_link_id": {
+          "name": "account_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_version": {
+          "name": "membership_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identity_migration_events_account_version_idx": {
+          "name": "identity_migration_events_account_version_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "membership_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_migration_events_tenant_person_idx": {
+          "name": "identity_migration_events_tenant_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_migration_events_tenant_id_tenants_id_fk": {
+          "name": "identity_migration_events_tenant_id_tenants_id_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "identity_migration_events_account_id_accounts_id_fk": {
+          "name": "identity_migration_events_account_id_accounts_id_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "identity_migration_events_actor_account_id_accounts_id_fk": {
+          "name": "identity_migration_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "identity_migration_events_tenant_person_fk": {
+          "name": "identity_migration_events_tenant_person_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "identity_migration_events_tenant_account_link_fk": {
+          "name": "identity_migration_events_tenant_account_link_fk",
+          "tableFrom": "identity_migration_events",
+          "tableTo": "account_links",
+          "columnsFrom": ["tenant_id", "account_link_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "identity_migration_events_tenant_id_id_unique": {
+          "name": "identity_migration_events_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "identity_migration_events_type_check": {
+          "name": "identity_migration_events_type_check",
+          "value": "\"identity_migration_events\".\"event_type\" IN ('account_link_backfilled', 'account_link_activated', 'account_link_revoked')"
+        },
+        "identity_migration_events_version_positive": {
+          "name": "identity_migration_events_version_positive",
+          "value": "\"identity_migration_events\".\"membership_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.people": {
+      "name": "people",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_user_id": {
+          "name": "legacy_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_display_name": {
+          "name": "normalized_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "people_tenant_name_idx": {
+          "name": "people_tenant_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "people_tenant_email_idx": {
+          "name": "people_tenant_email_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "people_tenant_id_tenants_id_fk": {
+          "name": "people_tenant_id_tenants_id_fk",
+          "tableFrom": "people",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "people_legacy_user_id_users_id_fk": {
+          "name": "people_legacy_user_id_users_id_fk",
+          "tableFrom": "people",
+          "tableTo": "users",
+          "columnsFrom": ["legacy_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "people_tenant_legacy_student_fk": {
+          "name": "people_tenant_legacy_student_fk",
+          "tableFrom": "people",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "people_tenant_id_id_unique": {
+          "name": "people_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "people_tenant_legacy_user_unique": {
+          "name": "people_tenant_legacy_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_user_id"]
+        },
+        "people_tenant_legacy_student_unique": {
+          "name": "people_tenant_legacy_student_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_student_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "people_status_check": {
+          "name": "people_status_check",
+          "value": "\"people\".\"status\" IN ('active', 'suspended', 'archived', 'deceased')"
+        },
+        "people_source_check": {
+          "name": "people_source_check",
+          "value": "\"people\".\"source\" IN ('legacy_user', 'legacy_student', 'native')"
+        },
+        "people_legacy_source_check": {
+          "name": "people_legacy_source_check",
+          "value": "(\"people\".\"source\" <> 'legacy_user' OR \"people\".\"legacy_user_id\" IS NOT NULL)\n          AND (\"people\".\"source\" <> 'legacy_student' OR \"people\".\"legacy_student_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.person_merge_evidence": {
+      "name": "person_merge_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "recorded_by_account_id": {
+          "name": "recorded_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_evidence_tenant_people_idx": {
+          "name": "person_merge_evidence_tenant_people_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_evidence_tenant_id_tenants_id_fk": {
+          "name": "person_merge_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_evidence_recorded_by_account_id_accounts_id_fk": {
+          "name": "person_merge_evidence_recorded_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_evidence",
+          "tableTo": "accounts",
+          "columnsFrom": ["recorded_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_evidence_tenant_source_fk": {
+          "name": "person_merge_evidence_tenant_source_fk",
+          "tableFrom": "person_merge_evidence",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_evidence_tenant_target_fk": {
+          "name": "person_merge_evidence_tenant_target_fk",
+          "tableFrom": "person_merge_evidence",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_evidence_tenant_id_id_unique": {
+          "name": "person_merge_evidence_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "person_merge_evidence_status_check": {
+          "name": "person_merge_evidence_status_check",
+          "value": "\"person_merge_evidence\".\"status\" IN ('proposed', 'approved', 'completed', 'rejected', 'reverted')"
+        },
+        "person_merge_evidence_distinct_people_check": {
+          "name": "person_merge_evidence_distinct_people_check",
+          "value": "\"person_merge_evidence\".\"source_person_id\" <> \"person_merge_evidence\".\"target_person_id\""
+        },
+        "person_merge_evidence_completion_check": {
+          "name": "person_merge_evidence_completion_check",
+          "value": "\"person_merge_evidence\".\"status\" <> 'completed' OR \"person_merge_evidence\".\"completed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.person_relationships": {
+      "name": "person_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_person_id": {
+          "name": "subject_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_person_id": {
+          "name": "related_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_authority": {
+          "name": "legal_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decision_authority": {
+          "name": "decision_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "emergency_priority": {
+          "name": "emergency_priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_authority": {
+          "name": "pickup_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "portal_eligible": {
+          "name": "portal_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_relationships_one_active_contact_per_learner_idx": {
+          "name": "person_relationships_one_active_contact_per_learner_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"person_relationships\".\"status\" = 'active' AND \"person_relationships\".\"type\" IN ('parent_of', 'guardian_of', 'emergency_contact_of')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_relationships_subject_effective_idx": {
+          "name": "person_relationships_subject_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_relationships_related_effective_idx": {
+          "name": "person_relationships_related_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_relationships_tenant_id_tenants_id_fk": {
+          "name": "person_relationships_tenant_id_tenants_id_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_relationships_issued_by_account_id_accounts_id_fk": {
+          "name": "person_relationships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_relationships_revoked_by_account_id_accounts_id_fk": {
+          "name": "person_relationships_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_relationships_tenant_subject_fk": {
+          "name": "person_relationships_tenant_subject_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "subject_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_relationships_tenant_related_fk": {
+          "name": "person_relationships_tenant_related_fk",
+          "tableFrom": "person_relationships",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "related_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_relationships_tenant_id_id_unique": {
+          "name": "person_relationships_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {
+        "person_relationships_runtime_select": {
+          "name": "person_relationships_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND (\n          (\n            nullif(current_setting('app.policy_capability', true), '')\n              = 'tenant.guardian_contacts.read'\n            AND public.openschool_guardian_contact_read_scope_allows(\n              \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n            )\n          )\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              = 'tenant.guardian_contacts.manage'\n            AND public.openschool_guardian_contact_manage_scope_allows(\n              \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n            )\n          )\n          OR (\n            nullif(current_setting('app.policy_capability', true), '')\n              IN ('identity.context.resolve', 'tenant.students.read')\n            AND \"person_relationships\".\"subject_person_id\"::text\n              = nullif(current_setting('app.person_id', true), '')\n            AND \"person_relationships\".\"type\" IN ('guardian_of', 'parent_of')\n            AND \"person_relationships\".\"portal_eligible\"\n            AND \"person_relationships\".\"status\" = 'active'\n            AND \"person_relationships\".\"valid_from\" <= now()\n            AND (\"person_relationships\".\"valid_until\" IS NULL OR \"person_relationships\".\"valid_until\" > now())\n            AND EXISTS (\n              SELECT 1\n              FROM jsonb_array_elements(public.openschool_policy_constraints()) AS constraint_row\n              WHERE constraint_row ->> 'kind' = 'linked_student'\n                AND constraint_row ->> 'tenantId' = \"person_relationships\".\"tenant_id\"::text\n                AND constraint_row ->> 'guardianPersonId' = \"person_relationships\".\"subject_person_id\"::text\n                AND (\n                  constraint_row ->> 'studentId' IS NULL\n                  OR constraint_row ->> 'studentId' = \"person_relationships\".\"related_person_id\"::text\n                )\n            )\n          )\n        )\n      "
+        },
+        "person_relationships_runtime_insert_deny": {
+          "name": "person_relationships_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "person_relationships_runtime_update_deny": {
+          "name": "person_relationships_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_relationships_runtime_delete_deny": {
+          "name": "person_relationships_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "person_relationships_contact_manager_select": {
+          "name": "person_relationships_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_insert": {
+          "name": "person_relationships_contact_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_guardian_contact_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_update": {
+          "name": "person_relationships_contact_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"person_relationships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_guardian_contact_manage_scope_allows(\n          \"person_relationships\".\"tenant_id\", \"person_relationships\".\"related_person_id\"\n        )\n      "
+        },
+        "person_relationships_contact_manager_delete_deny": {
+          "name": "person_relationships_contact_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "person_relationships_type_check": {
+          "name": "person_relationships_type_check",
+          "value": "\"person_relationships\".\"type\" IN ('guardian_of', 'parent_of', 'emergency_contact_of', 'spouse_of', 'sibling_of', 'other')"
+        },
+        "person_relationships_status_check": {
+          "name": "person_relationships_status_check",
+          "value": "\"person_relationships\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "person_relationships_distinct_people_check": {
+          "name": "person_relationships_distinct_people_check",
+          "value": "\"person_relationships\".\"subject_person_id\" <> \"person_relationships\".\"related_person_id\""
+        },
+        "person_relationships_valid_period_check": {
+          "name": "person_relationships_valid_period_check",
+          "value": "\"person_relationships\".\"valid_until\" IS NULL OR \"person_relationships\".\"valid_until\" > \"person_relationships\".\"valid_from\""
+        },
+        "person_relationships_revocation_evidence_check": {
+          "name": "person_relationships_revocation_evidence_check",
+          "value": "\"person_relationships\".\"status\" <> 'revoked' OR (\"person_relationships\".\"revoked_at\" IS NOT NULL AND \"person_relationships\".\"revocation_reason\" IS NOT NULL AND \"person_relationships\".\"valid_until\" IS NOT NULL)"
+        },
+        "person_relationships_decision_authority_check": {
+          "name": "person_relationships_decision_authority_check",
+          "value": "\"person_relationships\".\"decision_authority\" IN ('none', 'shared', 'sole', 'limited')"
+        },
+        "person_relationships_emergency_priority_check": {
+          "name": "person_relationships_emergency_priority_check",
+          "value": "\"person_relationships\".\"emergency_priority\" IS NULL OR \"person_relationships\".\"emergency_priority\" BETWEEN 1 AND 99"
+        },
+        "person_relationships_portal_eligibility_check": {
+          "name": "person_relationships_portal_eligibility_check",
+          "value": "NOT \"person_relationships\".\"portal_eligible\" OR \"person_relationships\".\"type\" IN ('guardian_of', 'parent_of')"
+        },
+        "person_relationships_version_positive": {
+          "name": "person_relationships_version_positive",
+          "value": "\"person_relationships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.role_template_assignments": {
+      "name": "role_template_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliation_id": {
+          "name": "affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_template_key": {
+          "name": "role_template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_template_assignments_affiliation_effective_idx": {
+          "name": "role_template_assignments_affiliation_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affiliation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_template_assignments_tenant_id_tenants_id_fk": {
+          "name": "role_template_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "role_template_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "role_template_assignments_issued_by_account_id_accounts_id_fk": {
+          "name": "role_template_assignments_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "role_template_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "role_template_assignments_revoked_by_account_id_accounts_id_fk": {
+          "name": "role_template_assignments_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "role_template_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "role_template_assignments_tenant_affiliation_fk": {
+          "name": "role_template_assignments_tenant_affiliation_fk",
+          "tableFrom": "role_template_assignments",
+          "tableTo": "affiliations",
+          "columnsFrom": ["tenant_id", "affiliation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_template_assignments_tenant_id_id_unique": {
+          "name": "role_template_assignments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "role_template_assignments_status_check": {
+          "name": "role_template_assignments_status_check",
+          "value": "\"role_template_assignments\".\"status\" IN ('active', 'suspended', 'revoked')"
+        },
+        "role_template_assignments_valid_period_check": {
+          "name": "role_template_assignments_valid_period_check",
+          "value": "\"role_template_assignments\".\"valid_until\" IS NULL OR \"role_template_assignments\".\"valid_until\" > \"role_template_assignments\".\"valid_from\""
+        },
+        "role_template_assignments_revocation_evidence_check": {
+          "name": "role_template_assignments_revocation_evidence_check",
+          "value": "\"role_template_assignments\".\"status\" <> 'revoked' OR (\"role_template_assignments\".\"revoked_at\" IS NOT NULL AND \"role_template_assignments\".\"revocation_reason\" IS NOT NULL AND \"role_template_assignments\".\"valid_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.student_profiles": {
+      "name": "student_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_profiles_tenant_id_tenants_id_fk": {
+          "name": "student_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "student_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_profiles_tenant_person_fk": {
+          "name": "student_profiles_tenant_person_fk",
+          "tableFrom": "student_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_profiles_tenant_legacy_student_fk": {
+          "name": "student_profiles_tenant_legacy_student_fk",
+          "tableFrom": "student_profiles",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_profiles_pk": {
+          "name": "student_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "student_profiles_tenant_student_number_unique": {
+          "name": "student_profiles_tenant_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "student_number"]
+        },
+        "student_profiles_tenant_legacy_student_unique": {
+          "name": "student_profiles_tenant_legacy_student_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_student_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "student_profiles_status_check": {
+          "name": "student_profiles_status_check",
+          "value": "\"student_profiles\".\"status\" IN ('active', 'inactive', 'graduated', 'withdrawn')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teacher_profiles": {
+      "name": "teacher_profiles",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teacher_profiles_tenant_id_tenants_id_fk": {
+          "name": "teacher_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "teacher_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "teacher_profiles_tenant_person_fk": {
+          "name": "teacher_profiles_tenant_person_fk",
+          "tableFrom": "teacher_profiles",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_profiles_pk": {
+          "name": "teacher_profiles_pk",
+          "columns": ["tenant_id", "person_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "teacher_profiles_tenant_registration_number_unique": {
+          "name": "teacher_profiles_tenant_registration_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "registration_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "teacher_profiles_status_check": {
+          "name": "teacher_profiles_status_check",
+          "value": "\"teacher_profiles\".\"status\" IN ('active', 'inactive', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classes": {
+      "name": "classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_level": {
+          "name": "grade_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classes_tenant_school_idx": {
+          "name": "classes_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classes_tenant_id_tenants_id_fk": {
+          "name": "classes_tenant_id_tenants_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "classes_tenant_school_fk": {
+          "name": "classes_tenant_school_fk",
+          "tableFrom": "classes",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classes_tenant_id_id_unique": {
+          "name": "classes_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_tenant_school_idx": {
+          "name": "students_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_tenant_id_tenants_id_fk": {
+          "name": "students_tenant_id_tenants_id_fk",
+          "tableFrom": "students",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "students_tenant_school_fk": {
+          "name": "students_tenant_school_fk",
+          "tableFrom": "students",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_tenant_id_id_unique": {
+          "name": "students_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "students_tenant_id_student_number_unique": {
+          "name": "students_tenant_id_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "student_number"]
+        }
+      },
+      "policies": {
+        "students_runtime_select": {
+          "name": "students_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          'tenant.students.create', 'tenant.students.read',\n          'tenant.students.update', 'tenant.students.delete',\n          'support.students.read',\n          'identity.context.resolve'\n        )\n        AND public.openschool_student_scope_allows(\n          \"students\".\"tenant_id\", \"students\".\"school_id\", \"students\".\"id\"\n        )\n      "
+        },
+        "students_runtime_insert": {
+          "name": "students_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "students_runtime_update": {
+          "name": "students_runtime_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "students_runtime_delete": {
+          "name": "students_runtime_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "students_admitter_select": {
+          "name": "students_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_insert": {
+          "name": "students_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.students.create'\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_update": {
+          "name": "students_admitter_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.update', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.update', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"students\".\"tenant_id\", \"students\".\"school_id\")\n      "
+        },
+        "students_admitter_delete_deny": {
+          "name": "students_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        },
+        "students_worker_select": {
+          "name": "students_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"students\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "students_worker_insert_deny": {
+          "name": "students_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "students_worker_update_deny": {
+          "name": "students_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "students_worker_delete_deny": {
+          "name": "students_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.school_enrollment_transition_events": {
+      "name": "school_enrollment_transition_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_id": {
+          "name": "transition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_enrollment_id": {
+          "name": "from_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_enrollment_id": {
+          "name": "to_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_school_id": {
+          "name": "source_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_school_id": {
+          "name": "destination_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_type": {
+          "name": "transition_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_reference": {
+          "name": "evidence_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_enrollment_version": {
+          "name": "expected_enrollment_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_tree_version_id": {
+          "name": "organization_tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_version_evidence": {
+          "name": "authorization_version_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_enrollment_transition_events_timeline_idx": {
+          "name": "school_enrollment_transition_events_timeline_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_enrollment_transition_events_due_idx": {
+          "name": "school_enrollment_transition_events_due_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_enrollment_transition_events_tenant_id_tenants_id_fk": {
+          "name": "school_enrollment_transition_events_tenant_id_tenants_id_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_actor_account_id_accounts_id_fk": {
+          "name": "school_enrollment_transition_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_person_fk": {
+          "name": "school_enrollment_transition_events_tenant_person_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_from_fk": {
+          "name": "school_enrollment_transition_events_tenant_from_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "from_enrollment_id", "person_id", "source_school_id"],
+          "columnsTo": ["tenant_id", "id", "person_id", "school_id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_to_fk": {
+          "name": "school_enrollment_transition_events_tenant_to_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "to_enrollment_id", "person_id", "destination_school_id"],
+          "columnsTo": ["tenant_id", "id", "person_id", "school_id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_source_school_fk": {
+          "name": "school_enrollment_transition_events_tenant_source_school_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "source_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_destination_school_fk": {
+          "name": "school_enrollment_transition_events_tenant_destination_school_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "destination_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollment_transition_events_tenant_tree_version_fk": {
+          "name": "school_enrollment_transition_events_tenant_tree_version_fk",
+          "tableFrom": "school_enrollment_transition_events",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "organization_tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_enrollment_transition_events_tenant_id_id_unique": {
+          "name": "school_enrollment_transition_events_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "school_enrollment_transition_events_kind_unique": {
+          "name": "school_enrollment_transition_events_kind_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "transition_id", "event_type"]
+        },
+        "school_enrollment_transition_events_request_unique": {
+          "name": "school_enrollment_transition_events_request_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "request_id", "event_type"]
+        }
+      },
+      "policies": {
+        "school_enrollment_transition_events_runtime_select": {
+          "name": "school_enrollment_transition_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.student_enrollments.read', 'tenant.student_enrollments.manage')\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_runtime_insert_deny": {
+          "name": "school_enrollment_transition_events_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_runtime_update_deny": {
+          "name": "school_enrollment_transition_events_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_runtime_delete_deny": {
+          "name": "school_enrollment_transition_events_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "school_enrollment_transition_events_admitter_select": {
+          "name": "school_enrollment_transition_events_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_admitter_insert": {
+          "name": "school_enrollment_transition_events_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollment_transition_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_enrollment_transition_scope_allows(\n          \"school_enrollment_transition_events\".\"tenant_id\", \"school_enrollment_transition_events\".\"person_id\", \"school_enrollment_transition_events\".\"source_school_id\", \"school_enrollment_transition_events\".\"destination_school_id\"\n        )\n      "
+        },
+        "school_enrollment_transition_events_admitter_update_deny": {
+          "name": "school_enrollment_transition_events_admitter_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollment_transition_events_admitter_delete_deny": {
+          "name": "school_enrollment_transition_events_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "school_enrollment_transition_events_event_check": {
+          "name": "school_enrollment_transition_events_event_check",
+          "value": "\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'applied', 'cancelled')"
+        },
+        "school_enrollment_transition_events_transition_check": {
+          "name": "school_enrollment_transition_events_transition_check",
+          "value": "\"school_enrollment_transition_events\".\"transition_type\" IN ('withdraw', 'transfer', 'graduate', 'reenroll', 'add_secondary', 'end_secondary')"
+        },
+        "school_enrollment_transition_events_reason_check": {
+          "name": "school_enrollment_transition_events_reason_check",
+          "value": "char_length(btrim(\"school_enrollment_transition_events\".\"reason\")) BETWEEN 3 AND 512"
+        },
+        "school_enrollment_transition_events_evidence_check": {
+          "name": "school_enrollment_transition_events_evidence_check",
+          "value": "\"school_enrollment_transition_events\".\"evidence_reference\" IS NULL OR char_length(btrim(\"school_enrollment_transition_events\".\"evidence_reference\")) BETWEEN 3 AND 512"
+        },
+        "school_enrollment_transition_events_expected_version_check": {
+          "name": "school_enrollment_transition_events_expected_version_check",
+          "value": "\"school_enrollment_transition_events\".\"expected_enrollment_version\" IS NULL OR \"school_enrollment_transition_events\".\"expected_enrollment_version\" > 0"
+        },
+        "school_enrollment_transition_events_shape_check": {
+          "name": "school_enrollment_transition_events_shape_check",
+          "value": "(\n          \"school_enrollment_transition_events\".\"transition_type\" IN ('withdraw', 'graduate', 'end_secondary')\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL\n        ) OR (\n          \"school_enrollment_transition_events\".\"transition_type\" = 'transfer'\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NOT NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NOT NULL\n          AND (\n            (\"school_enrollment_transition_events\".\"event_type\" = 'applied' AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NOT NULL)\n            OR (\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'cancelled') AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL)\n          )\n        ) OR (\n          \"school_enrollment_transition_events\".\"transition_type\" IN ('reenroll', 'add_secondary')\n          AND \"school_enrollment_transition_events\".\"from_enrollment_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"source_school_id\" IS NULL\n          AND \"school_enrollment_transition_events\".\"destination_school_id\" IS NOT NULL\n          AND (\n            (\"school_enrollment_transition_events\".\"event_type\" = 'applied' AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NOT NULL)\n            OR (\"school_enrollment_transition_events\".\"event_type\" IN ('scheduled', 'cancelled') AND \"school_enrollment_transition_events\".\"to_enrollment_id\" IS NULL)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.school_enrollments": {
+      "name": "school_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_affiliation_id": {
+          "name": "student_affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollment_type": {
+          "name": "enrollment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_reason": {
+          "name": "admission_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_evidence_reference": {
+          "name": "end_evidence_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supersedes_enrollment_id": {
+          "name": "supersedes_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_tree_version_id": {
+          "name": "organization_tree_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_enrollments_tenant_school_current_idx": {
+          "name": "school_enrollments_tenant_school_current_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_enrollments_tenant_person_history_idx": {
+          "name": "school_enrollments_tenant_person_history_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_enrollments_tenant_id_tenants_id_fk": {
+          "name": "school_enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_ended_by_account_id_accounts_id_fk": {
+          "name": "school_enrollments_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_created_by_account_id_accounts_id_fk": {
+          "name": "school_enrollments_created_by_account_id_accounts_id_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_person_fk": {
+          "name": "school_enrollments_tenant_person_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_school_fk": {
+          "name": "school_enrollments_tenant_school_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_affiliation_fk": {
+          "name": "school_enrollments_tenant_affiliation_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "affiliations",
+          "columnsFrom": ["tenant_id", "student_affiliation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_legacy_student_fk": {
+          "name": "school_enrollments_tenant_legacy_student_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_supersedes_fk": {
+          "name": "school_enrollments_tenant_supersedes_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "supersedes_enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "school_enrollments_tenant_tree_version_fk": {
+          "name": "school_enrollments_tenant_tree_version_fk",
+          "tableFrom": "school_enrollments",
+          "tableTo": "organization_tree_versions",
+          "columnsFrom": ["tenant_id", "organization_tree_version_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "school_enrollments_tenant_id_id_unique": {
+          "name": "school_enrollments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "school_enrollments_transition_reference_unique": {
+          "name": "school_enrollments_transition_reference_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id", "person_id", "school_id"]
+        }
+      },
+      "policies": {
+        "school_enrollments_runtime_select": {
+          "name": "school_enrollments_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          \n  'tenant.students.read', 'tenant.students.update',\n  'tenant.students.delete', 'support.students.read',\n  'tenant.student_enrollments.read', 'tenant.student_enrollments.manage'\n,\n          'tenant.guardian_contacts.read', 'tenant.guardian_contacts.manage',\n          'tenant.households.read', 'tenant.households.manage',\n          'tenant.sections.read', 'tenant.sections.manage',\n          'identity.context.resolve'\n        )\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_section_manager_select": {
+          "name": "school_enrollments_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_section_manager'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n        AND public.openschool_school_scope_allows(\"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\")\n      "
+        },
+        "school_enrollments_runtime_insert_deny": {
+          "name": "school_enrollments_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "school_enrollments_runtime_update_deny": {
+          "name": "school_enrollments_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "school_enrollments_runtime_delete_deny": {
+          "name": "school_enrollments_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "school_enrollments_admitter_select": {
+          "name": "school_enrollments_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_admitter_insert": {
+          "name": "school_enrollments_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.students.create', 'tenant.student_enrollments.manage')\n        AND public.openschool_school_scope_allows(\"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\")\n      "
+        },
+        "school_enrollments_admitter_update": {
+          "name": "school_enrollments_admitter_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.student_enrollments.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        },
+        "school_enrollments_admitter_delete_deny": {
+          "name": "school_enrollments_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        },
+        "school_enrollments_contact_manager_select": {
+          "name": "school_enrollments_contact_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_guardian_contact_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_guardian_contact_manager'\n        AND \"school_enrollments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          = 'tenant.guardian_contacts.manage'\n        AND public.openschool_canonical_student_scope_allows(\n          \"school_enrollments\".\"tenant_id\", \"school_enrollments\".\"school_id\", \"school_enrollments\".\"person_id\"\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "school_enrollments_type_check": {
+          "name": "school_enrollments_type_check",
+          "value": "\"school_enrollments\".\"enrollment_type\" IN ('primary', 'secondary')"
+        },
+        "school_enrollments_status_check": {
+          "name": "school_enrollments_status_check",
+          "value": "\"school_enrollments\".\"status\" IN ('enrolled', 'withdrawn', 'graduated', 'cancelled')"
+        },
+        "school_enrollments_source_check": {
+          "name": "school_enrollments_source_check",
+          "value": "\"school_enrollments\".\"source\" IN ('legacy_backfill', 'native')"
+        },
+        "school_enrollments_valid_period_check": {
+          "name": "school_enrollments_valid_period_check",
+          "value": "\"school_enrollments\".\"valid_until\" IS NULL OR \"school_enrollments\".\"valid_until\" > \"school_enrollments\".\"valid_from\""
+        },
+        "school_enrollments_closed_status_check": {
+          "name": "school_enrollments_closed_status_check",
+          "value": "\"school_enrollments\".\"status\" = 'enrolled' OR \"school_enrollments\".\"valid_until\" IS NOT NULL"
+        },
+        "school_enrollments_legacy_source_check": {
+          "name": "school_enrollments_legacy_source_check",
+          "value": "\"school_enrollments\".\"source\" <> 'legacy_backfill' OR \"school_enrollments\".\"legacy_student_id\" IS NOT NULL"
+        },
+        "school_enrollments_native_tree_version_check": {
+          "name": "school_enrollments_native_tree_version_check",
+          "value": "\"school_enrollments\".\"source\" = 'legacy_backfill' OR \"school_enrollments\".\"organization_tree_version_id\" IS NOT NULL"
+        },
+        "school_enrollments_version_positive": {
+          "name": "school_enrollments_version_positive",
+          "value": "\"school_enrollments\".\"version\" > 0"
+        },
+        "school_enrollments_end_evidence_check": {
+          "name": "school_enrollments_end_evidence_check",
+          "value": "(\"school_enrollments\".\"valid_until\" IS NULL AND \"school_enrollments\".\"end_reason\" IS NULL AND \"school_enrollments\".\"ended_by_account_id\" IS NULL AND \"school_enrollments\".\"ended_at\" IS NULL)\n        OR (\"school_enrollments\".\"valid_until\" IS NOT NULL AND \"school_enrollments\".\"end_reason\" IS NOT NULL AND \"school_enrollments\".\"ended_at\" IS NOT NULL)"
+        },
+        "school_enrollments_end_reason_check": {
+          "name": "school_enrollments_end_reason_check",
+          "value": "\"school_enrollments\".\"end_reason\" IS NULL OR \"school_enrollments\".\"end_reason\" IN ('withdrawal', 'transfer', 'graduation', 'secondary_ended', 'correction')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.student_compatibility_evidence": {
+      "name": "student_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_enrollment_id": {
+          "name": "school_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_affiliation_id": {
+          "name": "student_affiliation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_student_id": {
+          "name": "legacy_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parity_status": {
+          "name": "parity_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_snapshot": {
+          "name": "canonical_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "legacy_snapshot": {
+          "name": "legacy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_account_id": {
+          "name": "recorded_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_compatibility_evidence_tenant_person_idx": {
+          "name": "student_compatibility_evidence_tenant_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "student_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_recorded_by_account_id_accounts_id_fk": {
+          "name": "student_compatibility_evidence_recorded_by_account_id_accounts_id_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "accounts",
+          "columnsFrom": ["recorded_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_person_fk": {
+          "name": "student_compatibility_evidence_tenant_person_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_school_fk": {
+          "name": "student_compatibility_evidence_tenant_school_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_enrollment_fk": {
+          "name": "student_compatibility_evidence_tenant_enrollment_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "school_enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_affiliation_fk": {
+          "name": "student_compatibility_evidence_tenant_affiliation_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "affiliations",
+          "columnsFrom": ["tenant_id", "student_affiliation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "student_compatibility_evidence_tenant_legacy_student_fk": {
+          "name": "student_compatibility_evidence_tenant_legacy_student_fk",
+          "tableFrom": "student_compatibility_evidence",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "legacy_student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_compatibility_evidence_tenant_id_id_unique": {
+          "name": "student_compatibility_evidence_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "student_compatibility_evidence_request_unique": {
+          "name": "student_compatibility_evidence_request_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "person_id", "request_id", "operation"]
+        }
+      },
+      "policies": {
+        "student_compatibility_evidence_runtime_select": {
+          "name": "student_compatibility_evidence_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          \n  'tenant.students.read', 'tenant.students.update',\n  'tenant.students.delete', 'support.students.read',\n  'tenant.student_enrollments.read', 'tenant.student_enrollments.manage'\n\n        )\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_runtime_insert_deny": {
+          "name": "student_compatibility_evidence_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_runtime_update_deny": {
+          "name": "student_compatibility_evidence_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_runtime_delete_deny": {
+          "name": "student_compatibility_evidence_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "student_compatibility_evidence_admitter_select": {
+          "name": "student_compatibility_evidence_admitter_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_student_admitter"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_admitter_insert": {
+          "name": "student_compatibility_evidence_admitter_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_student_admitter"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_student_admitter'\n        AND \"student_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN (\n  'tenant.students.create', 'tenant.students.update',\n  'tenant.student_enrollments.manage'\n)\n        AND public.openschool_canonical_student_scope_allows(\n          \"student_compatibility_evidence\".\"tenant_id\", \"student_compatibility_evidence\".\"school_id\", \"student_compatibility_evidence\".\"person_id\"\n        )\n      "
+        },
+        "student_compatibility_evidence_admitter_update_deny": {
+          "name": "student_compatibility_evidence_admitter_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_student_admitter"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "student_compatibility_evidence_admitter_delete_deny": {
+          "name": "student_compatibility_evidence_admitter_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_student_admitter"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "student_compatibility_evidence_operation_check": {
+          "name": "student_compatibility_evidence_operation_check",
+          "value": "\"student_compatibility_evidence\".\"operation\" IN ('backfill', 'create', 'update', 'transition')"
+        },
+        "student_compatibility_evidence_parity_check": {
+          "name": "student_compatibility_evidence_parity_check",
+          "value": "\"student_compatibility_evidence\".\"parity_status\" IN ('matched', 'mismatch')"
+        },
+        "student_compatibility_evidence_request_check": {
+          "name": "student_compatibility_evidence_request_check",
+          "value": "btrim(\"student_compatibility_evidence\".\"request_id\") <> ''"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_compatibility_evidence": {
+      "name": "academic_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_value": {
+          "name": "legacy_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_status": {
+          "name": "mapping_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_term_id": {
+          "name": "academic_term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_compatibility_evidence_tenant_school_idx": {
+          "name": "academic_compatibility_evidence_tenant_school_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mapping_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "academic_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "academic_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_school_fk": {
+          "name": "academic_compatibility_evidence_tenant_school_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_year_fk": {
+          "name": "academic_compatibility_evidence_tenant_year_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "tableTo": "academic_years",
+          "columnsFrom": ["tenant_id", "academic_year_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_compatibility_evidence_tenant_term_fk": {
+          "name": "academic_compatibility_evidence_tenant_term_fk",
+          "tableFrom": "academic_compatibility_evidence",
+          "tableTo": "academic_terms",
+          "columnsFrom": ["tenant_id", "academic_term_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_compatibility_evidence_tenant_id_id_unique": {
+          "name": "academic_compatibility_evidence_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "academic_compatibility_evidence_source_unique": {
+          "name": "academic_compatibility_evidence_source_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "source_type", "source_key"]
+        }
+      },
+      "policies": {
+        "academic_compatibility_evidence_runtime_select": {
+          "name": "academic_compatibility_evidence_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_compatibility_evidence\".\"tenant_id\", \"academic_compatibility_evidence\".\"school_id\")\n"
+        },
+        "academic_compatibility_evidence_runtime_insert_deny": {
+          "name": "academic_compatibility_evidence_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_compatibility_evidence_runtime_update_deny": {
+          "name": "academic_compatibility_evidence_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_compatibility_evidence_runtime_delete_deny": {
+          "name": "academic_compatibility_evidence_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_compatibility_evidence_source_type_check": {
+          "name": "academic_compatibility_evidence_source_type_check",
+          "value": "\"academic_compatibility_evidence\".\"source_type\" IN ('school_academic_year', 'school_term', 'class_academic_year')"
+        },
+        "academic_compatibility_evidence_mapping_status_check": {
+          "name": "academic_compatibility_evidence_mapping_status_check",
+          "value": "\"academic_compatibility_evidence\".\"mapping_status\" IN ('mapped', 'unmapped', 'review_required')"
+        },
+        "academic_compatibility_evidence_source_key_check": {
+          "name": "academic_compatibility_evidence_source_key_check",
+          "value": "char_length(btrim(\"academic_compatibility_evidence\".\"source_key\")) BETWEEN 1 AND 256"
+        },
+        "academic_compatibility_evidence_reason_check": {
+          "name": "academic_compatibility_evidence_reason_check",
+          "value": "char_length(btrim(\"academic_compatibility_evidence\".\"reason\")) BETWEEN 3 AND 512"
+        },
+        "academic_compatibility_evidence_mapping_check": {
+          "name": "academic_compatibility_evidence_mapping_check",
+          "value": "\"academic_compatibility_evidence\".\"mapping_status\" <> 'mapped' OR \"academic_compatibility_evidence\".\"academic_year_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_terms": {
+      "name": "academic_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_terms_year_dates_idx": {
+          "name": "academic_terms_year_dates_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "academic_terms_tenant_id_tenants_id_fk": {
+          "name": "academic_terms_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_terms",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_terms_tenant_school_year_fk": {
+          "name": "academic_terms_tenant_school_year_fk",
+          "tableFrom": "academic_terms",
+          "tableTo": "academic_years",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_terms_tenant_id_id_unique": {
+          "name": "academic_terms_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "academic_terms_tenant_school_id_id_unique": {
+          "name": "academic_terms_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "academic_terms_year_code_unique": {
+          "name": "academic_terms_year_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "code"]
+        },
+        "academic_terms_year_ordinal_unique": {
+          "name": "academic_terms_year_ordinal_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "ordinal"]
+        }
+      },
+      "policies": {
+        "academic_terms_runtime_select": {
+          "name": "academic_terms_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_runtime_insert_deny": {
+          "name": "academic_terms_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_terms_runtime_update_deny": {
+          "name": "academic_terms_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_terms_runtime_delete_deny": {
+          "name": "academic_terms_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "academic_terms_configurator_select": {
+          "name": "academic_terms_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_section_manager_select": {
+          "name": "academic_terms_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_configurator_insert": {
+          "name": "academic_terms_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_terms\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_terms\".\"tenant_id\", \"academic_terms\".\"school_id\")\n"
+        },
+        "academic_terms_configurator_update_deny": {
+          "name": "academic_terms_configurator_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_terms_configurator_delete_deny": {
+          "name": "academic_terms_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_terms_code_check": {
+          "name": "academic_terms_code_check",
+          "value": "char_length(btrim(\"academic_terms\".\"code\")) BETWEEN 1 AND 64 AND \"academic_terms\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "academic_terms_name_check": {
+          "name": "academic_terms_name_check",
+          "value": "char_length(btrim(\"academic_terms\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "academic_terms_ordinal_check": {
+          "name": "academic_terms_ordinal_check",
+          "value": "\"academic_terms\".\"ordinal\" BETWEEN 1 AND 20"
+        },
+        "academic_terms_dates_check": {
+          "name": "academic_terms_dates_check",
+          "value": "\"academic_terms\".\"end_date\" >= \"academic_terms\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.academic_years": {
+      "name": "academic_years",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "migration_review_status": {
+          "name": "migration_review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "legacy_academic_year": {
+          "name": "legacy_academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by_account_id": {
+          "name": "published_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "academic_years_tenant_school_status_dates_idx": {
+          "name": "academic_years_tenant_school_status_dates_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "academic_years_tenant_id_tenants_id_fk": {
+          "name": "academic_years_tenant_id_tenants_id_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_years_created_by_account_id_accounts_id_fk": {
+          "name": "academic_years_created_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_years_published_by_account_id_accounts_id_fk": {
+          "name": "academic_years_published_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "accounts",
+          "columnsFrom": ["published_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_years_closed_by_account_id_accounts_id_fk": {
+          "name": "academic_years_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "accounts",
+          "columnsFrom": ["closed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "academic_years_tenant_school_fk": {
+          "name": "academic_years_tenant_school_fk",
+          "tableFrom": "academic_years",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_years_tenant_id_id_unique": {
+          "name": "academic_years_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "academic_years_tenant_school_id_id_unique": {
+          "name": "academic_years_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "academic_years_tenant_school_code_unique": {
+          "name": "academic_years_tenant_school_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "code"]
+        }
+      },
+      "policies": {
+        "academic_years_runtime_select": {
+          "name": "academic_years_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_runtime_insert_deny": {
+          "name": "academic_years_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "academic_years_runtime_update_deny": {
+          "name": "academic_years_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "academic_years_runtime_delete_deny": {
+          "name": "academic_years_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "academic_years_configurator_select": {
+          "name": "academic_years_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_section_manager_select": {
+          "name": "academic_years_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_insert": {
+          "name": "academic_years_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_update": {
+          "name": "academic_years_configurator_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"academic_years\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"academic_years\".\"tenant_id\", \"academic_years\".\"school_id\")\n"
+        },
+        "academic_years_configurator_delete_deny": {
+          "name": "academic_years_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "academic_years_code_check": {
+          "name": "academic_years_code_check",
+          "value": "char_length(btrim(\"academic_years\".\"code\")) BETWEEN 1 AND 64 AND \"academic_years\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "academic_years_name_check": {
+          "name": "academic_years_name_check",
+          "value": "char_length(btrim(\"academic_years\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "academic_years_timezone_check": {
+          "name": "academic_years_timezone_check",
+          "value": "char_length(btrim(\"academic_years\".\"time_zone\")) BETWEEN 1 AND 128"
+        },
+        "academic_years_dates_check": {
+          "name": "academic_years_dates_check",
+          "value": "\"academic_years\".\"end_date\" >= \"academic_years\".\"start_date\""
+        },
+        "academic_years_status_check": {
+          "name": "academic_years_status_check",
+          "value": "\"academic_years\".\"status\" IN ('draft', 'published', 'closed')"
+        },
+        "academic_years_source_check": {
+          "name": "academic_years_source_check",
+          "value": "\"academic_years\".\"source\" IN ('native', 'legacy_backfill')"
+        },
+        "academic_years_review_check": {
+          "name": "academic_years_review_check",
+          "value": "\"academic_years\".\"migration_review_status\" IN ('not_required', 'needs_review', 'approved')"
+        },
+        "academic_years_review_source_check": {
+          "name": "academic_years_review_source_check",
+          "value": "\"academic_years\".\"source\" = 'legacy_backfill' OR \"academic_years\".\"migration_review_status\" = 'not_required'"
+        },
+        "academic_years_publish_evidence_check": {
+          "name": "academic_years_publish_evidence_check",
+          "value": "\"academic_years\".\"status\" = 'draft' OR (\"academic_years\".\"published_at\" IS NOT NULL AND \"academic_years\".\"published_by_account_id\" IS NOT NULL)"
+        },
+        "academic_years_close_evidence_check": {
+          "name": "academic_years_close_evidence_check",
+          "value": "\"academic_years\".\"status\" <> 'closed' OR (\"academic_years\".\"closed_at\" IS NOT NULL AND \"academic_years\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"academic_years\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.learner_levels": {
+      "name": "learner_levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_stage": {
+          "name": "education_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "learner_levels_year_order_idx": {
+          "name": "learner_levels_year_order_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "learner_levels_tenant_id_tenants_id_fk": {
+          "name": "learner_levels_tenant_id_tenants_id_fk",
+          "tableFrom": "learner_levels",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "learner_levels_tenant_school_year_fk": {
+          "name": "learner_levels_tenant_school_year_fk",
+          "tableFrom": "learner_levels",
+          "tableTo": "academic_years",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "learner_levels_tenant_id_id_unique": {
+          "name": "learner_levels_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "learner_levels_tenant_school_id_id_unique": {
+          "name": "learner_levels_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "learner_levels_year_code_unique": {
+          "name": "learner_levels_year_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "code"]
+        },
+        "learner_levels_year_ordinal_unique": {
+          "name": "learner_levels_year_ordinal_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "ordinal"]
+        }
+      },
+      "policies": {
+        "learner_levels_runtime_select": {
+          "name": "learner_levels_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN (\n  'tenant.academic_structure.read', 'tenant.academic_structure.manage',\n  'tenant.sections.read', 'tenant.sections.manage'\n)\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_runtime_insert_deny": {
+          "name": "learner_levels_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "learner_levels_runtime_update_deny": {
+          "name": "learner_levels_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "learner_levels_runtime_delete_deny": {
+          "name": "learner_levels_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "learner_levels_configurator_select": {
+          "name": "learner_levels_configurator_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_academic_configurator"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_section_manager_select": {
+          "name": "learner_levels_section_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_configurator_insert": {
+          "name": "learner_levels_configurator_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_academic_configurator"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_academic_configurator'\n  AND \"learner_levels\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    = 'tenant.academic_structure.manage'\n  AND public.openschool_school_scope_allows(\"learner_levels\".\"tenant_id\", \"learner_levels\".\"school_id\")\n"
+        },
+        "learner_levels_configurator_update_deny": {
+          "name": "learner_levels_configurator_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "learner_levels_configurator_delete_deny": {
+          "name": "learner_levels_configurator_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_academic_configurator"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "learner_levels_code_check": {
+          "name": "learner_levels_code_check",
+          "value": "char_length(btrim(\"learner_levels\".\"code\")) BETWEEN 1 AND 64 AND \"learner_levels\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "learner_levels_name_check": {
+          "name": "learner_levels_name_check",
+          "value": "char_length(btrim(\"learner_levels\".\"name\")) BETWEEN 1 AND 128"
+        },
+        "learner_levels_ordinal_check": {
+          "name": "learner_levels_ordinal_check",
+          "value": "\"learner_levels\".\"ordinal\" BETWEEN 1 AND 30"
+        },
+        "learner_levels_stage_check": {
+          "name": "learner_levels_stage_check",
+          "value": "\"learner_levels\".\"education_stage\" IS NULL OR char_length(btrim(\"learner_levels\".\"education_stage\")) BETWEEN 1 AND 64"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_type": {
+          "name": "course_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_area": {
+          "name": "subject_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_value": {
+          "name": "credit_value",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by_account_id": {
+          "name": "archived_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "courses_tenant_school_status_name_idx": {
+          "name": "courses_tenant_school_status_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "courses_tenant_id_tenants_id_fk": {
+          "name": "courses_tenant_id_tenants_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "courses_created_by_account_id_accounts_id_fk": {
+          "name": "courses_created_by_account_id_accounts_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "courses_archived_by_account_id_accounts_id_fk": {
+          "name": "courses_archived_by_account_id_accounts_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "accounts",
+          "columnsFrom": ["archived_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "courses_tenant_school_fk": {
+          "name": "courses_tenant_school_fk",
+          "tableFrom": "courses",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "courses_tenant_id_id_unique": {
+          "name": "courses_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "courses_tenant_school_id_id_unique": {
+          "name": "courses_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "courses_tenant_school_code_unique": {
+          "name": "courses_tenant_school_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "code"]
+        }
+      },
+      "policies": {
+        "courses_runtime_select": {
+          "name": "courses_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_course_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\", \"courses\".\"id\")\n      "
+        },
+        "courses_runtime_write_deny": {
+          "name": "courses_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "courses_manager_all": {
+          "name": "courses_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"courses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"courses\".\"tenant_id\", \"courses\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "courses_code_check": {
+          "name": "courses_code_check",
+          "value": "char_length(btrim(\"courses\".\"code\")) BETWEEN 1 AND 64 AND \"courses\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "courses_name_check": {
+          "name": "courses_name_check",
+          "value": "char_length(btrim(\"courses\".\"name\")) BETWEEN 1 AND 160"
+        },
+        "courses_type_check": {
+          "name": "courses_type_check",
+          "value": "\"courses\".\"course_type\" IN ('general', 'subject', 'elective', 'support')"
+        },
+        "courses_status_check": {
+          "name": "courses_status_check",
+          "value": "\"courses\".\"status\" IN ('active', 'archived')"
+        },
+        "courses_credit_check": {
+          "name": "courses_credit_check",
+          "value": "\"courses\".\"credit_value\" IS NULL OR (\"courses\".\"credit_value\" >= 0 AND \"courses\".\"credit_value\" <= 100)"
+        },
+        "courses_creation_reason_check": {
+          "name": "courses_creation_reason_check",
+          "value": "char_length(btrim(\"courses\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "courses_archive_evidence_check": {
+          "name": "courses_archive_evidence_check",
+          "value": "\"courses\".\"status\" <> 'archived' OR (\"courses\".\"archived_at\" IS NOT NULL AND \"courses\".\"archived_by_account_id\" IS NOT NULL AND char_length(btrim(\"courses\".\"archive_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_compatibility_evidence": {
+      "name": "section_compatibility_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_class_id": {
+          "name": "legacy_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapping_status": {
+          "name": "mapping_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_roster_count": {
+          "name": "legacy_roster_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_roster_count": {
+          "name": "canonical_roster_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_roster_hash": {
+          "name": "legacy_roster_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_roster_hash": {
+          "name": "canonical_roster_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_compatibility_tenant_school_status_idx": {
+          "name": "section_compatibility_tenant_school_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mapping_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_compatibility_evidence_tenant_id_tenants_id_fk": {
+          "name": "section_compatibility_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_compatibility_tenant_school_fk": {
+          "name": "section_compatibility_tenant_school_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_compatibility_tenant_legacy_class_fk": {
+          "name": "section_compatibility_tenant_legacy_class_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "legacy_class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_compatibility_tenant_section_fk": {
+          "name": "section_compatibility_tenant_section_fk",
+          "tableFrom": "section_compatibility_evidence",
+          "tableTo": "sections",
+          "columnsFrom": ["tenant_id", "section_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_compatibility_tenant_id_id_unique": {
+          "name": "section_compatibility_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "section_compatibility_legacy_class_unique": {
+          "name": "section_compatibility_legacy_class_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_class_id"]
+        }
+      },
+      "policies": {
+        "section_compatibility_runtime_select": {
+          "name": "section_compatibility_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"section_compatibility_evidence\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_school_scope_allows(\"section_compatibility_evidence\".\"tenant_id\", \"section_compatibility_evidence\".\"school_id\")\n      "
+        },
+        "section_compatibility_runtime_write_deny": {
+          "name": "section_compatibility_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        }
+      },
+      "checkConstraints": {
+        "section_compatibility_status_check": {
+          "name": "section_compatibility_status_check",
+          "value": "\"section_compatibility_evidence\".\"mapping_status\" IN ('mapped', 'unmapped', 'review_required')"
+        },
+        "section_compatibility_counts_check": {
+          "name": "section_compatibility_counts_check",
+          "value": "\"section_compatibility_evidence\".\"legacy_roster_count\" >= 0 AND \"section_compatibility_evidence\".\"canonical_roster_count\" >= 0"
+        },
+        "section_compatibility_mapping_check": {
+          "name": "section_compatibility_mapping_check",
+          "value": "\"section_compatibility_evidence\".\"mapping_status\" <> 'mapped' OR (\"section_compatibility_evidence\".\"section_id\" IS NOT NULL AND \"section_compatibility_evidence\".\"legacy_roster_count\" = \"section_compatibility_evidence\".\"canonical_roster_count\" AND \"section_compatibility_evidence\".\"legacy_roster_hash\" = \"section_compatibility_evidence\".\"canonical_roster_hash\")"
+        },
+        "section_compatibility_reason_check": {
+          "name": "section_compatibility_reason_check",
+          "value": "char_length(btrim(\"section_compatibility_evidence\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_roster_memberships": {
+      "name": "section_roster_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_enrollment_id": {
+          "name": "school_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_key": {
+          "name": "roster_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_enrollment_id": {
+          "name": "legacy_enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_rosters_tenant_section_effective_idx": {
+          "name": "section_rosters_tenant_section_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_rosters_tenant_person_effective_idx": {
+          "name": "section_rosters_tenant_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_roster_memberships_tenant_id_tenants_id_fk": {
+          "name": "section_roster_memberships_tenant_id_tenants_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_roster_memberships_issued_by_account_id_accounts_id_fk": {
+          "name": "section_roster_memberships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_roster_memberships_ended_by_account_id_accounts_id_fk": {
+          "name": "section_roster_memberships_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_rosters_tenant_section_fk": {
+          "name": "section_rosters_tenant_section_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "sections",
+          "columnsFrom": ["tenant_id", "school_id", "section_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_rosters_tenant_person_fk": {
+          "name": "section_rosters_tenant_person_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_rosters_tenant_school_enrollment_fk": {
+          "name": "section_rosters_tenant_school_enrollment_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "school_enrollments",
+          "columnsFrom": ["tenant_id", "school_enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_rosters_tenant_legacy_enrollment_fk": {
+          "name": "section_rosters_tenant_legacy_enrollment_fk",
+          "tableFrom": "section_roster_memberships",
+          "tableTo": "enrollments",
+          "columnsFrom": ["tenant_id", "legacy_enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_rosters_tenant_id_id_unique": {
+          "name": "section_rosters_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "section_rosters_key_version_unique": {
+          "name": "section_rosters_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "roster_key", "version"]
+        },
+        "section_rosters_legacy_enrollment_unique": {
+          "name": "section_rosters_legacy_enrollment_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_enrollment_id"]
+        }
+      },
+      "policies": {
+        "section_rosters_runtime_select": {
+          "name": "section_rosters_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.sections.read', 'tenant.sections.manage')\n        AND public.openschool_section_roster_scope_allows(\n          \"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\", \"section_roster_memberships\".\"section_id\", \"section_roster_memberships\".\"person_id\"\n        )\n      "
+        },
+        "section_rosters_runtime_write_deny": {
+          "name": "section_rosters_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "section_rosters_manager_all": {
+          "name": "section_rosters_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_roster_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_roster_memberships\".\"tenant_id\", \"section_roster_memberships\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "section_rosters_period_check": {
+          "name": "section_rosters_period_check",
+          "value": "\"section_roster_memberships\".\"valid_until\" IS NULL OR \"section_roster_memberships\".\"valid_until\" > \"section_roster_memberships\".\"valid_from\""
+        },
+        "section_rosters_status_check": {
+          "name": "section_rosters_status_check",
+          "value": "\"section_roster_memberships\".\"status\" IN ('active', 'ended')"
+        },
+        "section_rosters_end_evidence_check": {
+          "name": "section_rosters_end_evidence_check",
+          "value": "\"section_roster_memberships\".\"status\" <> 'ended' OR (\"section_roster_memberships\".\"valid_until\" IS NOT NULL AND \"section_roster_memberships\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"section_roster_memberships\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "section_rosters_version_positive": {
+          "name": "section_rosters_version_positive",
+          "value": "\"section_roster_memberships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.section_staff_assignments": {
+      "name": "section_staff_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_key": {
+          "name": "assignment_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_teacher_class_id": {
+          "name": "legacy_teacher_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "section_staff_tenant_section_effective_idx": {
+          "name": "section_staff_tenant_section_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_staff_assignments_tenant_id_tenants_id_fk": {
+          "name": "section_staff_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_assignments_issued_by_account_id_accounts_id_fk": {
+          "name": "section_staff_assignments_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_assignments_ended_by_account_id_accounts_id_fk": {
+          "name": "section_staff_assignments_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_tenant_section_fk": {
+          "name": "section_staff_tenant_section_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "sections",
+          "columnsFrom": ["tenant_id", "school_id", "section_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_tenant_person_fk": {
+          "name": "section_staff_tenant_person_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "section_staff_tenant_legacy_assignment_fk": {
+          "name": "section_staff_tenant_legacy_assignment_fk",
+          "tableFrom": "section_staff_assignments",
+          "tableTo": "teachers_on_class",
+          "columnsFrom": ["tenant_id", "legacy_teacher_class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "section_staff_tenant_id_id_unique": {
+          "name": "section_staff_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "section_staff_key_version_unique": {
+          "name": "section_staff_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "assignment_key", "version"]
+        },
+        "section_staff_legacy_assignment_unique": {
+          "name": "section_staff_legacy_assignment_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_teacher_class_id"]
+        }
+      },
+      "policies": {
+        "section_staff_runtime_select": {
+          "name": "section_staff_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.sections.read', 'tenant.sections.manage')\n  AND public.openschool_section_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\", \"section_staff_assignments\".\"section_id\")\n"
+        },
+        "section_staff_runtime_write_deny": {
+          "name": "section_staff_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "section_staff_manager_all": {
+          "name": "section_staff_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"section_staff_assignments\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"section_staff_assignments\".\"tenant_id\", \"section_staff_assignments\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "section_staff_role_check": {
+          "name": "section_staff_role_check",
+          "value": "\"section_staff_assignments\".\"role\" IN ('lead_teacher', 'teacher', 'assistant', 'counselor')"
+        },
+        "section_staff_status_check": {
+          "name": "section_staff_status_check",
+          "value": "\"section_staff_assignments\".\"status\" IN ('active', 'ended')"
+        },
+        "section_staff_period_check": {
+          "name": "section_staff_period_check",
+          "value": "\"section_staff_assignments\".\"valid_until\" IS NULL OR \"section_staff_assignments\".\"valid_until\" > \"section_staff_assignments\".\"valid_from\""
+        },
+        "section_staff_end_evidence_check": {
+          "name": "section_staff_end_evidence_check",
+          "value": "\"section_staff_assignments\".\"status\" <> 'ended' OR (\"section_staff_assignments\".\"valid_until\" IS NOT NULL AND \"section_staff_assignments\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"section_staff_assignments\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "section_staff_version_positive": {
+          "name": "section_staff_version_positive",
+          "value": "\"section_staff_assignments\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year_id": {
+          "name": "academic_year_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_term_id": {
+          "name": "academic_term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learner_level_id": {
+          "name": "learner_level_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "legacy_class_id": {
+          "name": "legacy_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_by_account_id": {
+          "name": "activated_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sections_tenant_school_year_status_idx": {
+          "name": "sections_tenant_school_year_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sections_tenant_id_tenants_id_fk": {
+          "name": "sections_tenant_id_tenants_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_created_by_account_id_accounts_id_fk": {
+          "name": "sections_created_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_activated_by_account_id_accounts_id_fk": {
+          "name": "sections_activated_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "accounts",
+          "columnsFrom": ["activated_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_closed_by_account_id_accounts_id_fk": {
+          "name": "sections_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "accounts",
+          "columnsFrom": ["closed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_fk": {
+          "name": "sections_tenant_school_fk",
+          "tableFrom": "sections",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_year_fk": {
+          "name": "sections_tenant_school_year_fk",
+          "tableFrom": "sections",
+          "tableTo": "academic_years",
+          "columnsFrom": ["tenant_id", "school_id", "academic_year_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_term_fk": {
+          "name": "sections_tenant_school_term_fk",
+          "tableFrom": "sections",
+          "tableTo": "academic_terms",
+          "columnsFrom": ["tenant_id", "school_id", "academic_term_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_level_fk": {
+          "name": "sections_tenant_school_level_fk",
+          "tableFrom": "sections",
+          "tableTo": "learner_levels",
+          "columnsFrom": ["tenant_id", "school_id", "learner_level_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_school_course_fk": {
+          "name": "sections_tenant_school_course_fk",
+          "tableFrom": "sections",
+          "tableTo": "courses",
+          "columnsFrom": ["tenant_id", "school_id", "course_id"],
+          "columnsTo": ["tenant_id", "school_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "sections_tenant_legacy_class_fk": {
+          "name": "sections_tenant_legacy_class_fk",
+          "tableFrom": "sections",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "legacy_class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sections_tenant_id_id_unique": {
+          "name": "sections_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "sections_tenant_school_id_id_unique": {
+          "name": "sections_tenant_school_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "school_id", "id"]
+        },
+        "sections_year_code_unique": {
+          "name": "sections_year_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "academic_year_id", "code"]
+        },
+        "sections_legacy_class_unique": {
+          "name": "sections_legacy_class_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "legacy_class_id"]
+        }
+      },
+      "policies": {
+        "sections_runtime_select": {
+          "name": "sections_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.sections.read', 'tenant.sections.manage')\n  AND public.openschool_section_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\", \"sections\".\"id\")\n"
+        },
+        "sections_runtime_write_deny": {
+          "name": "sections_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "sections_manager_all": {
+          "name": "sections_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_section_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_section_manager'\n  AND \"sections\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.sections.manage'\n  AND public.openschool_school_scope_allows(\"sections\".\"tenant_id\", \"sections\".\"school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "sections_code_check": {
+          "name": "sections_code_check",
+          "value": "char_length(btrim(\"sections\".\"code\")) BETWEEN 1 AND 64 AND \"sections\".\"code\" ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'"
+        },
+        "sections_name_check": {
+          "name": "sections_name_check",
+          "value": "char_length(btrim(\"sections\".\"name\")) BETWEEN 1 AND 160"
+        },
+        "sections_type_check": {
+          "name": "sections_type_check",
+          "value": "\"sections\".\"section_type\" IN ('homeroom', 'course')"
+        },
+        "sections_course_requirement_check": {
+          "name": "sections_course_requirement_check",
+          "value": "\"sections\".\"section_type\" <> 'course' OR \"sections\".\"course_id\" IS NOT NULL"
+        },
+        "sections_dates_check": {
+          "name": "sections_dates_check",
+          "value": "\"sections\".\"end_date\" >= \"sections\".\"start_date\""
+        },
+        "sections_status_check": {
+          "name": "sections_status_check",
+          "value": "\"sections\".\"status\" IN ('draft', 'active', 'closed')"
+        },
+        "sections_capacity_check": {
+          "name": "sections_capacity_check",
+          "value": "\"sections\".\"capacity\" IS NULL OR \"sections\".\"capacity\" > 0"
+        },
+        "sections_version_positive": {
+          "name": "sections_version_positive",
+          "value": "\"sections\".\"version\" > 0"
+        },
+        "sections_source_check": {
+          "name": "sections_source_check",
+          "value": "\"sections\".\"source\" IN ('native', 'legacy_backfill') AND (\"sections\".\"source\" <> 'legacy_backfill' OR \"sections\".\"legacy_class_id\" IS NOT NULL)"
+        },
+        "sections_creation_reason_check": {
+          "name": "sections_creation_reason_check",
+          "value": "char_length(btrim(\"sections\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "sections_activation_evidence_check": {
+          "name": "sections_activation_evidence_check",
+          "value": "\"sections\".\"status\" = 'draft' OR (\"sections\".\"activated_at\" IS NOT NULL AND \"sections\".\"activated_by_account_id\" IS NOT NULL)"
+        },
+        "sections_closure_evidence_check": {
+          "name": "sections_closure_evidence_check",
+          "value": "\"sections\".\"status\" <> 'closed' OR (\"sections\".\"closed_at\" IS NOT NULL AND \"sections\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"sections\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_duplicate_case_events": {
+      "name": "person_duplicate_case_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signals": {
+          "name": "signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_hash": {
+          "name": "evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_duplicate_case_events_history_idx": {
+          "name": "person_duplicate_case_events_history_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_duplicate_case_events_tenant_id_tenants_id_fk": {
+          "name": "person_duplicate_case_events_tenant_id_tenants_id_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_case_events_actor_account_id_accounts_id_fk": {
+          "name": "person_duplicate_case_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_case_events_tenant_case_fk": {
+          "name": "person_duplicate_case_events_tenant_case_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "tableTo": "person_duplicate_cases",
+          "columnsFrom": ["tenant_id", "case_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_case_events_tenant_school_fk": {
+          "name": "person_duplicate_case_events_tenant_school_fk",
+          "tableFrom": "person_duplicate_case_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_duplicate_case_events_tenant_id_id_unique": {
+          "name": "person_duplicate_case_events_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_duplicate_case_events_case_version_unique": {
+          "name": "person_duplicate_case_events_case_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "case_id", "version"]
+        }
+      },
+      "policies": {
+        "person_duplicate_case_events_runtime_select": {
+          "name": "person_duplicate_case_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_duplicates.read',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        },
+        "person_duplicate_case_events_runtime_write_deny": {
+          "name": "person_duplicate_case_events_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_duplicate_case_events_manager_select": {
+          "name": "person_duplicate_case_events_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_duplicate_review_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        },
+        "person_duplicate_case_events_manager_insert": {
+          "name": "person_duplicate_case_events_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_duplicate_review_manager"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_case_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_case_events\".\"tenant_id\", \"person_duplicate_case_events\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_duplicate_case_events_version_check": {
+          "name": "person_duplicate_case_events_version_check",
+          "value": "\"person_duplicate_case_events\".\"version\" > 0"
+        },
+        "person_duplicate_case_events_type_check": {
+          "name": "person_duplicate_case_events_type_check",
+          "value": "\"person_duplicate_case_events\".\"event_type\" IN ('candidate_detected', 'evidence_refreshed', 'evidence_no_longer_matches', 'marked_distinct', 'merge_approval_requested', 'merge_executed')"
+        },
+        "person_duplicate_case_events_score_check": {
+          "name": "person_duplicate_case_events_score_check",
+          "value": "\"person_duplicate_case_events\".\"score\" BETWEEN 0 AND 100"
+        },
+        "person_duplicate_case_events_signals_check": {
+          "name": "person_duplicate_case_events_signals_check",
+          "value": "jsonb_typeof(\"person_duplicate_case_events\".\"signals\") = 'array' AND jsonb_array_length(\"person_duplicate_case_events\".\"signals\") <= 4"
+        },
+        "person_duplicate_case_events_hash_check": {
+          "name": "person_duplicate_case_events_hash_check",
+          "value": "\"person_duplicate_case_events\".\"evidence_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_duplicate_case_events_reason_check": {
+          "name": "person_duplicate_case_events_reason_check",
+          "value": "char_length(btrim(\"person_duplicate_case_events\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_duplicate_cases": {
+      "name": "person_duplicate_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_person_id": {
+          "name": "first_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_person_id": {
+          "name": "second_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_score": {
+          "name": "current_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_signals": {
+          "name": "current_signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_evidence_hash": {
+          "name": "current_evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_duplicate_cases_queue_idx": {
+          "name": "person_duplicate_cases_queue_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_duplicate_cases_first_person_idx": {
+          "name": "person_duplicate_cases_first_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_duplicate_cases_second_person_idx": {
+          "name": "person_duplicate_cases_second_person_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "second_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_duplicate_cases_tenant_id_tenants_id_fk": {
+          "name": "person_duplicate_cases_tenant_id_tenants_id_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_cases_created_by_account_id_accounts_id_fk": {
+          "name": "person_duplicate_cases_created_by_account_id_accounts_id_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_cases_tenant_school_fk": {
+          "name": "person_duplicate_cases_tenant_school_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_cases_tenant_first_person_fk": {
+          "name": "person_duplicate_cases_tenant_first_person_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "first_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_duplicate_cases_tenant_second_person_fk": {
+          "name": "person_duplicate_cases_tenant_second_person_fk",
+          "tableFrom": "person_duplicate_cases",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "second_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_duplicate_cases_tenant_id_id_unique": {
+          "name": "person_duplicate_cases_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_duplicate_cases_school_pair_unique": {
+          "name": "person_duplicate_cases_school_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "review_school_id", "first_person_id", "second_person_id"]
+        }
+      },
+      "policies": {
+        "person_duplicate_cases_runtime_select": {
+          "name": "person_duplicate_cases_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_duplicates.read',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n"
+        },
+        "person_duplicate_cases_runtime_write_deny": {
+          "name": "person_duplicate_cases_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_duplicate_cases_manager_all": {
+          "name": "person_duplicate_cases_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_duplicate_review_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_duplicate_review_manager'\n  AND \"person_duplicate_cases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.students.create',\n    'tenant.students.update',\n    'tenant.guardian_contacts.manage',\n    'tenant.people_duplicates.review'\n  )\n  AND public.openschool_school_scope_allows(\"person_duplicate_cases\".\"tenant_id\", \"person_duplicate_cases\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_duplicate_cases_pair_order_check": {
+          "name": "person_duplicate_cases_pair_order_check",
+          "value": "\"person_duplicate_cases\".\"first_person_id\"::text < \"person_duplicate_cases\".\"second_person_id\"::text"
+        },
+        "person_duplicate_cases_status_check": {
+          "name": "person_duplicate_cases_status_check",
+          "value": "\"person_duplicate_cases\".\"status\" IN ('open', 'distinct', 'merge_approval_requested', 'superseded')"
+        },
+        "person_duplicate_cases_version_check": {
+          "name": "person_duplicate_cases_version_check",
+          "value": "\"person_duplicate_cases\".\"current_version\" > 0"
+        },
+        "person_duplicate_cases_score_check": {
+          "name": "person_duplicate_cases_score_check",
+          "value": "\"person_duplicate_cases\".\"current_score\" BETWEEN 0 AND 100"
+        },
+        "person_duplicate_cases_signals_check": {
+          "name": "person_duplicate_cases_signals_check",
+          "value": "jsonb_typeof(\"person_duplicate_cases\".\"current_signals\") = 'array' AND jsonb_array_length(\"person_duplicate_cases\".\"current_signals\") <= 4"
+        },
+        "person_duplicate_cases_hash_check": {
+          "name": "person_duplicate_cases_hash_check",
+          "value": "\"person_duplicate_cases\".\"current_evidence_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_aliases": {
+      "name": "person_merge_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_by_account_id": {
+          "name": "reversed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_aliases_target_idx": {
+          "name": "person_merge_aliases_target_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_aliases_tenant_id_tenants_id_fk": {
+          "name": "person_merge_aliases_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_reversed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_aliases_reversed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "accounts",
+          "columnsFrom": ["reversed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_tenant_operation_fk": {
+          "name": "person_merge_aliases_tenant_operation_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_tenant_school_fk": {
+          "name": "person_merge_aliases_tenant_school_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_tenant_source_fk": {
+          "name": "person_merge_aliases_tenant_source_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_aliases_tenant_target_fk": {
+          "name": "person_merge_aliases_tenant_target_fk",
+          "tableFrom": "person_merge_aliases",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_aliases_tenant_id_id_unique": {
+          "name": "person_merge_aliases_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_merge_aliases_tenant_source_unique": {
+          "name": "person_merge_aliases_tenant_source_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "source_person_id"]
+        },
+        "person_merge_aliases_tenant_operation_unique": {
+          "name": "person_merge_aliases_tenant_operation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id"]
+        }
+      },
+      "policies": {
+        "person_merge_aliases_runtime_select": {
+          "name": "person_merge_aliases_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n"
+        },
+        "person_merge_aliases_runtime_write_deny": {
+          "name": "person_merge_aliases_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_aliases_manager_all": {
+          "name": "person_merge_aliases_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_aliases\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_aliases\".\"tenant_id\", \"person_merge_aliases\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_aliases_people_check": {
+          "name": "person_merge_aliases_people_check",
+          "value": "\"person_merge_aliases\".\"source_person_id\" <> \"person_merge_aliases\".\"target_person_id\""
+        },
+        "person_merge_aliases_status_check": {
+          "name": "person_merge_aliases_status_check",
+          "value": "\"person_merge_aliases\".\"status\" IN ('active', 'reversed')"
+        },
+        "person_merge_aliases_version_check": {
+          "name": "person_merge_aliases_version_check",
+          "value": "\"person_merge_aliases\".\"version\" > 0"
+        },
+        "person_merge_aliases_reversal_check": {
+          "name": "person_merge_aliases_reversal_check",
+          "value": "\"person_merge_aliases\".\"status\" <> 'reversed'\n        OR (\"person_merge_aliases\".\"reversed_at\" IS NOT NULL AND \"person_merge_aliases\".\"reversed_by_account_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_events": {
+      "name": "person_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_status": {
+          "name": "operation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_digest": {
+          "name": "preview_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_events_operation_idx": {
+          "name": "person_merge_events_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_events_tenant_id_tenants_id_fk": {
+          "name": "person_merge_events_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_events_actor_account_id_accounts_id_fk": {
+          "name": "person_merge_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_events_tenant_operation_fk": {
+          "name": "person_merge_events_tenant_operation_fk",
+          "tableFrom": "person_merge_events",
+          "tableTo": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_events_tenant_school_fk": {
+          "name": "person_merge_events_tenant_school_fk",
+          "tableFrom": "person_merge_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_events_tenant_id_id_unique": {
+          "name": "person_merge_events_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_merge_events_operation_version_unique": {
+          "name": "person_merge_events_operation_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id", "version"]
+        }
+      },
+      "policies": {
+        "person_merge_events_runtime_select": {
+          "name": "person_merge_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n"
+        },
+        "person_merge_events_runtime_write_deny": {
+          "name": "person_merge_events_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_events_manager_all": {
+          "name": "person_merge_events_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_events\".\"tenant_id\", \"person_merge_events\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_events_version_check": {
+          "name": "person_merge_events_version_check",
+          "value": "\"person_merge_events\".\"version\" > 0"
+        },
+        "person_merge_events_type_check": {
+          "name": "person_merge_events_type_check",
+          "value": "\"person_merge_events\".\"event_type\" IN ('preview_created', 'approval_granted', 'executed', 'reversal_requested', 'reversed', 'manual_recovery_required')"
+        },
+        "person_merge_events_status_check": {
+          "name": "person_merge_events_status_check",
+          "value": "\"person_merge_events\".\"operation_status\" IN ('blocked', 'pending_approval', 'approved', 'executed', 'reversed', 'manual_recovery')"
+        },
+        "person_merge_events_hash_check": {
+          "name": "person_merge_events_hash_check",
+          "value": "\"person_merge_events\".\"preview_digest\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_merge_events_reason_check": {
+          "name": "person_merge_events_reason_check",
+          "value": "char_length(btrim(\"person_merge_events\".\"reason\")) BETWEEN 3 AND 512"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_moves": {
+      "name": "person_merge_moves",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_name": {
+          "name": "relation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_key": {
+          "name": "source_record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_record_key": {
+          "name": "replacement_record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_fingerprint": {
+          "name": "before_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after_fingerprint": {
+          "name": "after_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_moves_operation_idx": {
+          "name": "person_merge_moves_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_moves_tenant_id_tenants_id_fk": {
+          "name": "person_merge_moves_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_moves",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_moves_tenant_operation_fk": {
+          "name": "person_merge_moves_tenant_operation_fk",
+          "tableFrom": "person_merge_moves",
+          "tableTo": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_moves_tenant_school_fk": {
+          "name": "person_merge_moves_tenant_school_fk",
+          "tableFrom": "person_merge_moves",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_moves_tenant_id_id_unique": {
+          "name": "person_merge_moves_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_merge_moves_operation_sequence_unique": {
+          "name": "person_merge_moves_operation_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id", "sequence"]
+        },
+        "person_merge_moves_operation_record_unique": {
+          "name": "person_merge_moves_operation_record_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id", "relation_name", "source_record_key"]
+        }
+      },
+      "policies": {
+        "person_merge_moves_runtime_select": {
+          "name": "person_merge_moves_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n"
+        },
+        "person_merge_moves_runtime_write_deny": {
+          "name": "person_merge_moves_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_moves_manager_all": {
+          "name": "person_merge_moves_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_moves\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_moves\".\"tenant_id\", \"person_merge_moves\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_moves_sequence_check": {
+          "name": "person_merge_moves_sequence_check",
+          "value": "\"person_merge_moves\".\"sequence\" > 0"
+        },
+        "person_merge_moves_action_check": {
+          "name": "person_merge_moves_action_check",
+          "value": "\"person_merge_moves\".\"action\" IN ('repoint', 'end_and_recreate', 'preserve_history', 'invalidate', 'archive_source')"
+        },
+        "person_merge_moves_text_check": {
+          "name": "person_merge_moves_text_check",
+          "value": "char_length(\"person_merge_moves\".\"relation_name\") BETWEEN 3 AND 128\n        AND char_length(\"person_merge_moves\".\"source_record_key\") BETWEEN 1 AND 512\n        AND (\"person_merge_moves\".\"replacement_record_key\" IS NULL\n          OR char_length(\"person_merge_moves\".\"replacement_record_key\") BETWEEN 1 AND 512)"
+        },
+        "person_merge_moves_hash_check": {
+          "name": "person_merge_moves_hash_check",
+          "value": "\"person_merge_moves\".\"before_fingerprint\" ~ '^[0-9a-f]{64}$'\n        AND \"person_merge_moves\".\"after_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_operations": {
+      "name": "person_merge_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_case_id": {
+          "name": "duplicate_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_case_version": {
+          "name": "duplicate_case_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_evidence_hash": {
+          "name": "duplicate_evidence_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plan_version": {
+          "name": "plan_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "preview_digest": {
+          "name": "preview_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_digest": {
+          "name": "execution_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_count": {
+          "name": "dependency_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "invalidation_count": {
+          "name": "invalidation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "initiated_by_account_id": {
+          "name": "initiated_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiation_reason": {
+          "name": "initiation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by_account_id": {
+          "name": "approved_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_reason": {
+          "name": "approval_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_by_account_id": {
+          "name": "executed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_by_account_id": {
+          "name": "reversed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_operations_active_source_unique": {
+          "name": "person_merge_operations_active_source_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"person_merge_operations\".\"status\" IN ('pending_approval', 'approved', 'executed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_merge_operations_school_status_idx": {
+          "name": "person_merge_operations_school_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_merge_operations_case_idx": {
+          "name": "person_merge_operations_case_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "duplicate_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_operations_tenant_id_tenants_id_fk": {
+          "name": "person_merge_operations_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_initiated_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_initiated_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "accounts",
+          "columnsFrom": ["initiated_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_approved_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_approved_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "accounts",
+          "columnsFrom": ["approved_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_executed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_executed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "accounts",
+          "columnsFrom": ["executed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_reversed_by_account_id_accounts_id_fk": {
+          "name": "person_merge_operations_reversed_by_account_id_accounts_id_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "accounts",
+          "columnsFrom": ["reversed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_tenant_school_fk": {
+          "name": "person_merge_operations_tenant_school_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_tenant_case_fk": {
+          "name": "person_merge_operations_tenant_case_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "person_duplicate_cases",
+          "columnsFrom": ["tenant_id", "duplicate_case_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_tenant_source_fk": {
+          "name": "person_merge_operations_tenant_source_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "source_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_operations_tenant_target_fk": {
+          "name": "person_merge_operations_tenant_target_fk",
+          "tableFrom": "person_merge_operations",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "target_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_operations_tenant_id_id_unique": {
+          "name": "person_merge_operations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {
+        "person_merge_operations_runtime_select": {
+          "name": "person_merge_operations_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n"
+        },
+        "person_merge_operations_runtime_write_deny": {
+          "name": "person_merge_operations_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_operations_manager_all": {
+          "name": "person_merge_operations_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_operations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_operations\".\"tenant_id\", \"person_merge_operations\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_operations_status_check": {
+          "name": "person_merge_operations_status_check",
+          "value": "\"person_merge_operations\".\"status\" IN ('blocked', 'pending_approval', 'approved', 'executed', 'reversed', 'manual_recovery')"
+        },
+        "person_merge_operations_people_check": {
+          "name": "person_merge_operations_people_check",
+          "value": "\"person_merge_operations\".\"source_person_id\" <> \"person_merge_operations\".\"target_person_id\""
+        },
+        "person_merge_operations_version_check": {
+          "name": "person_merge_operations_version_check",
+          "value": "\"person_merge_operations\".\"current_version\" > 0 AND \"person_merge_operations\".\"plan_version\" > 0"
+        },
+        "person_merge_operations_hash_check": {
+          "name": "person_merge_operations_hash_check",
+          "value": "\"person_merge_operations\".\"duplicate_evidence_hash\" ~ '^[0-9a-f]{64}$'\n        AND \"person_merge_operations\".\"preview_digest\" ~ '^[0-9a-f]{64}$'\n        AND (\"person_merge_operations\".\"execution_digest\" IS NULL OR \"person_merge_operations\".\"execution_digest\" ~ '^[0-9a-f]{64}$')"
+        },
+        "person_merge_operations_count_check": {
+          "name": "person_merge_operations_count_check",
+          "value": "\"person_merge_operations\".\"dependency_count\" >= 0 AND \"person_merge_operations\".\"conflict_count\" >= 0\n        AND \"person_merge_operations\".\"conflict_count\" <= \"person_merge_operations\".\"dependency_count\"\n        AND \"person_merge_operations\".\"invalidation_count\" >= 0"
+        },
+        "person_merge_operations_reason_check": {
+          "name": "person_merge_operations_reason_check",
+          "value": "char_length(btrim(\"person_merge_operations\".\"initiation_reason\")) BETWEEN 3 AND 512\n        AND (\"person_merge_operations\".\"approval_reason\" IS NULL OR char_length(btrim(\"person_merge_operations\".\"approval_reason\")) BETWEEN 3 AND 512)"
+        },
+        "person_merge_operations_approval_check": {
+          "name": "person_merge_operations_approval_check",
+          "value": "(\"person_merge_operations\".\"status\" NOT IN ('approved', 'executed', 'reversed', 'manual_recovery'))\n        OR (\"person_merge_operations\".\"approved_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"approval_reason\" IS NOT NULL\n          AND \"person_merge_operations\".\"approved_at\" IS NOT NULL AND \"person_merge_operations\".\"approved_by_account_id\" <> \"person_merge_operations\".\"initiated_by_account_id\")"
+        },
+        "person_merge_operations_execution_check": {
+          "name": "person_merge_operations_execution_check",
+          "value": "\"person_merge_operations\".\"status\" NOT IN ('executed', 'reversed', 'manual_recovery')\n        OR (\"person_merge_operations\".\"executed_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"executed_at\" IS NOT NULL\n          AND \"person_merge_operations\".\"execution_digest\" IS NOT NULL)"
+        },
+        "person_merge_operations_reversal_check": {
+          "name": "person_merge_operations_reversal_check",
+          "value": "\"person_merge_operations\".\"status\" <> 'reversed'\n        OR (\"person_merge_operations\".\"reversed_by_account_id\" IS NOT NULL AND \"person_merge_operations\".\"reversed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.person_merge_preview_items": {
+      "name": "person_merge_preview_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_school_id": {
+          "name": "review_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_name": {
+          "name": "relation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflict_code": {
+          "name": "conflict_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_fingerprint": {
+          "name": "row_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_preview_items_operation_idx": {
+          "name": "person_merge_preview_items_operation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_preview_items_tenant_id_tenants_id_fk": {
+          "name": "person_merge_preview_items_tenant_id_tenants_id_fk",
+          "tableFrom": "person_merge_preview_items",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_preview_items_tenant_operation_fk": {
+          "name": "person_merge_preview_items_tenant_operation_fk",
+          "tableFrom": "person_merge_preview_items",
+          "tableTo": "person_merge_operations",
+          "columnsFrom": ["tenant_id", "operation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "person_merge_preview_items_tenant_school_fk": {
+          "name": "person_merge_preview_items_tenant_school_fk",
+          "tableFrom": "person_merge_preview_items",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "review_school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_merge_preview_items_tenant_id_id_unique": {
+          "name": "person_merge_preview_items_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "person_merge_preview_items_operation_record_unique": {
+          "name": "person_merge_preview_items_operation_record_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "operation_id", "relation_name", "record_key", "direction"]
+        }
+      },
+      "policies": {
+        "person_merge_preview_items_runtime_select": {
+          "name": "person_merge_preview_items_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n"
+        },
+        "person_merge_preview_items_runtime_write_deny": {
+          "name": "person_merge_preview_items_runtime_write_deny",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "person_merge_preview_items_manager_all": {
+          "name": "person_merge_preview_items_manager_all",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["openschool_person_merge_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_person_merge_manager'\n  AND \"person_merge_preview_items\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND \n  nullif(current_setting('app.policy_capability', true), '') IN (\n    'tenant.people_merges.read',\n    'tenant.people_merges.preview',\n    'tenant.people_merges.approve',\n    'tenant.people_merges.execute'\n  )\n\n  AND public.openschool_school_scope_allows(\"person_merge_preview_items\".\"tenant_id\", \"person_merge_preview_items\".\"review_school_id\")\n"
+        }
+      },
+      "checkConstraints": {
+        "person_merge_preview_items_category_check": {
+          "name": "person_merge_preview_items_category_check",
+          "value": "\"person_merge_preview_items\".\"category\" IN ('account_link', 'profile', 'affiliation', 'relationship', 'household_membership', 'school_enrollment', 'section_staff', 'section_roster', 'invitation', 'authorization_history', 'academic_history', 'duplicate_case', 'audit_history', 'compatibility_evidence')"
+        },
+        "person_merge_preview_items_direction_check": {
+          "name": "person_merge_preview_items_direction_check",
+          "value": "\"person_merge_preview_items\".\"direction\" IN ('source', 'subject', 'related', 'actor', 'none')"
+        },
+        "person_merge_preview_items_disposition_check": {
+          "name": "person_merge_preview_items_disposition_check",
+          "value": "\"person_merge_preview_items\".\"disposition\" IN ('move', 'end_and_recreate', 'preserve_history', 'block')"
+        },
+        "person_merge_preview_items_text_check": {
+          "name": "person_merge_preview_items_text_check",
+          "value": "char_length(\"person_merge_preview_items\".\"relation_name\") BETWEEN 3 AND 128\n        AND char_length(\"person_merge_preview_items\".\"record_key\") BETWEEN 1 AND 512\n        AND (\"person_merge_preview_items\".\"conflict_code\" IS NULL OR \"person_merge_preview_items\".\"conflict_code\" ~ '^[A-Z][A-Z0-9_]{2,127}$')"
+        },
+        "person_merge_preview_items_hash_check": {
+          "name": "person_merge_preview_items_hash_check",
+          "value": "\"person_merge_preview_items\".\"row_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "person_merge_preview_items_conflict_check": {
+          "name": "person_merge_preview_items_conflict_check",
+          "value": "(\"person_merge_preview_items\".\"disposition\" = 'block') = (\"person_merge_preview_items\".\"conflict_code\" IS NOT NULL)"
+        },
+        "person_merge_preview_items_metadata_check": {
+          "name": "person_merge_preview_items_metadata_check",
+          "value": "jsonb_typeof(\"person_merge_preview_items\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.household_addresses": {
+      "name": "household_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_key": {
+          "name": "address_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "address_type": {
+          "name": "address_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line1": {
+          "name": "line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line2": {
+          "name": "line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administrative_area": {
+          "name": "administrative_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_address": {
+          "name": "normalized_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_addresses_household_effective_idx": {
+          "name": "household_addresses_household_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_addresses_issued_by_account_id_accounts_id_fk": {
+          "name": "household_addresses_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "household_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_addresses_ended_by_account_id_accounts_id_fk": {
+          "name": "household_addresses_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "household_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_addresses_tenant_household_fk": {
+          "name": "household_addresses_tenant_household_fk",
+          "tableFrom": "household_addresses",
+          "tableTo": "households",
+          "columnsFrom": ["tenant_id", "household_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_addresses_tenant_id_id_unique": {
+          "name": "household_addresses_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "household_addresses_tenant_key_version_unique": {
+          "name": "household_addresses_tenant_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "address_key", "version"]
+        }
+      },
+      "policies": {
+        "household_addresses_runtime_select": {
+          "name": "household_addresses_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.households.read', 'tenant.households.manage')\n  AND public.openschool_household_read_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_runtime_insert_deny": {
+          "name": "household_addresses_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "household_addresses_runtime_update_deny": {
+          "name": "household_addresses_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "household_addresses_runtime_delete_deny": {
+          "name": "household_addresses_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "household_addresses_manager_select": {
+          "name": "household_addresses_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_insert": {
+          "name": "household_addresses_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_update": {
+          "name": "household_addresses_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_addresses\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_addresses\".\"tenant_id\", \"household_addresses\".\"household_id\")\n"
+        },
+        "household_addresses_manager_delete_deny": {
+          "name": "household_addresses_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "household_addresses_type_check": {
+          "name": "household_addresses_type_check",
+          "value": "\"household_addresses\".\"address_type\" IN ('residential', 'mailing', 'temporary', 'other')"
+        },
+        "household_addresses_country_code_check": {
+          "name": "household_addresses_country_code_check",
+          "value": "\"household_addresses\".\"country_code\" ~ '^[A-Z]{2}$'"
+        },
+        "household_addresses_required_text_check": {
+          "name": "household_addresses_required_text_check",
+          "value": "char_length(btrim(\"household_addresses\".\"line1\")) BETWEEN 1 AND 200 AND char_length(btrim(\"household_addresses\".\"locality\")) BETWEEN 1 AND 120 AND char_length(btrim(\"household_addresses\".\"normalized_address\")) BETWEEN 3 AND 600"
+        },
+        "household_addresses_valid_period_check": {
+          "name": "household_addresses_valid_period_check",
+          "value": "\"household_addresses\".\"valid_until\" IS NULL OR \"household_addresses\".\"valid_until\" > \"household_addresses\".\"valid_from\""
+        },
+        "household_addresses_end_evidence_check": {
+          "name": "household_addresses_end_evidence_check",
+          "value": "\"household_addresses\".\"status\" <> 'ended' OR (\"household_addresses\".\"valid_until\" IS NOT NULL AND \"household_addresses\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"household_addresses\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "household_addresses_version_positive": {
+          "name": "household_addresses_version_positive",
+          "value": "\"household_addresses\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.household_memberships": {
+      "name": "household_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "membership_kind": {
+          "name": "membership_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary_residence": {
+          "name": "is_primary_residence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary_mailing": {
+          "name": "is_primary_mailing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_by_account_id": {
+          "name": "ended_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_memberships_household_effective_idx": {
+          "name": "household_memberships_household_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "household_memberships_person_effective_idx": {
+          "name": "household_memberships_person_effective_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_memberships_issued_by_account_id_accounts_id_fk": {
+          "name": "household_memberships_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "household_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_memberships_ended_by_account_id_accounts_id_fk": {
+          "name": "household_memberships_ended_by_account_id_accounts_id_fk",
+          "tableFrom": "household_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["ended_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_memberships_tenant_household_fk": {
+          "name": "household_memberships_tenant_household_fk",
+          "tableFrom": "household_memberships",
+          "tableTo": "households",
+          "columnsFrom": ["tenant_id", "household_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "household_memberships_tenant_person_fk": {
+          "name": "household_memberships_tenant_person_fk",
+          "tableFrom": "household_memberships",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_memberships_tenant_id_id_unique": {
+          "name": "household_memberships_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "household_memberships_tenant_key_version_unique": {
+          "name": "household_memberships_tenant_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "membership_key", "version"]
+        }
+      },
+      "policies": {
+        "household_memberships_runtime_select": {
+          "name": "household_memberships_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '')\n          IN ('tenant.households.read', 'tenant.households.manage')\n        AND public.openschool_household_member_read_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"household_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_runtime_insert_deny": {
+          "name": "household_memberships_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "household_memberships_runtime_update_deny": {
+          "name": "household_memberships_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "household_memberships_runtime_delete_deny": {
+          "name": "household_memberships_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "household_memberships_manager_select": {
+          "name": "household_memberships_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n        \n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"household_memberships\".\"tenant_id\", \"household_memberships\".\"household_id\")\n\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_insert": {
+          "name": "household_memberships_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_update": {
+          "name": "household_memberships_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"household_memberships\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n        AND public.openschool_household_person_manage_scope_allows(\n          \"household_memberships\".\"tenant_id\", \"household_memberships\".\"person_id\"\n        )\n      "
+        },
+        "household_memberships_manager_delete_deny": {
+          "name": "household_memberships_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "household_memberships_kind_check": {
+          "name": "household_memberships_kind_check",
+          "value": "\"household_memberships\".\"membership_kind\" IN ('resident', 'associated')"
+        },
+        "household_memberships_primary_requires_resident": {
+          "name": "household_memberships_primary_requires_resident",
+          "value": "(NOT \"household_memberships\".\"is_primary_residence\" AND NOT \"household_memberships\".\"is_primary_mailing\") OR \"household_memberships\".\"membership_kind\" = 'resident'"
+        },
+        "household_memberships_valid_period_check": {
+          "name": "household_memberships_valid_period_check",
+          "value": "\"household_memberships\".\"valid_until\" IS NULL OR \"household_memberships\".\"valid_until\" > \"household_memberships\".\"valid_from\""
+        },
+        "household_memberships_end_evidence_check": {
+          "name": "household_memberships_end_evidence_check",
+          "value": "\"household_memberships\".\"status\" <> 'ended' OR (\"household_memberships\".\"valid_until\" IS NOT NULL AND \"household_memberships\".\"ended_by_account_id\" IS NOT NULL AND char_length(btrim(\"household_memberships\".\"end_reason\")) BETWEEN 3 AND 512)"
+        },
+        "household_memberships_version_positive": {
+          "name": "household_memberships_version_positive",
+          "value": "\"household_memberships\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.households": {
+      "name": "households",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_display_name": {
+          "name": "normalized_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_reason": {
+          "name": "creation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "households_tenant_status_name_idx": {
+          "name": "households_tenant_status_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "households_tenant_id_tenants_id_fk": {
+          "name": "households_tenant_id_tenants_id_fk",
+          "tableFrom": "households",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "households_created_by_account_id_accounts_id_fk": {
+          "name": "households_created_by_account_id_accounts_id_fk",
+          "tableFrom": "households",
+          "tableTo": "accounts",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "households_closed_by_account_id_accounts_id_fk": {
+          "name": "households_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "households",
+          "tableTo": "accounts",
+          "columnsFrom": ["closed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "households_tenant_id_id_unique": {
+          "name": "households_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {
+        "households_runtime_select": {
+          "name": "households_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n  \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '')\n    IN ('tenant.households.read', 'tenant.households.manage')\n  AND public.openschool_household_read_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_runtime_insert_deny": {
+          "name": "households_runtime_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "false"
+        },
+        "households_runtime_update_deny": {
+          "name": "households_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "households_runtime_delete_deny": {
+          "name": "households_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "households_manager_select": {
+          "name": "households_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_manager_insert": {
+          "name": "households_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_household_manager"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_household_manager'\n        AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n      "
+        },
+        "households_manager_update": {
+          "name": "households_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_household_manager"],
+          "using": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n",
+          "withCheck": "\n  session_user = 'openschool_runtime'\n  AND current_user = 'openschool_household_manager'\n  AND \"households\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n  AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.households.manage'\n  AND public.openschool_household_manage_scope_allows(\"households\".\"tenant_id\", \"households\".\"id\")\n"
+        },
+        "households_manager_delete_deny": {
+          "name": "households_manager_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_household_manager"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "households_name_check": {
+          "name": "households_name_check",
+          "value": "char_length(btrim(\"households\".\"display_name\")) BETWEEN 1 AND 160 AND char_length(btrim(\"households\".\"normalized_display_name\")) BETWEEN 1 AND 160"
+        },
+        "households_status_check": {
+          "name": "households_status_check",
+          "value": "\"households\".\"status\" IN ('active', 'closed')"
+        },
+        "households_version_positive": {
+          "name": "households_version_positive",
+          "value": "\"households\".\"version\" > 0"
+        },
+        "households_creation_reason_check": {
+          "name": "households_creation_reason_check",
+          "value": "char_length(btrim(\"households\".\"creation_reason\")) BETWEEN 3 AND 512"
+        },
+        "households_closure_evidence_check": {
+          "name": "households_closure_evidence_check",
+          "value": "\"households\".\"status\" <> 'closed' OR (\"households\".\"closed_at\" IS NOT NULL AND \"households\".\"closed_by_account_id\" IS NOT NULL AND char_length(btrim(\"households\".\"closure_reason\")) BETWEEN 3 AND 512)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.parent_student": {
+      "name": "parent_student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_student_tenant_parent_idx": {
+          "name": "parent_student_tenant_parent_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parent_student_tenant_id_tenants_id_fk": {
+          "name": "parent_student_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "parent_student_parent_id_users_id_fk": {
+          "name": "parent_student_parent_id_users_id_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "users",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "parent_student_tenant_student_fk": {
+          "name": "parent_student_tenant_student_fk",
+          "tableFrom": "parent_student",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_student_tenant_id_id_unique": {
+          "name": "parent_student_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers_on_class": {
+      "name": "teachers_on_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teachers_on_class_tenant_user_idx": {
+          "name": "teachers_on_class_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teachers_on_class_tenant_id_tenants_id_fk": {
+          "name": "teachers_on_class_tenant_id_tenants_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "teachers_on_class_user_id_users_id_fk": {
+          "name": "teachers_on_class_user_id_users_id_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teachers_on_class_tenant_class_fk": {
+          "name": "teachers_on_class_tenant_class_fk",
+          "tableFrom": "teachers_on_class",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teachers_on_class_tenant_id_id_unique": {
+          "name": "teachers_on_class_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_org": {
+      "name": "users_on_org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_org_tenant_user_idx": {
+          "name": "users_on_org_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_org_tenant_id_tenants_id_fk": {
+          "name": "users_on_org_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_org_user_id_users_id_fk": {
+          "name": "users_on_org_user_id_users_id_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_org_tenant_organization_fk": {
+          "name": "users_on_org_tenant_organization_fk",
+          "tableFrom": "users_on_org",
+          "tableTo": "organizations",
+          "columnsFrom": ["tenant_id", "org_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_org_tenant_id_id_unique": {
+          "name": "users_on_org_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_on_school": {
+      "name": "users_on_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_on_school_tenant_user_idx": {
+          "name": "users_on_school_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_on_school_tenant_id_tenants_id_fk": {
+          "name": "users_on_school_tenant_id_tenants_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "users_on_school_user_id_users_id_fk": {
+          "name": "users_on_school_user_id_users_id_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_on_school_tenant_school_fk": {
+          "name": "users_on_school_tenant_school_fk",
+          "tableFrom": "users_on_school",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_on_school_tenant_id_id_unique": {
+          "name": "users_on_school_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrollments": {
+      "name": "enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "enrollments_tenant_student_idx": {
+          "name": "enrollments_tenant_student_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrollments_tenant_class_idx": {
+          "name": "enrollments_tenant_class_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrollments_tenant_id_tenants_id_fk": {
+          "name": "enrollments_tenant_id_tenants_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_student_fk": {
+          "name": "enrollments_tenant_student_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "students",
+          "columnsFrom": ["tenant_id", "student_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "enrollments_tenant_class_fk": {
+          "name": "enrollments_tenant_class_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrollments_tenant_id_id_unique": {
+          "name": "enrollments_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grades": {
+      "name": "grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_name": {
+          "name": "assignment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'100'"
+        },
+        "graded_by": {
+          "name": "graded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graded_at": {
+          "name": "graded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grades_tenant_enrollment_idx": {
+          "name": "grades_tenant_enrollment_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrollment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grades_tenant_id_tenants_id_fk": {
+          "name": "grades_tenant_id_tenants_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "grades_graded_by_users_id_fk": {
+          "name": "grades_graded_by_users_id_fk",
+          "tableFrom": "grades",
+          "tableTo": "users",
+          "columnsFrom": ["graded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grades_tenant_enrollment_fk": {
+          "name": "grades_tenant_enrollment_fk",
+          "tableFrom": "grades",
+          "tableTo": "enrollments",
+          "columnsFrom": ["tenant_id", "enrollment_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grades_tenant_id_id_unique": {
+          "name": "grades_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_archive_manifests": {
+      "name": "audit_archive_manifests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_class": {
+          "name": "retention_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_event_hash": {
+          "name": "first_event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_hash": {
+          "name": "last_event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_hash": {
+          "name": "root_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_manifest_hash": {
+          "name": "previous_manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_location_hash": {
+          "name": "archive_location_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "includes_legal_hold": {
+          "name": "includes_legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_archive_manifest_chain_idx": {
+          "name": "audit_archive_manifest_chain_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retention_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_archive_manifests_tenant_id_tenants_id_fk": {
+          "name": "audit_archive_manifests_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_archive_manifests",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audit_archive_manifest_period_unique": {
+          "name": "audit_archive_manifest_period_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "period_start", "retention_class"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "audit_archive_manifest_period_check": {
+          "name": "audit_archive_manifest_period_check",
+          "value": "\"audit_archive_manifests\".\"period_end\" > \"audit_archive_manifests\".\"period_start\""
+        },
+        "audit_archive_manifest_count_check": {
+          "name": "audit_archive_manifest_count_check",
+          "value": "\"audit_archive_manifests\".\"event_count\" >= 0"
+        },
+        "audit_archive_manifest_hashes_check": {
+          "name": "audit_archive_manifest_hashes_check",
+          "value": "\"audit_archive_manifests\".\"first_event_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"last_event_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"root_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"manifest_hash\" ~ '^[0-9a-f]{64}$' AND \"audit_archive_manifests\".\"archive_location_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_version": {
+          "name": "event_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_person_id": {
+          "name": "actor_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "causation_id": {
+          "name": "causation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_operation_receipt_id": {
+          "name": "pre_operation_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_grant_id": {
+          "name": "support_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_classes": {
+          "name": "data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_class": {
+          "name": "retention_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'security'"
+        },
+        "legal_hold": {
+          "name": "legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_tenant_time_idx": {
+          "name": "audit_events_tenant_time_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_tenant_target_idx": {
+          "name": "audit_events_tenant_target_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_correlation_idx": {
+          "name": "audit_events_correlation_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_tenant_id_tenants_id_fk": {
+          "name": "audit_events_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_events_actor_account_id_accounts_id_fk": {
+          "name": "audit_events_actor_account_id_accounts_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_events_tenant_actor_person_fk": {
+          "name": "audit_events_tenant_actor_person_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "actor_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_events_tenant_organization_fk": {
+          "name": "audit_events_tenant_organization_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_events_tenant_school_fk": {
+          "name": "audit_events_tenant_school_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audit_events_pk": {
+          "name": "audit_events_pk",
+          "columns": ["occurred_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "audit_events_runtime_select": {
+          "name": "audit_events_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.audit.read'\n        AND public.openschool_audit_scope_allows(\n          \"audit_events\".\"tenant_id\", \"audit_events\".\"education_organization_id\", \"audit_events\".\"school_id\"\n        )\n      "
+        },
+        "audit_events_runtime_insert": {
+          "name": "audit_events_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" IN ('account', 'support')\n        AND \"audit_events\".\"actor_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND \"audit_events\".\"actor_person_id\" IS NOT DISTINCT FROM nullif(current_setting('app.person_id', true), '')::uuid\n        AND \"audit_events\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_events\".\"education_organization_id\" IS NOT DISTINCT FROM nullif(current_setting('app.education_organization_id', true), '')::uuid\n        AND \"audit_events\".\"school_id\" IS NOT DISTINCT FROM nullif(current_setting('app.school_id', true), '')::uuid\n        AND (\n          (\"audit_events\".\"actor_type\" = 'account' AND \"audit_events\".\"source\" = 'web' AND \"audit_events\".\"support_grant_id\" IS NULL)\n          OR (\"audit_events\".\"actor_type\" = 'support' AND \"audit_events\".\"source\" = 'support' AND \"audit_events\".\"support_grant_id\" IS NOT NULL AND \"audit_events\".\"purpose\" IS NOT NULL)\n        )\n      "
+        },
+        "audit_events_invitation_denial_insert": {
+          "name": "audit_events_invitation_denial_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" = 'system'\n        AND \"audit_events\".\"actor_account_id\" IS NULL\n        AND \"audit_events\".\"actor_person_id\" IS NULL\n        AND \"audit_events\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_events\".\"education_organization_id\" IS NOT DISTINCT FROM nullif(current_setting('app.education_organization_id', true), '')::uuid\n        AND \"audit_events\".\"school_id\" IS NOT DISTINCT FROM nullif(current_setting('app.school_id', true), '')::uuid\n        AND \"audit_events\".\"event_type\" = 'account.invitation.accept'\n        AND \"audit_events\".\"outcome\" = 'denied'\n        AND \"audit_events\".\"capability\" = 'identity.invitation.accept'\n        AND \"audit_events\".\"policy_version\" = 'identity-invitation.v1'\n        AND \"audit_events\".\"policy_decision\" ->> 'effect' = 'deny'\n        AND \"audit_events\".\"policy_decision\" ->> 'reason' IN (\n          'INVITATION_UNAVAILABLE', 'INVITATION_IDENTITY_MISMATCH', 'INVITATION_ACCOUNT_CONFLICT'\n        )\n        AND \"audit_events\".\"target_type\" = 'account.invitation'\n        AND \"audit_events\".\"target_id\" IS NOT NULL\n        AND \"audit_events\".\"data_classes\" = '[\"credential\"]'::jsonb\n        AND \"audit_events\".\"purpose\" = 'account_onboarding'\n        AND \"audit_events\".\"source\" = 'web'\n        AND \"audit_events\".\"retention_class\" = 'security'\n      "
+        },
+        "audit_events_runtime_update_deny": {
+          "name": "audit_events_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_events_runtime_delete_deny": {
+          "name": "audit_events_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "audit_events_worker_select": {
+          "name": "audit_events_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_events_worker_insert": {
+          "name": "audit_events_worker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "\n        \"audit_events\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_events\".\"actor_type\" = 'worker'\n        AND \"audit_events\".\"actor_account_id\" IS NULL\n        AND \"audit_events\".\"actor_person_id\" IS NULL\n        AND \"audit_events\".\"source\" = 'worker'\n      "
+        },
+        "audit_events_worker_update_deny": {
+          "name": "audit_events_worker_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_events_worker_delete_deny": {
+          "name": "audit_events_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "audit_events_version_positive": {
+          "name": "audit_events_version_positive",
+          "value": "\"audit_events\".\"event_version\" > 0"
+        },
+        "audit_events_type_format": {
+          "name": "audit_events_type_format",
+          "value": "\"audit_events\".\"event_type\" ~ '^[a-z][a-z0-9_.]{2,127}$'"
+        },
+        "audit_events_reference_format": {
+          "name": "audit_events_reference_format",
+          "value": "\"audit_events\".\"target_type\" ~ '^[a-z][a-z0-9_.]{2,127}$' AND char_length(\"audit_events\".\"request_id\") BETWEEN 1 AND 512 AND char_length(\"audit_events\".\"correlation_id\") BETWEEN 1 AND 512 AND (\"audit_events\".\"target_id\" IS NULL OR char_length(\"audit_events\".\"target_id\") BETWEEN 1 AND 512) AND (\"audit_events\".\"purpose\" IS NULL OR \"audit_events\".\"purpose\" ~ '^[a-z][a-z0-9_.-]{2,63}$')"
+        },
+        "audit_events_outcome_check": {
+          "name": "audit_events_outcome_check",
+          "value": "\"audit_events\".\"outcome\" IN ('attempted', 'succeeded', 'denied', 'failed')"
+        },
+        "audit_events_actor_type_check": {
+          "name": "audit_events_actor_type_check",
+          "value": "\"audit_events\".\"actor_type\" IN ('account', 'worker', 'system', 'support', 'platform')"
+        },
+        "audit_events_source_check": {
+          "name": "audit_events_source_check",
+          "value": "\"audit_events\".\"source\" IN ('web', 'worker', 'migration', 'support', 'system', 'platform')"
+        },
+        "audit_events_retention_check": {
+          "name": "audit_events_retention_check",
+          "value": "\"audit_events\".\"retention_class\" IN ('operational', 'security', 'financial', 'safeguarding', 'legal_hold')"
+        },
+        "audit_events_data_classes_check": {
+          "name": "audit_events_data_classes_check",
+          "value": "jsonb_typeof(\"audit_events\".\"data_classes\") = 'array' AND jsonb_array_length(\"audit_events\".\"data_classes\") BETWEEN 1 AND 8 AND \"audit_events\".\"data_classes\" <@ '[\"internal\", \"student_personal\", \"financial\", \"health\", \"safeguarding\", \"credential\"]'::jsonb"
+        },
+        "audit_events_json_shape_check": {
+          "name": "audit_events_json_shape_check",
+          "value": "jsonb_typeof(\"audit_events\".\"change_summary\") = 'object' AND (\"audit_events\".\"policy_decision\" IS NULL OR jsonb_typeof(\"audit_events\".\"policy_decision\") = 'object')"
+        },
+        "audit_events_account_actor_check": {
+          "name": "audit_events_account_actor_check",
+          "value": "(\"audit_events\".\"actor_type\" NOT IN ('account', 'support', 'platform')) OR (\"audit_events\".\"actor_account_id\" IS NOT NULL AND (\"audit_events\".\"actor_type\" IN ('support', 'platform') OR \"audit_events\".\"actor_person_id\" IS NOT NULL))"
+        },
+        "audit_events_support_context_check": {
+          "name": "audit_events_support_context_check",
+          "value": "(\"audit_events\".\"actor_type\" = 'support' AND \"audit_events\".\"support_grant_id\" IS NOT NULL AND \"audit_events\".\"purpose\" IS NOT NULL AND \"audit_events\".\"source\" = 'support') OR (\"audit_events\".\"actor_type\" <> 'support' AND \"audit_events\".\"support_grant_id\" IS NULL AND (\"audit_events\".\"actor_type\" <> 'platform' OR (\"audit_events\".\"actor_person_id\" IS NULL AND \"audit_events\".\"source\" = 'platform')))"
+        },
+        "audit_events_content_hash_check": {
+          "name": "audit_events_content_hash_check",
+          "value": "\"audit_events\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_outbox": {
+      "name": "audit_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_event_occurred_at": {
+          "name": "audit_event_occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deduplication_key": {
+          "name": "deduplication_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_outbox_claim_idx": {
+          "name": "audit_outbox_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_outbox_event_idx": {
+          "name": "audit_outbox_event_idx",
+          "columns": [
+            {
+              "expression": "audit_event_occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audit_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_outbox_tenant_id_tenants_id_fk": {
+          "name": "audit_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_outbox",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "audit_outbox_event_fk": {
+          "name": "audit_outbox_event_fk",
+          "tableFrom": "audit_outbox",
+          "tableTo": "audit_events",
+          "columnsFrom": ["audit_event_occurred_at", "audit_event_id"],
+          "columnsTo": ["occurred_at", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audit_outbox_tenant_dedup_unique": {
+          "name": "audit_outbox_tenant_dedup_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "deduplication_key"]
+        }
+      },
+      "policies": {
+        "audit_outbox_runtime_select": {
+          "name": "audit_outbox_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' = nullif(current_setting('app.account_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' = nullif(current_setting('app.person_id', true), '')\n      "
+        },
+        "audit_outbox_runtime_insert": {
+          "name": "audit_outbox_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' = nullif(current_setting('app.account_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' = nullif(current_setting('app.person_id', true), '')\n      "
+        },
+        "audit_outbox_invitation_denial_select": {
+          "name": "audit_outbox_invitation_denial_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' IS NULL\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' IS NULL\n        AND \"audit_outbox\".\"topic\" = 'audit.event.committed'\n        AND \"audit_outbox\".\"payload\" ->> 'eventType' = 'account.invitation.accept'\n        AND \"audit_outbox\".\"payload\" ->> 'outcome' = 'denied'\n        AND \"audit_outbox\".\"payload\" ->> 'targetType' = 'account.invitation'\n        AND nullif(\"audit_outbox\".\"payload\" ->> 'targetId', '') IS NOT NULL\n        AND \"audit_outbox\".\"deduplication_key\" =\n          'account.invitation.accept.denied:' || (\"audit_outbox\".\"payload\" ->> 'targetId') || ':' ||\n          nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "audit_outbox_invitation_denial_insert": {
+          "name": "audit_outbox_invitation_denial_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"audit_outbox\".\"context\" ->> 'requestId' = nullif(current_setting('app.request_id', true), '')\n        AND \"audit_outbox\".\"context\" ->> 'actorAccountId' IS NULL\n        AND \"audit_outbox\".\"context\" ->> 'actorPersonId' IS NULL\n        AND \"audit_outbox\".\"topic\" = 'audit.event.committed'\n        AND \"audit_outbox\".\"payload\" ->> 'eventType' = 'account.invitation.accept'\n        AND \"audit_outbox\".\"payload\" ->> 'outcome' = 'denied'\n        AND \"audit_outbox\".\"payload\" ->> 'targetType' = 'account.invitation'\n        AND nullif(\"audit_outbox\".\"payload\" ->> 'targetId', '') IS NOT NULL\n        AND \"audit_outbox\".\"deduplication_key\" =\n          'account.invitation.accept.denied:' || (\"audit_outbox\".\"payload\" ->> 'targetId') || ':' ||\n          nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "audit_outbox_runtime_update_deny": {
+          "name": "audit_outbox_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "audit_outbox_runtime_delete_deny": {
+          "name": "audit_outbox_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "audit_outbox_worker_select": {
+          "name": "audit_outbox_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_outbox_worker_update": {
+          "name": "audit_outbox_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"audit_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "audit_outbox_worker_insert_deny": {
+          "name": "audit_outbox_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "audit_outbox_worker_delete_deny": {
+          "name": "audit_outbox_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "audit_outbox_attempt_nonnegative": {
+          "name": "audit_outbox_attempt_nonnegative",
+          "value": "\"audit_outbox\".\"attempt_count\" >= 0"
+        },
+        "audit_outbox_topic_format": {
+          "name": "audit_outbox_topic_format",
+          "value": "\"audit_outbox\".\"topic\" ~ '^[a-z][a-z0-9_.]{2,127}$'"
+        },
+        "audit_outbox_reference_format": {
+          "name": "audit_outbox_reference_format",
+          "value": "char_length(\"audit_outbox\".\"deduplication_key\") BETWEEN 1 AND 512 AND char_length(\"audit_outbox\".\"correlation_id\") BETWEEN 1 AND 512"
+        },
+        "audit_outbox_context_binding_check": {
+          "name": "audit_outbox_context_binding_check",
+          "value": "jsonb_typeof(\"audit_outbox\".\"context\") = 'object' AND jsonb_typeof(\"audit_outbox\".\"payload\") = 'object' AND \"audit_outbox\".\"context\" ->> 'tenantId' = \"audit_outbox\".\"tenant_id\"::text AND \"audit_outbox\".\"context\" ->> 'correlationId' = \"audit_outbox\".\"correlation_id\" AND nullif(\"audit_outbox\".\"context\" ->> 'requestId', '') IS NOT NULL AND \"audit_outbox\".\"payload\" ->> 'auditEventId' = \"audit_outbox\".\"audit_event_id\"::text"
+        },
+        "audit_outbox_status_check": {
+          "name": "audit_outbox_status_check",
+          "value": "\"audit_outbox\".\"status\" IN ('pending', 'processing', 'published', 'failed', 'dead_letter')"
+        },
+        "audit_outbox_payload_hash_check": {
+          "name": "audit_outbox_payload_hash_check",
+          "value": "\"audit_outbox\".\"payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.account_invitations": {
+      "name": "account_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intended_email": {
+          "name": "intended_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_provider": {
+          "name": "identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'supabase'"
+        },
+        "intended_provider_subject": {
+          "name": "intended_provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "affiliation_kind": {
+          "name": "affiliation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_template_keys": {
+          "name": "role_template_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliation_valid_until": {
+          "name": "affiliation_valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_account_id": {
+          "name": "accepted_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_provider_subject": {
+          "name": "accepted_provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_account_id": {
+          "name": "cancelled_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_invitations_tenant_status_expiry_idx": {
+          "name": "account_invitations_tenant_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_tenant_person_status_idx": {
+          "name": "account_invitations_tenant_person_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_tenant_id_tenants_id_fk": {
+          "name": "account_invitations_tenant_id_tenants_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_issued_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_accepted_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_accepted_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["accepted_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_cancelled_by_account_id_accounts_id_fk": {
+          "name": "account_invitations_cancelled_by_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["cancelled_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_tenant_person_fk": {
+          "name": "account_invitations_tenant_person_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_tenant_organization_fk": {
+          "name": "account_invitations_tenant_organization_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_tenant_school_fk": {
+          "name": "account_invitations_tenant_school_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "account_invitations_tenant_class_fk": {
+          "name": "account_invitations_tenant_class_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "classes",
+          "columnsFrom": ["tenant_id", "class_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_invitations_tenant_id_id_unique": {
+          "name": "account_invitations_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "account_invitations_token_hash_unique": {
+          "name": "account_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {
+        "account_invitations_runtime_select": {
+          "name": "account_invitations_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') IN (\n          'tenant.accounts.invite', 'tenant.accounts.manage'\n        )\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_insert": {
+          "name": "account_invitations_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"issued_by_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.invite'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_update": {
+          "name": "account_invitations_runtime_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      ",
+          "withCheck": "\n        \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"cancelled_by_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.manage'\n        AND public.openschool_invitation_scope_allows(\n          \"account_invitations\".\"tenant_id\", \"account_invitations\".\"scope_type\", \"account_invitations\".\"education_organization_id\",\n          \"account_invitations\".\"school_id\", \"account_invitations\".\"class_id\"\n        )\n      "
+        },
+        "account_invitations_runtime_delete_deny": {
+          "name": "account_invitations_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "account_invitations_worker_select": {
+          "name": "account_invitations_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "account_invitations_acceptance_select": {
+          "name": "account_invitations_acceptance_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n      "
+        },
+        "account_invitations_acceptance_update": {
+          "name": "account_invitations_acceptance_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["public"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n        AND \"account_invitations\".\"status\" = 'pending'\n        AND \"account_invitations\".\"expires_at\" > now()\n        AND \"account_invitations\".\"identity_provider\" = nullif(current_setting('app.identity_provider', true), '')\n        AND \"account_invitations\".\"intended_email\" = lower(btrim(nullif(current_setting('app.identity_email', true), '')))\n        AND (\n          \"account_invitations\".\"intended_provider_subject\" IS NULL\n          OR \"account_invitations\".\"intended_provider_subject\" = nullif(current_setting('app.provider_subject', true), '')\n        )\n      ",
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_invitation_acceptor'\n        AND \"account_invitations\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"account_invitations\".\"token_hash\" = nullif(current_setting('app.invitation_token_hash', true), '')\n        AND \"account_invitations\".\"status\" = 'accepted'\n        AND \"account_invitations\".\"accepted_provider_subject\" = nullif(current_setting('app.provider_subject', true), '')\n        AND EXISTS (\n          SELECT 1 FROM public.accounts AS accepted_account\n          WHERE accepted_account.id = \"account_invitations\".\"accepted_by_account_id\"\n            AND accepted_account.identity_provider = nullif(current_setting('app.identity_provider', true), '')\n            AND accepted_account.provider_subject = nullif(current_setting('app.provider_subject', true), '')\n            AND lower(btrim(accepted_account.primary_email)) = lower(btrim(nullif(current_setting('app.identity_email', true), '')))\n            AND accepted_account.status = 'active'\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "account_invitations_email_normalized_check": {
+          "name": "account_invitations_email_normalized_check",
+          "value": "\"account_invitations\".\"intended_email\" = lower(btrim(\"account_invitations\".\"intended_email\")) AND char_length(\"account_invitations\".\"intended_email\") BETWEEN 3 AND 320 AND \"account_invitations\".\"intended_email\" ~ '^[^[:space:]@]+@[^[:space:]@]+$'"
+        },
+        "account_invitations_identity_check": {
+          "name": "account_invitations_identity_check",
+          "value": "char_length(\"account_invitations\".\"identity_provider\") BETWEEN 1 AND 128 AND (\"account_invitations\".\"intended_provider_subject\" IS NULL OR char_length(\"account_invitations\".\"intended_provider_subject\") BETWEEN 1 AND 512)"
+        },
+        "account_invitations_token_check": {
+          "name": "account_invitations_token_check",
+          "value": "\"account_invitations\".\"token_version\" = 1 AND \"account_invitations\".\"token_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "account_invitations_scope_check": {
+          "name": "account_invitations_scope_check",
+          "value": "(\"account_invitations\".\"scope_type\" = 'tenant' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"education_organization_id\" IS NOT NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NOT NULL AND \"account_invitations\".\"class_id\" IS NULL)\n          OR (\"account_invitations\".\"scope_type\" = 'class' AND \"account_invitations\".\"education_organization_id\" IS NULL AND \"account_invitations\".\"school_id\" IS NULL AND \"account_invitations\".\"class_id\" IS NOT NULL)"
+        },
+        "account_invitations_roles_check": {
+          "name": "account_invitations_roles_check",
+          "value": "jsonb_typeof(\"account_invitations\".\"role_template_keys\") = 'array'\n          AND jsonb_array_length(\"account_invitations\".\"role_template_keys\") = 1\n          AND NOT jsonb_path_exists(\"account_invitations\".\"role_template_keys\", '$[*] ? (@.type() != \"string\")')\n          AND (\n            (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"affiliation_kind\" = 'administrator' AND \"account_invitations\".\"role_template_keys\" = '[\"org_admin\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'education_organization' AND \"account_invitations\".\"affiliation_kind\" = 'member' AND \"account_invitations\".\"role_template_keys\" = '[\"org_viewer\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'administrator' AND \"account_invitations\".\"role_template_keys\" = '[\"school_admin\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'employee' AND \"account_invitations\".\"role_template_keys\" = '[\"staff\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'guardian' AND \"account_invitations\".\"role_template_keys\" = '[\"parent\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'school' AND \"account_invitations\".\"affiliation_kind\" = 'student' AND \"account_invitations\".\"role_template_keys\" = '[\"student\"]'::jsonb)\n            OR (\"account_invitations\".\"scope_type\" = 'class' AND \"account_invitations\".\"affiliation_kind\" = 'teacher' AND \"account_invitations\".\"role_template_keys\" = '[\"teacher\"]'::jsonb)\n          )"
+        },
+        "account_invitations_affiliation_kind_check": {
+          "name": "account_invitations_affiliation_kind_check",
+          "value": "\"account_invitations\".\"affiliation_kind\" IN ('student', 'guardian', 'employee', 'teacher', 'administrator', 'member')"
+        },
+        "account_invitations_period_check": {
+          "name": "account_invitations_period_check",
+          "value": "\"account_invitations\".\"expires_at\" > \"account_invitations\".\"created_at\" AND (\"account_invitations\".\"affiliation_valid_until\" IS NULL OR \"account_invitations\".\"affiliation_valid_until\" > \"account_invitations\".\"created_at\")"
+        },
+        "account_invitations_status_evidence_check": {
+          "name": "account_invitations_status_evidence_check",
+          "value": "(\"account_invitations\".\"status\" = 'pending' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)\n          OR (\"account_invitations\".\"status\" = 'accepted' AND \"account_invitations\".\"accepted_at\" IS NOT NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NOT NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NOT NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)\n          OR (\"account_invitations\".\"status\" = 'cancelled' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NOT NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NOT NULL AND nullif(btrim(\"account_invitations\".\"cancellation_reason\"), '') IS NOT NULL)\n          OR (\"account_invitations\".\"status\" = 'expired' AND \"account_invitations\".\"accepted_at\" IS NULL AND \"account_invitations\".\"accepted_by_account_id\" IS NULL AND \"account_invitations\".\"accepted_provider_subject\" IS NULL AND \"account_invitations\".\"cancelled_at\" IS NULL AND \"account_invitations\".\"cancelled_by_account_id\" IS NULL AND \"account_invitations\".\"cancellation_reason\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.invitation_acceptance_rate_limits": {
+      "name": "invitation_acceptance_rate_limits",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_acceptance_rate_limits_pkey": {
+          "name": "invitation_acceptance_rate_limits_pkey",
+          "columns": ["key_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "invitation_acceptance_rate_limits_acceptor_select": {
+          "name": "invitation_acceptance_rate_limits_acceptor_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        },
+        "invitation_acceptance_rate_limits_acceptor_insert": {
+          "name": "invitation_acceptance_rate_limits_acceptor_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["public"],
+          "withCheck": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        },
+        "invitation_acceptance_rate_limits_acceptor_update": {
+          "name": "invitation_acceptance_rate_limits_acceptor_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["public"],
+          "using": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'",
+          "withCheck": "session_user = 'openschool_runtime' AND current_user = 'openschool_invitation_acceptor'"
+        }
+      },
+      "checkConstraints": {
+        "invitation_acceptance_rate_limits_key_check": {
+          "name": "invitation_acceptance_rate_limits_key_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"key_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "invitation_acceptance_rate_limits_count_check": {
+          "name": "invitation_acceptance_rate_limits_count_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"attempt_count\" BETWEEN 1 AND 1000000"
+        },
+        "invitation_acceptance_rate_limits_time_check": {
+          "name": "invitation_acceptance_rate_limits_time_check",
+          "value": "\"invitation_acceptance_rate_limits\".\"updated_at\" >= \"invitation_acceptance_rate_limits\".\"window_started_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.invitation_delivery_outbox": {
+      "name": "invitation_delivery_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_key_id": {
+          "name": "encryption_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_auth_tag": {
+          "name": "token_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_delivery_claim_idx": {
+          "name": "invitation_delivery_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_delivery_outbox_tenant_id_tenants_id_fk": {
+          "name": "invitation_delivery_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "invitation_delivery_outbox",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "invitation_delivery_invitation_fk": {
+          "name": "invitation_delivery_invitation_fk",
+          "tableFrom": "invitation_delivery_outbox",
+          "tableTo": "account_invitations",
+          "columnsFrom": ["tenant_id", "invitation_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_delivery_invitation_unique": {
+          "name": "invitation_delivery_invitation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "invitation_id"]
+        }
+      },
+      "policies": {
+        "invitation_delivery_runtime_insert": {
+          "name": "invitation_delivery_runtime_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_runtime"],
+          "withCheck": "\n        \"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.accounts.invite'\n        AND EXISTS (\n          SELECT 1 FROM public.account_invitations AS invitation\n          WHERE invitation.tenant_id = \"invitation_delivery_outbox\".\"tenant_id\"\n            AND invitation.id = \"invitation_delivery_outbox\".\"invitation_id\"\n            AND invitation.intended_email = \"invitation_delivery_outbox\".\"recipient_email\"\n            AND invitation.issued_by_account_id = nullif(current_setting('app.account_id', true), '')::uuid\n            AND invitation.status = 'pending'\n        )\n      "
+        },
+        "invitation_delivery_runtime_select_deny": {
+          "name": "invitation_delivery_runtime_select_deny",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "invitation_delivery_runtime_update_deny": {
+          "name": "invitation_delivery_runtime_update_deny",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_runtime"],
+          "using": "false",
+          "withCheck": "false"
+        },
+        "invitation_delivery_runtime_delete_deny": {
+          "name": "invitation_delivery_runtime_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_runtime"],
+          "using": "false"
+        },
+        "invitation_delivery_worker_select": {
+          "name": "invitation_delivery_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "invitation_delivery_worker_update": {
+          "name": "invitation_delivery_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"invitation_delivery_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "invitation_delivery_worker_insert_deny": {
+          "name": "invitation_delivery_worker_insert_deny",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "false"
+        },
+        "invitation_delivery_worker_delete_deny": {
+          "name": "invitation_delivery_worker_delete_deny",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": ["openschool_worker"],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {
+        "invitation_delivery_email_normalized_check": {
+          "name": "invitation_delivery_email_normalized_check",
+          "value": "\"invitation_delivery_outbox\".\"recipient_email\" = lower(btrim(\"invitation_delivery_outbox\".\"recipient_email\")) AND char_length(\"invitation_delivery_outbox\".\"recipient_email\") BETWEEN 3 AND 320"
+        },
+        "invitation_delivery_encryption_check": {
+          "name": "invitation_delivery_encryption_check",
+          "value": "(\n            \"invitation_delivery_outbox\".\"status\" IN ('pending', 'processing', 'failed')\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" ~ '^[A-Za-z0-9_.-]{1,64}$'\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" ~ '^[A-Za-z0-9_-]+$'\n            AND char_length(\"invitation_delivery_outbox\".\"token_ciphertext\") BETWEEN 16 AND 1024\n            AND \"invitation_delivery_outbox\".\"token_iv\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_iv\" ~ '^[A-Za-z0-9_-]{16}$'\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" IS NOT NULL\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" ~ '^[A-Za-z0-9_-]{22}$'\n          ) OR (\n            \"invitation_delivery_outbox\".\"status\" IN ('delivered', 'dead_letter')\n            AND \"invitation_delivery_outbox\".\"encryption_key_id\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_ciphertext\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_iv\" IS NULL\n            AND \"invitation_delivery_outbox\".\"token_auth_tag\" IS NULL\n          )"
+        },
+        "invitation_delivery_attempt_nonnegative": {
+          "name": "invitation_delivery_attempt_nonnegative",
+          "value": "\"invitation_delivery_outbox\".\"attempt_count\" >= 0"
+        },
+        "invitation_delivery_status_check": {
+          "name": "invitation_delivery_status_check",
+          "value": "\"invitation_delivery_outbox\".\"status\" IN ('pending', 'processing', 'delivered', 'failed', 'dead_letter')"
+        },
+        "invitation_delivery_status_evidence_check": {
+          "name": "invitation_delivery_status_evidence_check",
+          "value": "(\"invitation_delivery_outbox\".\"status\" = 'pending' AND \"invitation_delivery_outbox\".\"attempt_count\" = 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'processing' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NOT NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'delivered' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NOT NULL AND \"invitation_delivery_outbox\".\"last_error_code\" IS NULL)\n          OR (\"invitation_delivery_outbox\".\"status\" = 'failed' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')\n          OR (\"invitation_delivery_outbox\".\"status\" = 'dead_letter' AND \"invitation_delivery_outbox\".\"attempt_count\" > 0 AND \"invitation_delivery_outbox\".\"locked_at\" IS NULL AND \"invitation_delivery_outbox\".\"delivered_at\" IS NULL AND \"invitation_delivery_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.platform_access_grants": {
+      "name": "platform_access_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_template_key": {
+          "name": "role_template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuance_source": {
+          "name": "issuance_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuance_reason": {
+          "name": "issuance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_access_grants_account_status_idx": {
+          "name": "platform_access_grants_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_access_grants_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "platform_access_grants_issued_by_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_issued_by_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["issued_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "platform_access_grants_revoked_by_account_id_accounts_id_fk": {
+          "name": "platform_access_grants_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "platform_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_access_grants_role_check": {
+          "name": "platform_access_grants_role_check",
+          "value": "\"platform_access_grants\".\"role_template_key\" IN ('super_admin', 'support_agent', 'break_glass_operator')"
+        },
+        "platform_access_grants_status_check": {
+          "name": "platform_access_grants_status_check",
+          "value": "\"platform_access_grants\".\"status\" IN ('active', 'revoked')"
+        },
+        "platform_access_grants_issuance_source_check": {
+          "name": "platform_access_grants_issuance_source_check",
+          "value": "\"platform_access_grants\".\"issuance_source\" IN ('bootstrap', 'platform')"
+        },
+        "platform_access_grants_period_check": {
+          "name": "platform_access_grants_period_check",
+          "value": "\"platform_access_grants\".\"valid_until\" > \"platform_access_grants\".\"valid_from\" AND \"platform_access_grants\".\"valid_until\" <= \"platform_access_grants\".\"valid_from\" + interval '90 days'"
+        },
+        "platform_access_grants_reason_check": {
+          "name": "platform_access_grants_reason_check",
+          "value": "char_length(btrim(\"platform_access_grants\".\"issuance_reason\")) BETWEEN 3 AND 512 AND (\"platform_access_grants\".\"revocation_reason\" IS NULL OR char_length(btrim(\"platform_access_grants\".\"revocation_reason\")) BETWEEN 3 AND 512)"
+        },
+        "platform_access_grants_issuer_check": {
+          "name": "platform_access_grants_issuer_check",
+          "value": "(\"platform_access_grants\".\"issuance_source\" = 'bootstrap' AND \"platform_access_grants\".\"issued_by_account_id\" IS NULL) OR (\"platform_access_grants\".\"issuance_source\" = 'platform' AND \"platform_access_grants\".\"issued_by_account_id\" IS NOT NULL)"
+        },
+        "platform_access_grants_revocation_check": {
+          "name": "platform_access_grants_revocation_check",
+          "value": "(\"platform_access_grants\".\"status\" = 'active' AND \"platform_access_grants\".\"revoked_at\" IS NULL AND \"platform_access_grants\".\"revoked_by_account_id\" IS NULL AND \"platform_access_grants\".\"revocation_reason\" IS NULL) OR (\"platform_access_grants\".\"status\" = 'revoked' AND \"platform_access_grants\".\"revoked_at\" IS NOT NULL AND \"platform_access_grants\".\"revoked_by_account_id\" IS NOT NULL AND \"platform_access_grants\".\"revocation_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_security_reconciliation_outbox": {
+      "name": "provider_security_reconciliation_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_security_version": {
+          "name": "expected_security_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_person_id": {
+          "name": "actor_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_factor_count": {
+          "name": "deleted_factor_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_security_reconciliation_claim_idx": {
+          "name": "provider_security_reconciliation_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_security_reconciliation_outbox_tenant_id_tenants_id_fk": {
+          "name": "provider_security_reconciliation_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "provider_security_reconciliation_outbox_account_id_accounts_id_fk": {
+          "name": "provider_security_reconciliation_outbox_account_id_accounts_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "provider_security_reconciliation_outbox_actor_account_id_accounts_id_fk": {
+          "name": "provider_security_reconciliation_outbox_actor_account_id_accounts_id_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "provider_security_reconciliation_actor_person_fk": {
+          "name": "provider_security_reconciliation_actor_person_fk",
+          "tableFrom": "provider_security_reconciliation_outbox",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "actor_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_security_reconciliation_effect_unique": {
+          "name": "provider_security_reconciliation_effect_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "account_id", "action", "expected_security_version"]
+        }
+      },
+      "policies": {
+        "provider_security_reconciliation_revoker_insert": {
+          "name": "provider_security_reconciliation_revoker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_identity_revoker"],
+          "withCheck": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_identity_revoker'\n        AND \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"actor_account_id\" = nullif(current_setting('app.account_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"actor_person_id\" = nullif(current_setting('app.person_id', true), '')::uuid\n        AND \"provider_security_reconciliation_outbox\".\"request_id\" = nullif(current_setting('app.request_id', true), '')\n      "
+        },
+        "provider_security_reconciliation_worker_select": {
+          "name": "provider_security_reconciliation_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_worker_update": {
+          "name": "provider_security_reconciliation_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      ",
+          "withCheck": "\n        \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_resolver_select": {
+          "name": "provider_security_reconciliation_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_provider_security_resolver"],
+          "using": "\n        session_user = 'openschool_worker'\n        AND current_user = 'openschool_provider_security_resolver'\n        AND \"provider_security_reconciliation_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'provider_mfa_reconciliation'\n        AND nullif(current_setting('app.job_id', true), '') IS NOT NULL\n        AND nullif(current_setting('app.request_id', true), '') IS NOT NULL\n      "
+        },
+        "provider_security_reconciliation_identity_resolver_select": {
+          "name": "provider_security_reconciliation_identity_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_provider_security_resolver"],
+          "using": "\n        session_user = 'openschool_runtime'\n        AND current_user = 'openschool_provider_security_resolver'\n        AND EXISTS (\n          SELECT 1 FROM public.accounts AS verified_account\n          WHERE verified_account.id = \"provider_security_reconciliation_outbox\".\"account_id\"\n            AND verified_account.identity_provider = nullif(current_setting('app.identity_provider', true), '')\n            AND verified_account.provider_subject = nullif(current_setting('app.provider_subject', true), '')\n        )\n      "
+        }
+      },
+      "checkConstraints": {
+        "provider_security_reconciliation_action_check": {
+          "name": "provider_security_reconciliation_action_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"action\" = 'reset_mfa'"
+        },
+        "provider_security_reconciliation_version_check": {
+          "name": "provider_security_reconciliation_version_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"expected_security_version\" > 0"
+        },
+        "provider_security_reconciliation_request_check": {
+          "name": "provider_security_reconciliation_request_check",
+          "value": "char_length(\"provider_security_reconciliation_outbox\".\"request_id\") BETWEEN 1 AND 512"
+        },
+        "provider_security_reconciliation_attempt_check": {
+          "name": "provider_security_reconciliation_attempt_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"attempt_count\" >= 0"
+        },
+        "provider_security_reconciliation_status_check": {
+          "name": "provider_security_reconciliation_status_check",
+          "value": "\"provider_security_reconciliation_outbox\".\"status\" IN ('pending', 'processing', 'completed', 'failed', 'dead_letter')"
+        },
+        "provider_security_reconciliation_status_evidence_check": {
+          "name": "provider_security_reconciliation_status_evidence_check",
+          "value": "(\"provider_security_reconciliation_outbox\".\"status\" = 'pending' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" = 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'processing' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NOT NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'completed' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NOT NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" >= 0 AND \"provider_security_reconciliation_outbox\".\"last_error_code\" IS NULL)\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'failed' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')\n          OR (\"provider_security_reconciliation_outbox\".\"status\" = 'dead_letter' AND \"provider_security_reconciliation_outbox\".\"attempt_count\" > 0 AND \"provider_security_reconciliation_outbox\".\"locked_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"completed_at\" IS NULL AND \"provider_security_reconciliation_outbox\".\"deleted_factor_count\" IS NULL AND \"provider_security_reconciliation_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_access_grants": {
+      "name": "support_access_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_account_id": {
+          "name": "support_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_access_grant_id": {
+          "name": "platform_access_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_organization_id": {
+          "name": "education_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_capabilities": {
+          "name": "allowed_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_reference": {
+          "name": "ticket_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emergency_rule_reference": {
+          "name": "emergency_rule_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_by_account_id": {
+          "name": "authorized_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_by_person_id": {
+          "name": "authorized_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_reason": {
+          "name": "authorization_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_account_session_id": {
+          "name": "bound_account_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_account_id": {
+          "name": "closed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_person_id": {
+          "name": "closed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_account_id": {
+          "name": "revoked_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_person_id": {
+          "name": "revoked_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_due'"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_account_id": {
+          "name": "reviewed_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_person_id": {
+          "name": "reviewed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_outcome": {
+          "name": "review_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_notes": {
+          "name": "review_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_access_grants_resolve_idx": {
+          "name": "support_access_grants_resolve_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "support_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_access_grants_review_idx": {
+          "name": "support_access_grants_review_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_access_grants_tenant_id_tenants_id_fk": {
+          "name": "support_access_grants_tenant_id_tenants_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_support_account_id_accounts_id_fk": {
+          "name": "support_access_grants_support_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["support_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_platform_access_grant_id_platform_access_grants_id_fk": {
+          "name": "support_access_grants_platform_access_grant_id_platform_access_grants_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "platform_access_grants",
+          "columnsFrom": ["platform_access_grant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_authorized_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_authorized_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["authorized_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_bound_account_session_id_account_sessions_id_fk": {
+          "name": "support_access_grants_bound_account_session_id_account_sessions_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "account_sessions",
+          "columnsFrom": ["bound_account_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_closed_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_closed_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["closed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_revoked_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_revoked_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["revoked_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_reviewed_by_account_id_accounts_id_fk": {
+          "name": "support_access_grants_reviewed_by_account_id_accounts_id_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "accounts",
+          "columnsFrom": ["reviewed_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_organization_fk": {
+          "name": "support_access_grants_tenant_organization_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "education_organizations",
+          "columnsFrom": ["tenant_id", "education_organization_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_school_fk": {
+          "name": "support_access_grants_tenant_school_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "schools",
+          "columnsFrom": ["tenant_id", "school_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_authorizer_person_fk": {
+          "name": "support_access_grants_tenant_authorizer_person_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "authorized_by_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_closer_person_fk": {
+          "name": "support_access_grants_tenant_closer_person_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "closed_by_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_revoker_person_fk": {
+          "name": "support_access_grants_tenant_revoker_person_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "revoked_by_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_grants_tenant_reviewer_person_fk": {
+          "name": "support_access_grants_tenant_reviewer_person_fk",
+          "tableFrom": "support_access_grants",
+          "tableTo": "people",
+          "columnsFrom": ["tenant_id", "reviewed_by_person_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_access_grants_tenant_id_id_unique": {
+          "name": "support_access_grants_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        }
+      },
+      "policies": {
+        "support_access_grants_manager_select": {
+          "name": "support_access_grants_manager_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_support_grant_manager"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_manager_insert": {
+          "name": "support_access_grants_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_manager_update": {
+          "name": "support_access_grants_manager_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_support_grant_manager"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid",
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_grants_resolver_select": {
+          "name": "support_access_grants_resolver_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_support_access_resolver"],
+          "using": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_grants_resolver_update": {
+          "name": "support_access_grants_resolver_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_support_access_resolver"],
+          "using": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid",
+          "withCheck": "\"support_access_grants\".\"id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_grants_worker_select": {
+          "name": "support_access_grants_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        },
+        "support_access_grants_worker_update": {
+          "name": "support_access_grants_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'",
+          "withCheck": "\"support_access_grants\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        }
+      },
+      "checkConstraints": {
+        "support_access_grants_kind_check": {
+          "name": "support_access_grants_kind_check",
+          "value": "\"support_access_grants\".\"kind\" IN ('support', 'break_glass')"
+        },
+        "support_access_grants_status_check": {
+          "name": "support_access_grants_status_check",
+          "value": "\"support_access_grants\".\"status\" IN ('approved', 'active', 'closed', 'revoked', 'expired')"
+        },
+        "support_access_grants_scope_check": {
+          "name": "support_access_grants_scope_check",
+          "value": "(\"support_access_grants\".\"scope_type\" = 'tenant' AND \"support_access_grants\".\"education_organization_id\" IS NULL AND \"support_access_grants\".\"school_id\" IS NULL)\n          OR (\"support_access_grants\".\"scope_type\" = 'organization_subtree' AND \"support_access_grants\".\"education_organization_id\" IS NOT NULL AND \"support_access_grants\".\"school_id\" IS NULL)\n          OR (\"support_access_grants\".\"scope_type\" = 'school' AND \"support_access_grants\".\"education_organization_id\" IS NULL AND \"support_access_grants\".\"school_id\" IS NOT NULL)"
+        },
+        "support_access_grants_capabilities_check": {
+          "name": "support_access_grants_capabilities_check",
+          "value": "jsonb_typeof(\"support_access_grants\".\"allowed_capabilities\") = 'array'\n          AND jsonb_array_length(\"support_access_grants\".\"allowed_capabilities\") BETWEEN 1 AND 2\n          AND \"support_access_grants\".\"allowed_capabilities\" <@ '[\"support.schools.read\", \"support.students.read\"]'::jsonb\n          AND (jsonb_array_length(\"support_access_grants\".\"allowed_capabilities\") = 1\n            OR (\"support_access_grants\".\"allowed_capabilities\" ? 'support.schools.read'\n              AND \"support_access_grants\".\"allowed_capabilities\" ? 'support.students.read'))"
+        },
+        "support_access_grants_purpose_check": {
+          "name": "support_access_grants_purpose_check",
+          "value": "\"support_access_grants\".\"purpose\" IN ('customer_support', 'incident_response')\n          AND (\"support_access_grants\".\"kind\" <> 'break_glass' OR \"support_access_grants\".\"purpose\" = 'incident_response')"
+        },
+        "support_access_grants_reference_check": {
+          "name": "support_access_grants_reference_check",
+          "value": "char_length(btrim(\"support_access_grants\".\"ticket_reference\")) BETWEEN 3 AND 128\n          AND char_length(btrim(\"support_access_grants\".\"authorization_reason\")) BETWEEN 3 AND 512\n          AND (\"support_access_grants\".\"emergency_rule_reference\" IS NULL OR char_length(btrim(\"support_access_grants\".\"emergency_rule_reference\")) BETWEEN 3 AND 128)\n          AND (\"support_access_grants\".\"close_reason\" IS NULL OR char_length(btrim(\"support_access_grants\".\"close_reason\")) BETWEEN 3 AND 512)\n          AND (\"support_access_grants\".\"revocation_reason\" IS NULL OR char_length(btrim(\"support_access_grants\".\"revocation_reason\")) BETWEEN 3 AND 512)\n          AND (\"support_access_grants\".\"review_notes\" IS NULL OR char_length(btrim(\"support_access_grants\".\"review_notes\")) BETWEEN 3 AND 2048)"
+        },
+        "support_access_grants_authorizer_check": {
+          "name": "support_access_grants_authorizer_check",
+          "value": "(\"support_access_grants\".\"kind\" = 'support' AND \"support_access_grants\".\"authorized_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"emergency_rule_reference\" IS NULL)\n          OR (\"support_access_grants\".\"kind\" = 'break_glass' AND \"support_access_grants\".\"authorized_by_person_id\" IS NULL AND \"support_access_grants\".\"emergency_rule_reference\" IS NOT NULL)"
+        },
+        "support_access_grants_period_check": {
+          "name": "support_access_grants_period_check",
+          "value": "\"support_access_grants\".\"valid_until\" > \"support_access_grants\".\"valid_from\"\n          AND ((\"support_access_grants\".\"kind\" = 'support' AND \"support_access_grants\".\"valid_until\" <= \"support_access_grants\".\"valid_from\" + interval '8 hours')\n            OR (\"support_access_grants\".\"kind\" = 'break_glass' AND \"support_access_grants\".\"valid_until\" <= \"support_access_grants\".\"valid_from\" + interval '30 minutes'))"
+        },
+        "support_access_grants_state_evidence_check": {
+          "name": "support_access_grants_state_evidence_check",
+          "value": "(\"support_access_grants\".\"status\" = 'approved' AND \"support_access_grants\".\"bound_account_session_id\" IS NULL AND \"support_access_grants\".\"opened_at\" IS NULL AND \"support_access_grants\".\"closed_at\" IS NULL AND \"support_access_grants\".\"closed_by_account_id\" IS NULL AND \"support_access_grants\".\"closed_by_person_id\" IS NULL AND \"support_access_grants\".\"close_reason\" IS NULL AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"review_status\" = 'not_due')\n          OR (\"support_access_grants\".\"status\" = 'active' AND \"support_access_grants\".\"bound_account_session_id\" IS NOT NULL AND \"support_access_grants\".\"opened_at\" IS NOT NULL AND \"support_access_grants\".\"closed_at\" IS NULL AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"review_status\" = 'not_due')\n          OR (\"support_access_grants\".\"status\" IN ('closed', 'expired') AND \"support_access_grants\".\"revoked_at\" IS NULL AND \"support_access_grants\".\"closed_at\" IS NOT NULL AND \"support_access_grants\".\"close_reason\" IS NOT NULL AND \"support_access_grants\".\"review_status\" IN ('pending', 'completed'))\n          OR (\"support_access_grants\".\"status\" = 'revoked' AND \"support_access_grants\".\"revoked_at\" IS NOT NULL AND \"support_access_grants\".\"revoked_by_account_id\" IS NOT NULL AND \"support_access_grants\".\"revoked_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"revocation_reason\" IS NOT NULL AND \"support_access_grants\".\"review_status\" IN ('pending', 'completed'))"
+        },
+        "support_access_grants_review_evidence_check": {
+          "name": "support_access_grants_review_evidence_check",
+          "value": "(\"support_access_grants\".\"review_status\" IN ('not_due', 'pending') AND \"support_access_grants\".\"reviewed_at\" IS NULL AND \"support_access_grants\".\"reviewed_by_account_id\" IS NULL AND \"support_access_grants\".\"reviewed_by_person_id\" IS NULL AND \"support_access_grants\".\"review_outcome\" IS NULL AND \"support_access_grants\".\"review_notes\" IS NULL)\n          OR (\"support_access_grants\".\"review_status\" = 'completed' AND \"support_access_grants\".\"reviewed_at\" IS NOT NULL AND \"support_access_grants\".\"reviewed_by_account_id\" IS NOT NULL AND \"support_access_grants\".\"reviewed_by_person_id\" IS NOT NULL AND \"support_access_grants\".\"review_outcome\" IN ('confirmed', 'no_impact', 'control_gap', 'incident') AND \"support_access_grants\".\"review_notes\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_access_notifications": {
+      "name": "support_access_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_grant_id": {
+          "name": "support_grant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_account_id": {
+          "name": "actor_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tenant_security_admins'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_access_notifications_tenant_time_idx": {
+          "name": "support_access_notifications_tenant_time_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_access_notifications_tenant_id_tenants_id_fk": {
+          "name": "support_access_notifications_tenant_id_tenants_id_fk",
+          "tableFrom": "support_access_notifications",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_notifications_actor_account_id_accounts_id_fk": {
+          "name": "support_access_notifications_actor_account_id_accounts_id_fk",
+          "tableFrom": "support_access_notifications",
+          "tableTo": "accounts",
+          "columnsFrom": ["actor_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_access_notifications_grant_fk": {
+          "name": "support_access_notifications_grant_fk",
+          "tableFrom": "support_access_notifications",
+          "tableTo": "support_access_grants",
+          "columnsFrom": ["tenant_id", "support_grant_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_access_notifications_tenant_id_id_unique": {
+          "name": "support_access_notifications_tenant_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "id"]
+        },
+        "support_access_notifications_operation_unique": {
+          "name": "support_access_notifications_operation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "support_grant_id", "event", "operation_id"]
+        }
+      },
+      "policies": {
+        "support_access_notifications_runtime_select": {
+          "name": "support_access_notifications_runtime_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_runtime"],
+          "using": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.policy_capability', true), '') = 'tenant.support.grants.manage'\n        AND openschool_private.tenant_admin_can_view_support_notification(\n          \"support_access_notifications\".\"tenant_id\",\n          nullif(current_setting('app.person_id', true), '')::uuid,\n          \"support_access_notifications\".\"support_grant_id\",\n          statement_timestamp()\n        )"
+        },
+        "support_access_notifications_manager_insert": {
+          "name": "support_access_notifications_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_access_notifications_resolver_insert": {
+          "name": "support_access_notifications_resolver_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_access_resolver"],
+          "withCheck": "\"support_access_notifications\".\"support_grant_id\" = nullif(current_setting('app.support_grant_id', true), '')::uuid"
+        },
+        "support_access_notifications_worker_insert": {
+          "name": "support_access_notifications_worker_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_worker"],
+          "withCheck": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_access_expiry'"
+        },
+        "support_access_notifications_worker_select": {
+          "name": "support_access_notifications_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_access_notifications\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        }
+      },
+      "checkConstraints": {
+        "support_access_notifications_event_check": {
+          "name": "support_access_notifications_event_check",
+          "value": "\"support_access_notifications\".\"event\" IN ('approved', 'opened', 'used', 'closed', 'revoked', 'expired', 'reviewed', 'break_glass_opened')"
+        },
+        "support_access_notifications_audience_check": {
+          "name": "support_access_notifications_audience_check",
+          "value": "\"support_access_notifications\".\"audience\" = 'tenant_security_admins'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.support_notification_outbox": {
+      "name": "support_notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_notification_outbox_claim_idx": {
+          "name": "support_notification_outbox_claim_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_notification_outbox_tenant_id_tenants_id_fk": {
+          "name": "support_notification_outbox_tenant_id_tenants_id_fk",
+          "tableFrom": "support_notification_outbox",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        },
+        "support_notification_outbox_notification_fk": {
+          "name": "support_notification_outbox_notification_fk",
+          "tableFrom": "support_notification_outbox",
+          "tableTo": "support_access_notifications",
+          "columnsFrom": ["tenant_id", "notification_id"],
+          "columnsTo": ["tenant_id", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "support_notification_outbox_notification_unique": {
+          "name": "support_notification_outbox_notification_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "notification_id"]
+        }
+      },
+      "policies": {
+        "support_notification_outbox_manager_insert": {
+          "name": "support_notification_outbox_manager_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_grant_manager"],
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid"
+        },
+        "support_notification_outbox_resolver_insert": {
+          "name": "support_notification_outbox_resolver_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["openschool_support_access_resolver"],
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.support_grant_id', true), '') IS NOT NULL"
+        },
+        "support_notification_outbox_worker_select": {
+          "name": "support_notification_outbox_worker_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["openschool_worker"],
+          "using": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        },
+        "support_notification_outbox_worker_update": {
+          "name": "support_notification_outbox_worker_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": ["openschool_worker"],
+          "using": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'",
+          "withCheck": "\"support_notification_outbox\".\"tenant_id\" = nullif(current_setting('app.tenant_id', true), '')::uuid\n        AND nullif(current_setting('app.job_type', true), '') = 'support_notification_delivery'"
+        }
+      },
+      "checkConstraints": {
+        "support_notification_outbox_attempt_check": {
+          "name": "support_notification_outbox_attempt_check",
+          "value": "\"support_notification_outbox\".\"attempt_count\" >= 0"
+        },
+        "support_notification_outbox_status_check": {
+          "name": "support_notification_outbox_status_check",
+          "value": "\"support_notification_outbox\".\"status\" IN ('pending', 'processing', 'delivered', 'failed', 'dead_letter')"
+        },
+        "support_notification_outbox_state_check": {
+          "name": "support_notification_outbox_state_check",
+          "value": "(\"support_notification_outbox\".\"status\" = 'pending' AND \"support_notification_outbox\".\"attempt_count\" = 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" = 'processing' AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NOT NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" = 'delivered' AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NOT NULL AND \"support_notification_outbox\".\"last_error_code\" IS NULL)\n          OR (\"support_notification_outbox\".\"status\" IN ('failed', 'dead_letter') AND \"support_notification_outbox\".\"attempt_count\" > 0 AND \"support_notification_outbox\".\"locked_at\" IS NULL AND \"support_notification_outbox\".\"delivered_at\" IS NULL AND \"support_notification_outbox\".\"last_error_code\" ~ '^[A-Z][A-Z0-9_]{2,63}$')"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1786673455685,
       "tag": "0042_brave_maelstrom",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1786677604726,
+      "tag": "0043_person_merge_plan_v2",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1786677604726,
       "tag": "0043_person_merge_plan_v2",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1786683220198,
+      "tag": "0044_person_merge_execution",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1786606767950,
       "tag": "0041_person_merge_preview_workflow",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1786673455685,
+      "tag": "0042_brave_maelstrom",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/isolation-release-evidence-poc.ts
+++ b/packages/db/src/isolation-release-evidence-poc.ts
@@ -89,7 +89,7 @@ async function run(): Promise<void> {
       readFileSync(new URL('../migrations/meta/_journal.json', import.meta.url), 'utf8')
     ) as { entries?: Array<{ tag?: string }> }
     const migration = journal.entries?.at(-1)?.tag
-    assert.equal(migration, '0041_person_merge_preview_workflow')
+    assert.equal(migration, '0042_brave_maelstrom')
 
     const roles = await admin.execute<RoleDefinition>(sql`
       select

--- a/packages/db/src/isolation-release-evidence-poc.ts
+++ b/packages/db/src/isolation-release-evidence-poc.ts
@@ -89,7 +89,7 @@ async function run(): Promise<void> {
       readFileSync(new URL('../migrations/meta/_journal.json', import.meta.url), 'utf8')
     ) as { entries?: Array<{ tag?: string }> }
     const migration = journal.entries?.at(-1)?.tag
-    assert.equal(migration, '0042_brave_maelstrom')
+    assert.equal(migration, '0043_person_merge_plan_v2')
 
     const roles = await admin.execute<RoleDefinition>(sql`
       select

--- a/packages/db/src/isolation-release-evidence-poc.ts
+++ b/packages/db/src/isolation-release-evidence-poc.ts
@@ -89,7 +89,7 @@ async function run(): Promise<void> {
       readFileSync(new URL('../migrations/meta/_journal.json', import.meta.url), 'utf8')
     ) as { entries?: Array<{ tag?: string }> }
     const migration = journal.entries?.at(-1)?.tag
-    assert.equal(migration, '0043_person_merge_plan_v2')
+    assert.equal(migration, '0044_person_merge_execution')
 
     const roles = await admin.execute<RoleDefinition>(sql`
       select

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -825,4 +825,34 @@ describe('database migration baseline', () => {
       assert.equal(migration.includes(expected), true, `execution ledger must include ${expected}`)
     }
   })
+
+  it('finalizes dependency-complete Person merge plan version 2', () => {
+    const migration = readFileSync(
+      join(migrationsDirectory, '0043_person_merge_plan_v2.sql'),
+      'utf8'
+    )
+    for (const expected of [
+      'create_person_merge_preview_v1',
+      'finalize_person_merge_preview_v2',
+      "'kind', 'derived_dependency'",
+      "'path', 'affiliation_role'",
+      "'path', 'account_invalidation'",
+      "'path', 'account_session'",
+      "'path', 'legacy_enrollment_grade'",
+      'TARGET_ACCOUNT_LINK_EXISTS',
+      'TARGET_AFFILIATION_EXISTS',
+      'TARGET_HOUSEHOLD_MEMBERSHIP_EXISTS',
+      'TARGET_RELATIONSHIP_EXISTS',
+      'TARGET_SCHOOL_ENROLLMENT_EXISTS',
+      'TARGET_SECTION_STAFF_EXISTS',
+      'TARGET_SECTION_ROSTER_EXISTS',
+      "'plan:2:'",
+      'assert_person_merge_plan_v2_current',
+      'approve_person_merge_preview_v1',
+      'PERSON_MERGE_DERIVED_DEPENDENCY_SET_CHANGED',
+      'Person merge plan v2 implementation helpers are exposed',
+    ]) {
+      assert.equal(migration.includes(expected), true, `plan v2 must include ${expected}`)
+    }
+  })
 })

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -873,7 +873,7 @@ describe('database migration baseline', () => {
       "SET status = 'revoked'",
       'membership_version = account.membership_version + 1',
       'CREATE FUNCTION "openschool_private"."execute_person_merge"',
-      "'person.merge.execute'",
+      "'person_merge.execute'",
       "'audit.event.committed'",
       'Person merge execution authority is misconfigured',
     ]) {

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -805,4 +805,24 @@ describe('database migration baseline', () => {
       'approval must reject the initiating Account'
     )
   })
+
+  it('installs a forced-RLS Person merge alias and immutable move ledger', () => {
+    const migration = readFileSync(join(migrationsDirectory, '0042_brave_maelstrom.sql'), 'utf8')
+    for (const expected of [
+      'CREATE TABLE "person_merge_aliases"',
+      'CREATE TABLE "person_merge_moves"',
+      '"plan_version" integer DEFAULT 1 NOT NULL',
+      '"execution_digest" text',
+      'person_merge_aliases_tenant_source_unique',
+      'person_merge_moves_operation_sequence_unique',
+      'ALTER TABLE "person_merge_aliases" FORCE ROW LEVEL SECURITY',
+      'ALTER TABLE "person_merge_moves" FORCE ROW LEVEL SECURITY',
+      'person_merge_moves_append_only',
+      'people_merged_alias_immutable',
+      'OLD.plan_version IS DISTINCT FROM NEW.plan_version',
+      "'tenant.people_merges.execute'",
+    ]) {
+      assert.equal(migration.includes(expected), true, `execution ledger must include ${expected}`)
+    }
+  })
 })

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -819,6 +819,7 @@ describe('database migration baseline', () => {
       'ALTER TABLE "person_merge_moves" FORCE ROW LEVEL SECURITY',
       'person_merge_moves_append_only',
       'people_merged_alias_immutable',
+      'CREATE FUNCTION "openschool_private"."protect_merged_person_alias"()\nRETURNS trigger\nLANGUAGE plpgsql\nSECURITY DEFINER',
       'OLD.plan_version IS DISTINCT FROM NEW.plan_version',
       "'tenant.people_merges.execute'",
     ]) {

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -856,4 +856,27 @@ describe('database migration baseline', () => {
       assert.equal(migration.includes(expected), true, `plan v2 must include ${expected}`)
     }
   })
+
+  it('executes approved Person merges atomically through one guarded authority', () => {
+    const migration = readFileSync(
+      join(migrationsDirectory, '0044_person_merge_execution.sql'),
+      'utf8'
+    )
+    for (const expected of [
+      "'merge_executed'",
+      'guard_operational_person_reference',
+      'IN SHARE ROW EXCLUSIVE MODE',
+      'assert_person_merge_plan_v2_current',
+      'PERSON_MERGE_APPROVAL_CHANGED',
+      'PERSON_MERGE_OPERATIONAL_REFERENCE_REMAINS',
+      "SET status = 'revoked'",
+      'membership_version = account.membership_version + 1',
+      'CREATE FUNCTION "openschool_private"."execute_person_merge"',
+      "'person.merge.execute'",
+      "'audit.event.committed'",
+      'Person merge execution authority is misconfigured',
+    ]) {
+      assert.equal(migration.includes(expected), true, `execution must include ${expected}`)
+    }
+  })
 })

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -865,6 +865,7 @@ describe('database migration baseline', () => {
     for (const expected of [
       "'merge_executed'",
       'guard_operational_person_reference',
+      "IF FOUND AND v_status NOT IN ('active', 'suspended')",
       'IN SHARE ROW EXCLUSIVE MODE',
       'assert_person_merge_plan_v2_current',
       'PERSON_MERGE_APPROVAL_CHANGED',

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -847,6 +847,8 @@ describe('database migration baseline', () => {
       'TARGET_SCHOOL_ENROLLMENT_EXISTS',
       'TARGET_SECTION_STAFF_EXISTS',
       'TARGET_SECTION_ROSTER_EXISTS',
+      'PENDING_INVITATION_REQUIRES_RESOLUTION',
+      "jsonb_build_object('lifecycle', 'terminal')",
       "'plan:2:'",
       'assert_person_merge_plan_v2_current',
       'approve_person_merge_preview_v1',

--- a/packages/db/src/schema/duplicate-review.ts
+++ b/packages/db/src/schema/duplicate-review.ts
@@ -171,6 +171,7 @@ export const personDuplicateCaseEvents = pgTable(
         'evidence_no_longer_matches',
         'marked_distinct',
         'merge_approval_requested',
+        'merge_executed',
       ],
     }).notNull(),
     score: integer('score').notNull(),
@@ -212,7 +213,7 @@ export const personDuplicateCaseEvents = pgTable(
     check('person_duplicate_case_events_version_check', sql`${table.version} > 0`),
     check(
       'person_duplicate_case_events_type_check',
-      sql`${table.eventType} IN ('candidate_detected', 'evidence_refreshed', 'evidence_no_longer_matches', 'marked_distinct', 'merge_approval_requested')`
+      sql`${table.eventType} IN ('candidate_detected', 'evidence_refreshed', 'evidence_no_longer_matches', 'marked_distinct', 'merge_approval_requested', 'merge_executed')`
     ),
     check('person_duplicate_case_events_score_check', sql`${table.score} BETWEEN 0 AND 100`),
     check(

--- a/packages/db/src/schema/person-merge.ts
+++ b/packages/db/src/schema/person-merge.ts
@@ -60,16 +60,29 @@ export const PERSON_MERGE_EVENT_TYPES = [
   'manual_recovery_required',
 ] as const
 
+export const PERSON_MERGE_ALIAS_STATUSES = ['active', 'reversed'] as const
+
+export const PERSON_MERGE_MOVE_ACTIONS = [
+  'repoint',
+  'end_and_recreate',
+  'preserve_history',
+  'invalidate',
+  'archive_source',
+] as const
+
 export type PersonMergeOperationStatus = (typeof PERSON_MERGE_OPERATION_STATUSES)[number]
 export type PersonMergePreviewCategory = (typeof PERSON_MERGE_PREVIEW_CATEGORIES)[number]
 export type PersonMergePreviewDisposition = (typeof PERSON_MERGE_PREVIEW_DISPOSITIONS)[number]
 export type PersonMergeEventType = (typeof PERSON_MERGE_EVENT_TYPES)[number]
+export type PersonMergeAliasStatus = (typeof PERSON_MERGE_ALIAS_STATUSES)[number]
+export type PersonMergeMoveAction = (typeof PERSON_MERGE_MOVE_ACTIONS)[number]
 
 const mergeCapabilities = sql`
   nullif(current_setting('app.policy_capability', true), '') IN (
     'tenant.people_merges.read',
     'tenant.people_merges.preview',
-    'tenant.people_merges.approve'
+    'tenant.people_merges.approve',
+    'tenant.people_merges.execute'
   )
 `
 
@@ -102,9 +115,12 @@ export const personMergeOperations = pgTable(
     targetPersonId: uuid('target_person_id').notNull(),
     status: text('status', { enum: PERSON_MERGE_OPERATION_STATUSES }).notNull(),
     currentVersion: integer('current_version').default(1).notNull(),
+    planVersion: integer('plan_version').default(1).notNull(),
     previewDigest: text('preview_digest').notNull(),
+    executionDigest: text('execution_digest'),
     dependencyCount: integer('dependency_count').default(0).notNull(),
     conflictCount: integer('conflict_count').default(0).notNull(),
+    invalidationCount: integer('invalidation_count').default(0).notNull(),
     initiatedByAccountId: uuid('initiated_by_account_id')
       .references(() => accounts.id, { onDelete: 'restrict', onUpdate: 'restrict' })
       .notNull(),
@@ -182,14 +198,21 @@ export const personMergeOperations = pgTable(
       'person_merge_operations_people_check',
       sql`${table.sourcePersonId} <> ${table.targetPersonId}`
     ),
-    check('person_merge_operations_version_check', sql`${table.currentVersion} > 0`),
+    check(
+      'person_merge_operations_version_check',
+      sql`${table.currentVersion} > 0 AND ${table.planVersion} > 0`
+    ),
     check(
       'person_merge_operations_hash_check',
-      sql`${table.duplicateEvidenceHash} ~ '^[0-9a-f]{64}$' AND ${table.previewDigest} ~ '^[0-9a-f]{64}$'`
+      sql`${table.duplicateEvidenceHash} ~ '^[0-9a-f]{64}$'
+        AND ${table.previewDigest} ~ '^[0-9a-f]{64}$'
+        AND (${table.executionDigest} IS NULL OR ${table.executionDigest} ~ '^[0-9a-f]{64}$')`
     ),
     check(
       'person_merge_operations_count_check',
-      sql`${table.dependencyCount} >= 0 AND ${table.conflictCount} >= 0 AND ${table.conflictCount} <= ${table.dependencyCount}`
+      sql`${table.dependencyCount} >= 0 AND ${table.conflictCount} >= 0
+        AND ${table.conflictCount} <= ${table.dependencyCount}
+        AND ${table.invalidationCount} >= 0`
     ),
     check(
       'person_merge_operations_reason_check',
@@ -205,7 +228,8 @@ export const personMergeOperations = pgTable(
     check(
       'person_merge_operations_execution_check',
       sql`${table.status} NOT IN ('executed', 'reversed', 'manual_recovery')
-        OR (${table.executedByAccountId} IS NOT NULL AND ${table.executedAt} IS NOT NULL)`
+        OR (${table.executedByAccountId} IS NOT NULL AND ${table.executedAt} IS NOT NULL
+          AND ${table.executionDigest} IS NOT NULL)`
     ),
     check(
       'person_merge_operations_reversal_check',
@@ -224,6 +248,179 @@ export const personMergeOperations = pgTable(
       withCheck: sql`false`,
     }),
     pgPolicy('person_merge_operations_manager_all', {
+      for: 'all',
+      to: 'openschool_person_merge_manager',
+      using: managerAccess(table.tenantId, table.reviewSchoolId),
+      withCheck: managerAccess(table.tenantId, table.reviewSchoolId),
+    }),
+  ]
+).enableRLS()
+
+export const personMergeAliases = pgTable(
+  'person_merge_aliases',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, { onDelete: 'restrict', onUpdate: 'restrict' })
+      .notNull(),
+    reviewSchoolId: uuid('review_school_id').notNull(),
+    operationId: uuid('operation_id').notNull(),
+    sourcePersonId: uuid('source_person_id').notNull(),
+    targetPersonId: uuid('target_person_id').notNull(),
+    status: text('status', { enum: PERSON_MERGE_ALIAS_STATUSES }).default('active').notNull(),
+    version: integer('version').default(1).notNull(),
+    mergedAt: timestamp('merged_at', { withTimezone: true }).notNull(),
+    reversedAt: timestamp('reversed_at', { withTimezone: true }),
+    reversedByAccountId: uuid('reversed_by_account_id').references(() => accounts.id, {
+      onDelete: 'restrict',
+      onUpdate: 'restrict',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    unique('person_merge_aliases_tenant_id_id_unique').on(table.tenantId, table.id),
+    unique('person_merge_aliases_tenant_source_unique').on(table.tenantId, table.sourcePersonId),
+    unique('person_merge_aliases_tenant_operation_unique').on(table.tenantId, table.operationId),
+    foreignKey({
+      name: 'person_merge_aliases_tenant_operation_fk',
+      columns: [table.tenantId, table.operationId],
+      foreignColumns: [personMergeOperations.tenantId, personMergeOperations.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    foreignKey({
+      name: 'person_merge_aliases_tenant_school_fk',
+      columns: [table.tenantId, table.reviewSchoolId],
+      foreignColumns: [schools.tenantId, schools.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    foreignKey({
+      name: 'person_merge_aliases_tenant_source_fk',
+      columns: [table.tenantId, table.sourcePersonId],
+      foreignColumns: [people.tenantId, people.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    foreignKey({
+      name: 'person_merge_aliases_tenant_target_fk',
+      columns: [table.tenantId, table.targetPersonId],
+      foreignColumns: [people.tenantId, people.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('person_merge_aliases_target_idx').on(table.tenantId, table.targetPersonId, table.status),
+    check(
+      'person_merge_aliases_people_check',
+      sql`${table.sourcePersonId} <> ${table.targetPersonId}`
+    ),
+    check('person_merge_aliases_status_check', sql`${table.status} IN ('active', 'reversed')`),
+    check('person_merge_aliases_version_check', sql`${table.version} > 0`),
+    check(
+      'person_merge_aliases_reversal_check',
+      sql`${table.status} <> 'reversed'
+        OR (${table.reversedAt} IS NOT NULL AND ${table.reversedByAccountId} IS NOT NULL)`
+    ),
+    pgPolicy('person_merge_aliases_runtime_select', {
+      for: 'select',
+      to: 'openschool_runtime',
+      using: runtimeRead(table.tenantId, table.reviewSchoolId),
+    }),
+    pgPolicy('person_merge_aliases_runtime_write_deny', {
+      for: 'all',
+      to: 'openschool_runtime',
+      using: sql`false`,
+      withCheck: sql`false`,
+    }),
+    pgPolicy('person_merge_aliases_manager_all', {
+      for: 'all',
+      to: 'openschool_person_merge_manager',
+      using: managerAccess(table.tenantId, table.reviewSchoolId),
+      withCheck: managerAccess(table.tenantId, table.reviewSchoolId),
+    }),
+  ]
+).enableRLS()
+
+export const personMergeMoves = pgTable(
+  'person_merge_moves',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .references(() => tenants.id, { onDelete: 'restrict', onUpdate: 'restrict' })
+      .notNull(),
+    reviewSchoolId: uuid('review_school_id').notNull(),
+    operationId: uuid('operation_id').notNull(),
+    sequence: integer('sequence').notNull(),
+    relationName: text('relation_name').notNull(),
+    sourceRecordKey: text('source_record_key').notNull(),
+    replacementRecordKey: text('replacement_record_key'),
+    action: text('action', { enum: PERSON_MERGE_MOVE_ACTIONS }).notNull(),
+    beforeFingerprint: text('before_fingerprint').notNull(),
+    afterFingerprint: text('after_fingerprint').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    unique('person_merge_moves_tenant_id_id_unique').on(table.tenantId, table.id),
+    unique('person_merge_moves_operation_sequence_unique').on(
+      table.tenantId,
+      table.operationId,
+      table.sequence
+    ),
+    unique('person_merge_moves_operation_record_unique').on(
+      table.tenantId,
+      table.operationId,
+      table.relationName,
+      table.sourceRecordKey
+    ),
+    foreignKey({
+      name: 'person_merge_moves_tenant_operation_fk',
+      columns: [table.tenantId, table.operationId],
+      foreignColumns: [personMergeOperations.tenantId, personMergeOperations.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    foreignKey({
+      name: 'person_merge_moves_tenant_school_fk',
+      columns: [table.tenantId, table.reviewSchoolId],
+      foreignColumns: [schools.tenantId, schools.id],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    index('person_merge_moves_operation_idx').on(
+      table.tenantId,
+      table.operationId,
+      table.sequence,
+      table.id
+    ),
+    check('person_merge_moves_sequence_check', sql`${table.sequence} > 0`),
+    check(
+      'person_merge_moves_action_check',
+      sql`${table.action} IN ('repoint', 'end_and_recreate', 'preserve_history', 'invalidate', 'archive_source')`
+    ),
+    check(
+      'person_merge_moves_text_check',
+      sql`char_length(${table.relationName}) BETWEEN 3 AND 128
+        AND char_length(${table.sourceRecordKey}) BETWEEN 1 AND 512
+        AND (${table.replacementRecordKey} IS NULL
+          OR char_length(${table.replacementRecordKey}) BETWEEN 1 AND 512)`
+    ),
+    check(
+      'person_merge_moves_hash_check',
+      sql`${table.beforeFingerprint} ~ '^[0-9a-f]{64}$'
+        AND ${table.afterFingerprint} ~ '^[0-9a-f]{64}$'`
+    ),
+    pgPolicy('person_merge_moves_runtime_select', {
+      for: 'select',
+      to: 'openschool_runtime',
+      using: runtimeRead(table.tenantId, table.reviewSchoolId),
+    }),
+    pgPolicy('person_merge_moves_runtime_write_deny', {
+      for: 'all',
+      to: 'openschool_runtime',
+      using: sql`false`,
+      withCheck: sql`false`,
+    }),
+    pgPolicy('person_merge_moves_manager_all', {
       for: 'all',
       to: 'openschool_person_merge_manager',
       using: managerAccess(table.tenantId, table.reviewSchoolId),
@@ -412,3 +609,5 @@ export const personMergeEvents = pgTable(
 export type PersonMergeOperation = typeof personMergeOperations.$inferSelect
 export type PersonMergePreviewItem = typeof personMergePreviewItems.$inferSelect
 export type PersonMergeEvent = typeof personMergeEvents.$inferSelect
+export type PersonMergeAlias = typeof personMergeAliases.$inferSelect
+export type PersonMergeMove = typeof personMergeMoves.$inferSelect

--- a/packages/isolation/src/matrix.test.ts
+++ b/packages/isolation/src/matrix.test.ts
@@ -5,7 +5,7 @@ import { ISOLATION_EVIDENCE_IDS, ISOLATION_MATRIX, evaluateIsolationMatrixGate }
 const metadata = {
   commit: 'abc123',
   ciRun: 'local',
-  migration: '0041_person_merge_preview_workflow',
+  migration: '0042_brave_maelstrom',
   postgresVersion: '17.10',
   roleEvidenceDigest: 'a'.repeat(64),
   policyEvidenceDigest: 'b'.repeat(64),

--- a/packages/isolation/src/matrix.test.ts
+++ b/packages/isolation/src/matrix.test.ts
@@ -5,7 +5,7 @@ import { ISOLATION_EVIDENCE_IDS, ISOLATION_MATRIX, evaluateIsolationMatrixGate }
 const metadata = {
   commit: 'abc123',
   ciRun: 'local',
-  migration: '0043_person_merge_plan_v2',
+  migration: '0044_person_merge_execution',
   postgresVersion: '17.10',
   roleEvidenceDigest: 'a'.repeat(64),
   policyEvidenceDigest: 'b'.repeat(64),

--- a/packages/isolation/src/matrix.test.ts
+++ b/packages/isolation/src/matrix.test.ts
@@ -5,7 +5,7 @@ import { ISOLATION_EVIDENCE_IDS, ISOLATION_MATRIX, evaluateIsolationMatrixGate }
 const metadata = {
   commit: 'abc123',
   ciRun: 'local',
-  migration: '0042_brave_maelstrom',
+  migration: '0043_person_merge_plan_v2',
   postgresVersion: '17.10',
   roleEvidenceDigest: 'a'.repeat(64),
   policyEvidenceDigest: 'b'.repeat(64),

--- a/packages/rbac/src/default-policy.ts
+++ b/packages/rbac/src/default-policy.ts
@@ -172,6 +172,11 @@ function tenantRoleTemplates(options: {
                 SCOPES.ORGANIZATION_SUBTREE,
                 personMergeAdmin('person_merge.approve'),
               ] as const,
+              [
+                CAPABILITIES.PEOPLE_MERGES_EXECUTE,
+                SCOPES.ORGANIZATION_SUBTREE,
+                personMergeAdmin('person_merge.execute'),
+              ] as const,
             ]
           : []),
         [CAPABILITIES.STUDENTS_CREATE, SCOPES.ORGANIZATION_SUBTREE, recorded('student.create')],
@@ -316,6 +321,11 @@ function tenantRoleTemplates(options: {
                 CAPABILITIES.PEOPLE_MERGES_APPROVE,
                 SCOPES.SCHOOL,
                 personMergeAdmin('person_merge.approve'),
+              ] as const,
+              [
+                CAPABILITIES.PEOPLE_MERGES_EXECUTE,
+                SCOPES.SCHOOL,
+                personMergeAdmin('person_merge.execute'),
               ] as const,
             ]
           : []),

--- a/packages/rbac/src/policy.test.ts
+++ b/packages/rbac/src/policy.test.ts
@@ -711,7 +711,7 @@ describe('capability Policy Decisions', () => {
     )
   })
 
-  it('requires recent AAL2 authentication for person merge preview and approval', () => {
+  it('requires recent AAL2 authentication for person merge preview, approval, and execution', () => {
     const resource = {
       kind: 'person_merge',
       tenantId: 'tenant-1',
@@ -755,6 +755,18 @@ describe('capability Policy Decisions', () => {
         .filter((obligation) => obligation.kind === 'audit')
         .map(({ event }) => event),
       ['person_merge.approve']
+    )
+    const execution = decision({
+      ...request,
+      capability: CAPABILITIES.PEOPLE_MERGES_EXECUTE,
+      context: context({ assuranceLevel: 'aal2', authenticatedAt: NOW.toISOString() }),
+    })
+    assert.equal(execution.effect, 'allow')
+    assert.deepEqual(
+      execution.obligations
+        .filter((obligation) => obligation.kind === 'audit')
+        .map(({ event }) => event),
+      ['person_merge.execute']
     )
     assert.equal(
       decision({
@@ -904,6 +916,7 @@ describe('versioned Role Template bundles', () => {
       [CAPABILITIES.PEOPLE_MERGES_READ, ['org_admin', 'school_admin']],
       [CAPABILITIES.PEOPLE_MERGES_PREVIEW, ['org_admin', 'school_admin']],
       [CAPABILITIES.PEOPLE_MERGES_APPROVE, ['org_admin', 'school_admin']],
+      [CAPABILITIES.PEOPLE_MERGES_EXECUTE, ['org_admin', 'school_admin']],
       [CAPABILITIES.STUDENTS_CREATE, ['org_admin', 'school_admin', 'staff']],
       [
         CAPABILITIES.STUDENTS_READ,

--- a/packages/rbac/src/registry.ts
+++ b/packages/rbac/src/registry.ts
@@ -58,6 +58,7 @@ export const CAPABILITIES = Object.freeze({
   PEOPLE_MERGES_READ: 'tenant.people_merges.read',
   PEOPLE_MERGES_PREVIEW: 'tenant.people_merges.preview',
   PEOPLE_MERGES_APPROVE: 'tenant.people_merges.approve',
+  PEOPLE_MERGES_EXECUTE: 'tenant.people_merges.execute',
   STUDENTS_CREATE: 'tenant.students.create',
   STUDENTS_READ: 'tenant.students.read',
   STUDENTS_UPDATE: 'tenant.students.update',
@@ -188,6 +189,10 @@ export const CAPABILITY_REGISTRY = Object.freeze({
     scopes: tenantBroadScopes,
   },
   [CAPABILITIES.PEOPLE_MERGES_APPROVE]: {
+    resourceKinds: [RESOURCE_KINDS.PERSON_MERGE],
+    scopes: tenantBroadScopes,
+  },
+  [CAPABILITIES.PEOPLE_MERGES_EXECUTE]: {
     resourceKinds: [RESOURCE_KINDS.PERSON_MERGE],
     scopes: tenantBroadScopes,
   },


### PR DESCRIPTION
## Summary
- add plan-versioned Person merge execution state
- add a forced-RLS durable alias registry
- add an append-only per-record move ledger
- add merged-source immutability and a separately audited execute capability

## Current safety boundary
This draft does not yet expose an execution function. Existing plan-version-1 previews are intentionally ineligible for execution. The next commits add transitive dependency inventory, atomic execution, invalidation, and live fault/race proof.

## Verification
- `bun run check`
- `bun run lint` (two pre-existing household warnings)
- `bun run typecheck`
- `bun test packages/db/src/migrations.test.ts packages/rbac/src/policy.test.ts packages/isolation/src/matrix.test.ts`

Refs #119
